### PR TITLE
Implements /records endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ README_OLD.md
 conf/ds-present-environment.yaml
 conf/ds-present-local.yaml
 setup_project.sh
-/conf/ds-present-kb-collections.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ README_OLD.md
 conf/ds-present-environment.yaml
 conf/ds-present-local.yaml
 setup_project.sh
+/conf/ds-present-kb-collections.yaml

--- a/README.md
+++ b/README.md
@@ -33,14 +33,35 @@ slow to render the response).
 Install [ds-storage](https://github.com/kb-dk/ds-storage) and follow its instructions for starting
 a test instance.
 
-Navigate to the `ds-present`-corpus folder and upload a sample to the running `ds-storage`:
+Navigate to the `ds-present`-corpus folder and upload samples to the running `ds-storage`:
 ```shell
 cd src/test/resources/xml/corpus/
-./post_to_storage.sh illum.xml
-
+./post_to_storage.sh albert-einstein.xml hvidovre-teater.xml simonsen-brandes.xml tystrup-soroe.xml homiliae-super-psalmos.xml work_on_logic.xml joergen_hansens_visebog.xml responsa.xml
 ```
-After this, a record for ID `id=doms.radio:illum.xml` should be delivered when requested from the
-[record/{id}](http://localhost:9073/ds-present/api/#/ds-present/getRecord) endpoint.
+After this, a record for ID `doms.radio:albert-einstein.xml` should be delivered when requested from the
+[/record/{id}](http://localhost:9073/ds-present/api/#/ds-present/record) endpoint.
+
+
+## Test with Solr
+
+### Setup Solr
+
+Checkout [ds-solr](https://github.com/kb-dk/ds-solr/), change to the `solr-nested-indexing` branch and follow
+the README, using the Solr setup from `nested-template/conf/`. This boils down to
+```shell
+  bin/cloud_install.sh
+  bin/cloud_start.sh
+  bin/cloud_sync.sh nested-template/conf/ ds-conf ds
+```
+Check that the collection was created by visiting
+[http://localhost:10007/solr/#/~cloud?view=graph](http://localhost:10007/solr/#/~cloud?view=graph)
+
+### Extract SolrJSONDocuments
+
+With `ds-storage` populated with the sample documents and `ds-present` running, use the 
+[ds-present Swagger GUI](http://localhost:9073/ds-present/api/) to call 
+[/records](http://localhost:9073/ds-present/api/#/ds-present/records) for ``
+
 
 
 ## General setup

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ providing multiple views on metadata, such as MODS, JSON-LD and SolrJsonDocument
 
 Developed and maintained by the Royal Danish Library.
 
-## Status
-
-This project is at the "first real attempt"-status: Connections to ds-storage and simple 1-input-1-output
-transformations are working.
 
 ## Requirements
 
@@ -56,13 +52,22 @@ the README, using the Solr setup from `nested-template/conf/`. This boils down t
 Check that the collection was created by visiting
 [http://localhost:10007/solr/#/~cloud?view=graph](http://localhost:10007/solr/#/~cloud?view=graph)
 
-### Extract SolrJSONDocuments
+### Extract SolrJSONDocuments and index in Solr
 
 With `ds-storage` populated with the sample documents and `ds-present` running, use the 
-[ds-present Swagger GUI](http://localhost:9073/ds-present/api/) to call 
-[/records](http://localhost:9073/ds-present/api/#/ds-present/records) for ``
+[ds-present API](http://localhost:9073/ds-present/api/) to call 
+[/records](http://localhost:9073/ds-present/api/#/ds-present/records) for collection `remote`
+and send them to Solr. 
 
+This can be done from the command line with
+```shell
+curl -s 'http://localhost:9073/ds-present/v1/records?collection=remote&maxRecords=1000&format=SolrJSON' > solrdocs.json
 
+Indekser dem i Solr:
+
+curl -X POST -H 'Content-Type: application/json' 'http://localhost:10007/solr/ds/update' --data-binary @solrdocs.json
+curl -X POST -H 'Content-Type: application/json' 'http://localhost:10007/solr/ds/update' --data-binary '{ "commit": {} }'
+```
 
 ## General setup
 

--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -69,6 +69,13 @@ config:
       # and the second being the collection specific par of the ID
       # Mandatory. Suggested value: '([a-z0-9.]+):([a-zA-Z0-9:._-]+)', e.g. 'images.dsfl:Image1234:2_3-b'
       pattern: '([a-z0-9.]+):([a-zA-Z0-9:._-]+)'
+  collection:
+    prefix:
+      # Pattern for acceptable collection prefixes. This will practically always be a mirror of the first capturing
+      # group for record.id.pattern.
+      # Primarily used for verifying configuration.
+      # Mandatory. Suggested value: '[a-z0-9.]+', e.g. 'images.dsfl'
+      pattern: '[a-z0-9.]+'
 
   # The collections available for this instance of ds-present 
   collections:

--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -10,6 +10,10 @@
 #
 config:
   # List of backing storages. This information should be overridden in ds-present-environment.yaml
+
+  # The storages defined in this file are
+  # * ds-storage, expecting https://github.com/kb-dk/ds-storage/ to be running locally with the default port
+  # * folder, serving sample files
   storages:
     # There can be multiple defined storages. The outer YAML key is used as the ID for the storage.
     - main:
@@ -20,7 +24,7 @@ config:
         # the implementation (aka type) of the backend
         #
         # Available backends are
-        # ds-storage: Connection to a https://github.com/kb-dk/ds-storage/ instance
+        # ds-storage: A local instance of https://github.com/kb-dk/ds-storage/
         # folder:     Local files under the stated folder. Use only for test as the implementation in unsecure
         backends:
           # The ds-storage backend connects to a running https://github.com/kb-dk/ds-storage/ instance

--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -28,7 +28,7 @@ config:
               # The name of the machine running the service. Mandatory
               host: 'localhost'
               # The port for the service. Mandatory
-              port: 8080
+              port: 9072
               # The path the the service. Optional, default is '/ds-storage/v1/'
               basepath: '/ds-storage/v1/'
               # The connection scheme: http or https. Optional, default is http for localhost, https for everything else

--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -33,6 +33,9 @@ config:
               basepath: '/ds-storage/v1/'
               # The connection scheme: http or https. Optional, default is http for localhost, https for everything else
               scheme: 'http'
+              # The recordBase for the ds-storage
+              # Optional, but needed for the /records endpoint
+              base: 'doms.radio'
     - test:
         # If there is more that one backend implementation, the property 'order' controls how they are queried:
         # * parallel:   All backends are queried in parallel. Whoever answers with a record first wins.

--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -35,22 +35,22 @@ config:
 
     # Royal Danish Library image collection with the core format being MODS
     # Uses the default storage, which connects to a running ds-storage instance
-    - images_hca:
+    - imageshca:
         description: 'Hans Christian Andersen images from the collections at the Royal Danish Library'
         prefix: 'kb.images.billed.hca' # The prefix to match on incoming IDs. Selected to use ds-storage without any tweaks
         base: 'kb.images.billed.hca' # Overrides the default base for the storage
         views: *MODS_IMAGE_VIEWS
-    - images_jsmss:
+    - imagesjsmss:
         description: 'Judaistisk Samling: Håndskrifter images from the collections at the Royal Danish Library'
         prefix: 'kb.image.judsam.jsmss'
         base: 'kb.image.judsam.jsmss'
         views: *MODS_IMAGE_VIEWS
-    - images_luftfoto:
+    - imagesluftfoto:
         description: 'Luftfoto (arial photographs) images from the collections at the Royal Danish Library'
         prefix: 'kb.image.luftfo.luftfoto'
         base: 'kb.images.luftfo.luftfoto'
         views: *MODS_IMAGE_VIEWS
-    - images_smaatryk:
+    - imagessmaatryk:
         description: 'Småtryk images from the collections at the Royal Danish Library'
         prefix: 'kb.pamphlets.dasmaa.smaatryk'
         base: 'kb.pamphlets.dasmaa.smaatryk'

--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -1,0 +1,109 @@
+#
+# This config contains definitions for image collections at the Royal Danish Library.
+#
+# If used by another institution the collections should be overwritten by another config sorted alphanumerically
+# later than "ds-present-kb-collections.yaml". Optionally this config file should also be deleted.
+#
+config:
+
+  # Generic views for images represented as MODS, used for multiple collections
+  baseviews: &MODS_IMAGE_VIEWS
+    # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
+    - raw:
+        mime: 'text/plain'
+        transformers:
+          - identity:
+    - MODS:
+        mime: 'application/xml'
+        transformers:
+          - identity: # No transformation steps as mods is the core format for images-dsfl
+    - JSON-LD:
+        mime: 'application/json'
+        transformers:
+          - xslt:
+              stylesheet: 'xslt/mods2schemaorg.xsl'
+    - SolrJSON:
+        mime: 'application/json'
+        transformers:
+          - xslt:
+              stylesheet: 'xslt/mods2solr.xsl'
+
+  # The collections available for this instance of ds-present
+  collections:
+    # General note: All collections are expected to support at least the views raw, mods, jsonld and solrjson.
+    # If any of those are not supported, the transformer 'fail' should be used with a telling message.
+
+    # Royal Danish Library image collection with the core format being MODS
+    # Uses the default storage, which connects to a running ds-storage instance
+    - images_hca:
+        description: 'Hans Christian Andersen images from the collections at the Royal Danish Library'
+        prefix: 'kb.images.billed.hca' # The prefix to match on incoming IDs. Selected to use ds-storage without any tweaks
+        base: 'kb.images.billed.hca' # Overrides the default base for the storage
+        views: *MODS_IMAGE_VIEWS
+    - images_jsmss:
+        description: 'Judaistisk Samling: Håndskrifter images from the collections at the Royal Danish Library'
+        prefix: 'kb.image.judsam.jsmss'
+        base: 'kb.image.judsam.jsmss'
+        views: *MODS_IMAGE_VIEWS
+    - images_luftfoto:
+        description: 'Luftfoto (arial photographs) images from the collections at the Royal Danish Library'
+        prefix: 'kb.image.luftfo.luftfoto'
+        base: 'kb.images.luftfo.luftfoto'
+        views: *MODS_IMAGE_VIEWS
+    - images_smaatryk:
+        description: 'Småtryk images from the collections at the Royal Danish Library'
+        prefix: 'kb.pamphlets.dasmaa.smaatryk'
+        base: 'kb.pamphlets.dasmaa.smaatryk'
+        views: *MODS_IMAGE_VIEWS
+
+    # Straight forward collection with the core format being MODS
+    # Uses the default storage, which connects to a running ds-storage instance
+    - remote: # ds-present internal
+        prefix: 'doms.radio' # The prefix to match on incoming IDs. Selectet to use ds-storage without any tweaks
+        description: 'Images from the collections at the Royal Danish Library'
+        # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
+        views:
+          - raw:
+              mime: 'text/plain'
+              transformers:
+                - identity:
+          - MODS:
+              mime: 'application/xml'
+              transformers:
+                - identity: # No transformation steps as mods is the core format for images-dsfl
+          - JSON-LD:
+              mime: 'application/json'
+              transformers:
+                - xslt:
+                    stylesheet: 'xslt/mods2schemaorg.xsl'
+          - SolrJSON:
+              mime: 'application/json'
+              transformers:
+                - xslt:
+                    stylesheet: 'xslt/mods2solr.xsl'
+
+    # Straight forward collection with the core format being MODS, using test data
+    - local: # ds-present internal
+        prefix: 'local.test' # The prefix to match on incoming IDs
+        description: 'Selected image data from the collections at the Royal Danish Library'
+        storage: 'test' # Not production here
+        # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
+        views:
+          - raw:
+              mime: 'text/plain'
+              transformers:
+                - identity:
+          - MODS:
+              mime: 'application/xml'
+              transformers:
+                - identity: # No transformation steps as mods is the core format for images-dsfl
+          - JSON-LD:
+              mime: 'application/json'
+              transformers:
+                - xslt:
+                    stylesheet: 'xslt/mods2schemaorg.xsl'
+          - SolrJSON:
+              mime: 'application/json'
+              transformers:
+                - xslt:
+                    stylesheet: 'xslt/mods2solr.xsl'

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-xml-provider</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>2.10.1</version>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.2</version>
+            <version>1.4.7</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->

--- a/src/main/java/dk/kb/present/CollectionHandler.java
+++ b/src/main/java/dk/kb/present/CollectionHandler.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -80,6 +81,13 @@ public class CollectionHandler {
      */
     public DSCollection getCollection(String collectionID) {
         return collections.get(collectionID);
+    }
+
+    /**
+     * @return a complete list of supported collections.
+     */
+    public List<String> getCollectionNames() {
+        return collections.values().stream().map(DSCollection::getId).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/dk/kb/present/CollectionHandler.java
+++ b/src/main/java/dk/kb/present/CollectionHandler.java
@@ -41,8 +41,8 @@ public class CollectionHandler {
     private final StorageHandler storageHandler;
     private final Map<String, DSCollection> collectionsByPrefix; // prefix, collection
     private final Map<String, DSCollection> collectionsByID; // id, collection
-    private static Pattern recordIDPattern;
-    private static Pattern collectionPrefixPattern;
+    private final Pattern recordIDPattern;
+    private final Pattern collectionPrefixPattern;
 
     /**
      * Creates a {@link StorageHandler} and a set of {@link Storage}s based on the given configuration.

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -130,7 +130,8 @@ public class DSCollection {
                     try {
                         record.data(view.apply(record.getData()));
                     } catch (Exception e) {
-                        throw new RuntimeTransformerException("Exception transforming record '" + record.getId() + "'");
+                        throw new RuntimeTransformerException(
+                                "Exception transforming record '" + record.getId() + "' to format '" + format + "'");
 
                     }
                 });

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -65,6 +65,12 @@ public class DSCollection {
     private final Storage storage;
 
     /**
+     * Optional recordBase, with fallback to the default recordBase for {@link Storage}.
+     * Used when {@link #getDSRecords(Long, Long, String)} is called.
+     */
+    private final String recordBase;
+
+    /**
      * Map from format -> view. A view is at the core an array of transformations and responsible for transforming
      * metadata to the requested format.
      */
@@ -84,6 +90,7 @@ public class DSCollection {
         prefix = conf.getString(PREFIX_KEY);
         description = conf.getString(DESCRIPTION_KEY, null);
         storage = storageHandler.getStorage(conf.getString(STORAGE_KEY, null)); // null means default storage
+        recordBase = conf.getString("BASE_KEY", null);
         views = conf.getYAMLList(VIEWS_KEY).stream()
                 .map(View::new)
                 .collect(Collectors.toMap(view -> view.getId().toLowerCase(Locale.ROOT), view -> view));
@@ -125,7 +132,7 @@ public class DSCollection {
      */
     public Stream<DsRecordDto> getDSRecords(Long mTime, Long maxRecords, String format) {
         View view = getView(format);
-        return storage.getDSRecords(mTime, maxRecords)
+        return storage.getDSRecords(recordBase, mTime, maxRecords)
                 .peek(record -> {
                     try {
                         record.data(view.apply(record.getData()));
@@ -200,6 +207,7 @@ public class DSCollection {
                ", prefix='" + prefix + '\'' +
                ", description='" + description + '\'' +
                ", storage=" + storage +
+               ", recordBase=" + recordBase +
                ", views=" + views +
                ')';
     }

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -16,6 +16,7 @@ package dk.kb.present;
 
 import dk.kb.present.backend.model.v1.DsRecordDto;
 import dk.kb.present.storage.Storage;
+import dk.kb.present.transform.RuntimeTransformerException;
 import dk.kb.present.webservice.exception.InvalidArgumentServiceException;
 import dk.kb.present.webservice.exception.ServiceException;
 import dk.kb.util.yaml.YAML;
@@ -125,7 +126,14 @@ public class DSCollection {
     public Stream<DsRecordDto> getDSRecords(Long mTime, Long maxRecords, String format) {
         View view = getView(format);
         return storage.getDSRecords(mTime, maxRecords)
-                .peek(record -> record.data(view.apply(record.getData())));
+                .peek(record -> {
+                    try {
+                        record.data(view.apply(record.getData()));
+                    } catch (Exception e) {
+                        throw new RuntimeTransformerException("Exception transforming record '" + record.getId() + "'");
+
+                    }
+                });
     }
 
     /**

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -40,6 +40,7 @@ public class DSCollection {
     private static final String PREFIX_KEY = "prefix"; // IDs for this collection starts with <prefix>_ (note the underscore)
     private static final String DESCRIPTION_KEY = "description";
     private static final String STORAGE_KEY = "storage";
+    private static final String BASE_KEY = "base";
     private static final String VIEWS_KEY = "views";
 
     /**
@@ -90,7 +91,7 @@ public class DSCollection {
         prefix = conf.getString(PREFIX_KEY);
         description = conf.getString(DESCRIPTION_KEY, null);
         storage = storageHandler.getStorage(conf.getString(STORAGE_KEY, null)); // null means default storage
-        recordBase = conf.getString("BASE_KEY", null);
+        recordBase = conf.getString(BASE_KEY, null);
         views = conf.getYAMLList(VIEWS_KEY).stream()
                 .map(View::new)
                 .collect(Collectors.toMap(view -> view.getId().toLowerCase(Locale.ROOT), view -> view));
@@ -132,6 +133,8 @@ public class DSCollection {
      */
     public Stream<DsRecordDto> getDSRecords(Long mTime, Long maxRecords, String format) {
         View view = getView(format);
+        log.debug("Calling storage.getDSRecords(recordBase='{}', mTime={}, maxRecords={})",
+                  recordBase, mTime, maxRecords);
         return storage.getDSRecords(recordBase, mTime, maxRecords)
                 .peek(record -> {
                     try {

--- a/src/main/java/dk/kb/present/PresentFacade.java
+++ b/src/main/java/dk/kb/present/PresentFacade.java
@@ -26,6 +26,7 @@ import dk.kb.present.webservice.JSONStreamWriter;
 import dk.kb.present.webservice.exception.InternalServiceException;
 import dk.kb.present.webservice.exception.InvalidArgumentServiceException;
 import dk.kb.present.webservice.exception.NotFoundServiceException;
+import dk.kb.present.webservice.exception.ServiceException;
 import dk.kb.util.json.JSON;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -203,6 +204,9 @@ public class PresentFacade {
                         .forEach(writer::write);
                 //       writer.close();
             } catch (Exception e) {
+                if (e instanceof ServiceException) {
+                    throw e;
+                }
                 String message = String.format(
                         Locale.ROOT,
                         "Exception delivering Solr records with collection='%s', mTime=%d, maxRecords=%d",

--- a/src/main/java/dk/kb/present/PresentFacade.java
+++ b/src/main/java/dk/kb/present/PresentFacade.java
@@ -107,6 +107,7 @@ public class PresentFacade {
     private static CollectionDto toDto(DSCollection collection) {
         return new CollectionDto()
                 .id(collection.getId())
+                .prefix(collection.getPrefix())
                 .description(collection.getDescription())
                 .views(collection.getViews().values().stream()
                                .map(PresentFacade::toDto)

--- a/src/main/java/dk/kb/present/PresentFacade.java
+++ b/src/main/java/dk/kb/present/PresentFacade.java
@@ -191,19 +191,11 @@ public class PresentFacade {
             // Hacking the output to confirm to Solr's non-valid JSON: https://solr.apache.org/guide/8_10/uploading-data-with-index-handlers.html#sending-json-update-commands
             ((JSONStreamWriter) writer).setPreOutput("{\n");
             ((JSONStreamWriter) writer).setPostOutput("\n}\n");
-            Stream<DsRecordDto> records;
+
             try {
-                records = collection.getDSRecords(mTime, maxRecords, "SolrJSON");
-            } catch (Exception e) {
-                writer.close();
-                log.warn("Exception requesting records for Solr export with collection='{}', mTime={}, maxRecords={}",
-                         collection, mTime, maxRecords);
-                throw new InternalServerErrorException("Exception requesting records for SolrJSON format", e);
-            }
-            try {
-                records.map(PresentFacade::wrapSolrJSON)
+                collection.getDSRecords(mTime, maxRecords, "SolrJSON")
+                        .map(PresentFacade::wrapSolrJSON)
                         .forEach(writer::write);
-                //       writer.close();
             } catch (Exception e) {
                 if (e instanceof ServiceException) {
                     throw e;
@@ -212,6 +204,7 @@ public class PresentFacade {
                         Locale.ROOT,
                         "Exception delivering Solr records with collection='%s', mTime=%d, maxRecords=%d",
                         collection.getId(), mTime, maxRecords);
+                // We need to log here as the writer does not have information on collection, mTime and maxRecords
                 log.warn(message, e);
                 throw new InternalServiceException(message);
             }
@@ -222,7 +215,13 @@ public class PresentFacade {
         };
     }
 
-    // https://solr.apache.org/guide/8_8/uploading-data-with-index-handlers.html#json-formatted-index-updates
+    /**
+     * Uses information from the record object to wrap its data component in either {@code add} or {@code delete}.
+     * See https://solr.apache.org/guide/8_8/uploading-data-with-index-handlers.html#json-formatted-index-updates
+     * @param record a record where the data component contains a SolrJSONDocument.
+     * @return the record's data component wrapped as either {@code add} or {@code delete}.
+     */
+    //
     private static String wrapSolrJSON(DsRecordDto record) {
         if (Boolean.TRUE.equals(record.getDeleted())) {
             return "\"delete\": { \"id\": \"" + record.getId() + "\" }";
@@ -238,8 +237,14 @@ public class PresentFacade {
         return sb.toString();
     }
 
+    /**
+     * If the source data contains multiple DOMS, there will also be multiple SolrJSONDocuments.
+     * This method splits those from one JSON structure to one structure/document.
+     * @param solrJSONs one or more JSON documents in a JSON array.
+     * @return the JSON documents as a list.
+     */
     // Really hacking here to handle the case of the source containing multiple MODS-sections
-    // TODO: Hopefully determine that 1 record = 1 mods
+    // TODO: Hopefully determine that 1 record = 1 mods always
     private static List<String> splitSolrJSON(String solrJSONs) {
         ObjectMapper mapper = new ObjectMapper();
         List<?> jsonArray = JSON.fromJson(solrJSONs, List.class);

--- a/src/main/java/dk/kb/present/PresentFacade.java
+++ b/src/main/java/dk/kb/present/PresentFacade.java
@@ -14,14 +14,21 @@
  */
 package dk.kb.present;
 
+import dk.kb.present.backend.model.v1.DsRecordDto;
 import dk.kb.present.config.ServiceConfig;
 import dk.kb.present.model.v1.CollectionDto;
 import dk.kb.present.model.v1.ViewDto;
+import dk.kb.present.webservice.ExportWriter;
+import dk.kb.present.webservice.ExportWriterFactory;
+import dk.kb.present.webservice.exception.InvalidArgumentServiceException;
 import dk.kb.present.webservice.exception.NotFoundServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.StreamingOutput;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 /**
@@ -56,7 +63,7 @@ public class PresentFacade {
      * @throws NotFoundServiceException if the record or the format was unknown.
      */
     public static String getRecord(String recordID, String format) {
-        return collectionHandler.getRecord(recordID, format);
+        return getCollectionHandler().getRecord(recordID, format);
     }
 
     /**
@@ -65,9 +72,10 @@ public class PresentFacade {
      * @throws NotFoundServiceException if the collection was not known.
      */
     public static CollectionDto getCollection(String id) {
-        DSCollection collection = collectionHandler.getCollection(id);
+        DSCollection collection = getCollectionHandler().getCollection(id);
         if (collection == null) {
-            throw new NotFoundServiceException("A collection with the id '" + id + "' could not be located");
+            throw new NotFoundServiceException("A collection with the id '" + id + "' could not be located. " +
+                                               "Supported collections are " + collectionHandler.getCollectionNames());
         }
         return toDto(collection);
     }
@@ -76,7 +84,7 @@ public class PresentFacade {
      * @return all known collections.
      */
     public static List<CollectionDto> getCollections() {
-        return collectionHandler.getCollections().stream()
+        return getCollectionHandler().getCollections().stream()
                 .map(PresentFacade::toDto)
                 .collect(Collectors.toList());
     }
@@ -94,4 +102,104 @@ public class PresentFacade {
     private static ViewDto toDto(View view) {
         return new ViewDto().id(view.getId()).mime(view.getMime().toString());
     }
+
+    public static StreamingOutput getRecords(
+            HttpServletResponse httpServletResponse, String collectionID, Long mTime, Long maxRecords, String format) {
+        DSCollection collection = collectionHandler.getCollection(collectionID);
+        if (collection == null) {
+            throw new InvalidArgumentServiceException(String.format(
+                    Locale.ROOT, "The collection '%s' was unknown. Known collections are %s",
+                    collectionID, collectionHandler.getCollections()));
+        }
+
+        // enum:  ['JSON-LD', 'JSON-LD-Lines', 'MODS', 'SolrJSON', "StorageRecord"]
+        switch (format.toUpperCase(Locale.ROOT)) {
+            case "JSON-LD": return getRecordsData(
+                    collection, mTime, maxRecords,
+                    httpServletResponse, "JSON-LD", ExportWriterFactory.FORMAT.json);
+            case "JSON-LD-LINES": return getRecordsData(
+                    collection, mTime, maxRecords,
+                    httpServletResponse, "JSON-LD", ExportWriterFactory.FORMAT.jsonl);
+            case "MODS": return getRecordsData(
+                    collection, mTime, maxRecords,
+                    httpServletResponse, "MODS", ExportWriterFactory.FORMAT.xml);
+            case "STORAGERECORD": return getRecordsFull(
+                    collection, mTime, maxRecords,
+                    httpServletResponse, ExportWriterFactory.FORMAT.json);
+            case "STORAGERECORD-LINES": return getRecordsFull(
+                    collection, mTime, maxRecords,
+                    httpServletResponse, ExportWriterFactory.FORMAT.jsonl);
+            case "SOLRJSON": return getRecordsSolr(collection, mTime, maxRecords, httpServletResponse);
+            default: throw new InvalidArgumentServiceException("The format '" + format + "' is not supported");
+        }
+    }
+
+    private static StreamingOutput getRecordsData(
+            DSCollection collection, Long mTime, Long maxRecords,
+            HttpServletResponse httpServletResponse, String recordFormat, ExportWriterFactory.FORMAT deliveryFormat) {
+        setFilename(httpServletResponse, mTime, maxRecords, deliveryFormat);
+        return output -> {
+            try (ExportWriter writer = ExportWriterFactory.wrap(
+                    output, httpServletResponse, deliveryFormat, false, "records")) {
+                collection.getDSRecords(mTime, maxRecords, recordFormat)
+                        .map(DsRecordDto::getData)
+                        .forEach(writer::write);
+            }
+        };
+    }
+
+    // Only deliver the data-part of the Records
+    private static StreamingOutput getRecordsFull(
+            DSCollection collection, Long mTime, Long maxRecords,
+            HttpServletResponse httpServletResponse, ExportWriterFactory.FORMAT deliveryFormat) {
+        return output -> {
+            try (ExportWriter writer = ExportWriterFactory.wrap(
+                    output, httpServletResponse, deliveryFormat, false, "records")) {
+                collection.getDSRecords(mTime, maxRecords, "raw") // Does not contain deleted records
+                        .forEach(writer::write);
+            }
+        };
+    }
+
+    // Direct ds-storage record JSON
+    private static StreamingOutput getRecordsSolr(DSCollection collection, Long mTime, Long maxRecords,
+                                                  HttpServletResponse httpServletResponse) {
+        return output -> {
+            try (ExportWriter writer = ExportWriterFactory.wrap(
+                    output, httpServletResponse, ExportWriterFactory.FORMAT.json, false, "records")) {
+                collection.getDSRecords(mTime, maxRecords, "SolrJSON")
+                        .map(PresentFacade::wrapSolrJSON)
+                        .forEach(writer::write);
+            }
+        };
+    }
+
+    // https://solr.apache.org/guide/8_8/uploading-data-with-index-handlers.html#json-formatted-index-updates
+    private static String wrapSolrJSON(DsRecordDto record) {
+        return Boolean.TRUE.equals(record.getDeleted()) ?
+                "\"delete\": { \"id\": \"" + record.getId() + "\" }" :
+                "\"add\": \n{ \"doc\" : " + record.getData() + "\n}\n}";
+
+    }
+
+    private static void setFilename(
+            HttpServletResponse httpServletResponse,
+            Long mTime, Long maxRecords, ExportWriterFactory.FORMAT deliveryFormat) {
+        if (httpServletResponse == null) {
+            log.debug("setFilename: No HttpServletResponse, so no filename stated");
+            return;
+        }
+        String filename = "records_" + mTime + ".json";
+        if (maxRecords <= 2) { // The Swagger GUI is extremely sluggish for inline rendering
+            // A few records is ok to show inline in the Swagger GUI:
+            // Show inline in Swagger UI, inline when opened directly in browser
+            httpServletResponse.setHeader("Content-Disposition", "inline; filename=\"" + filename + "\"");
+        } else {
+            // When there are a lot of records, they should not be displayed inline in the OpenAPI GUI:
+            // Show download link in Swagger UI, inline when opened directly in browser
+            // https://github.com/swagger-api/swagger-ui/issues/3832
+            httpServletResponse.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + filename + "\"");
+        }
+    }
+
 }

--- a/src/main/java/dk/kb/present/View.java
+++ b/src/main/java/dk/kb/present/View.java
@@ -16,12 +16,14 @@ package dk.kb.present;
 
 import dk.kb.present.transform.DSTransformer;
 import dk.kb.present.transform.TransformerController;
+import dk.kb.present.webservice.exception.InternalServiceException;
 import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.MediaType;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.function.Function;
 
 /**
@@ -76,7 +78,14 @@ public class View extends ArrayList<DSTransformer> implements Function<String, S
     @Override
     public String apply(String s) {
         for (DSTransformer transformer: this) {
-            s = transformer.apply(s);
+            try {
+                s = transformer.apply(s);
+            } catch (Exception e) {
+                String message = String.format(
+                        Locale.ROOT, "Exception in View '%s' while calling %s", getId(), transformer);
+                log.warn(message, e);
+                throw new InternalServiceException(message);
+            }
         }
         return s;
     }

--- a/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
@@ -2,12 +2,7 @@ package dk.kb.present.api.v1.impl;
 
 import dk.kb.present.PresentFacade;
 import dk.kb.present.api.v1.*;
-import java.util.ArrayList;
 import dk.kb.present.model.v1.CollectionDto;
-import dk.kb.present.model.v1.ErrorDto;
-import java.util.List;
-import java.util.Map;
-import dk.kb.present.model.v1.ViewDto;
 
 import dk.kb.present.webservice.exception.ServiceException;
 import dk.kb.present.webservice.exception.InternalServiceException;
@@ -15,34 +10,15 @@ import dk.kb.present.webservice.exception.InternalServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.List;
-import java.util.Map;
-import java.io.File;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.*;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Request;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.core.*;
 import javax.ws.rs.ext.Providers;
-import javax.ws.rs.core.MediaType;
-import org.apache.cxf.jaxrs.model.wadl.Description;
-import org.apache.cxf.jaxrs.model.wadl.DocTarget;
-import org.apache.cxf.jaxrs.ext.MessageContext;
-import org.apache.cxf.jaxrs.ext.multipart.*;
 
-import io.swagger.annotations.Api;
+import org.apache.cxf.jaxrs.ext.MessageContext;
 
 /**
  * ds-present
@@ -153,6 +129,20 @@ public class DsPresentApiServiceImpl implements DsPresentApi {
     public String getRecord(String id, String format) throws ServiceException {
         try {
             return PresentFacade.getRecord(id, format);
+        } catch (Exception e){
+            throw handleException(e);
+        }
+    }
+
+    @Override
+    public StreamingOutput getRecords(String recordBase, Long mTime, Long maxRecords, String format) {
+        if (recordBase == null) {
+            throw new InternalServiceException("recordBase must be specified but was not");
+        }
+        long finalMTime = mTime == null ? 0L : mTime;
+        long finalMaxRecords = maxRecords == null ? 1000L : maxRecords;
+        try {
+            return PresentFacade.getRecords(httpServletResponse, recordBase, finalMTime, finalMaxRecords, format);
         } catch (Exception e){
             throw handleException(e);
         }

--- a/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
@@ -135,14 +135,14 @@ public class DsPresentApiServiceImpl implements DsPresentApi {
     }
 
     @Override
-    public StreamingOutput getRecords(String recordBase, Long mTime, Long maxRecords, String format) {
-        if (recordBase == null) {
-            throw new InternalServiceException("recordBase must be specified but was not");
+    public StreamingOutput getRecords(String collection, Long mTime, Long maxRecords, String format) {
+        if (collection == null) {
+            throw new InternalServiceException("collection must be specified but was not");
         }
         long finalMTime = mTime == null ? 0L : mTime;
         long finalMaxRecords = maxRecords == null ? 1000L : maxRecords;
         try {
-            return PresentFacade.getRecords(httpServletResponse, recordBase, finalMTime, finalMaxRecords, format);
+            return PresentFacade.getRecords(httpServletResponse, collection, finalMTime, finalMaxRecords, format);
         } catch (Exception e){
             throw handleException(e);
         }

--- a/src/main/java/dk/kb/present/storage/DSStorage.java
+++ b/src/main/java/dk/kb/present/storage/DSStorage.java
@@ -119,7 +119,7 @@ public class DSStorage implements Storage {
             boolean finished = pending == 0;
 
             void ensureFilled() {
-                if (finished || !records.isEmpty()) {
+                if (finished || (records != null && !records.isEmpty())) {
                     return;
                 }
                 if (pending <= 0) {

--- a/src/main/java/dk/kb/present/storage/DSStorage.java
+++ b/src/main/java/dk/kb/present/storage/DSStorage.java
@@ -18,11 +18,17 @@ import dk.kb.present.backend.api.v1.DsStorageApi;
 import dk.kb.present.backend.invoker.v1.ApiClient;
 import dk.kb.present.backend.invoker.v1.ApiException;
 import dk.kb.present.backend.model.v1.DsRecordDto;
-import dk.kb.util.yaml.YAML;
+import dk.kb.present.webservice.exception.InternalServiceException;
+import dk.kb.present.webservice.exception.NotFoundServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Proxy for a ds-storage https://github.com/kb-dk/ds-storage instance.
@@ -33,11 +39,13 @@ public class DSStorage implements Storage {
     public static final String TYPE = "ds-storage";
 
     private final String id;
+    private final String recordBase;
 
     private final String host;
     private final int port;
     private final String basepath;
     private final String scheme;
+    private final int batchCount;
 
     // Used for logging and debugging
     private final String serverHuman;
@@ -48,19 +56,26 @@ public class DSStorage implements Storage {
     /**
      * Create a Storage connection to a ds-storage server.
      * @param id the ID for the storage, used for connecting collections to storages.
+     * @param recordBase the base used for requests to {@link DsStorageApi#getRecordsModifiedAfter(String, Long, Long)}.
      * @param scheme the scheme for the connection: {@code http} or {@code https}.
      * @param host the host name for the server: {@code example.com}.
      * @param port the port for the server: {@code 8080}.
      * @param basepath the basepath for the service: {@code /ds-storage/v1/}.
+     * @param batchCount the number of records to request in one call when paging using
+     *                   {@link DsStorageApi#getRecordsModifiedAfter(String, Long, Long)}.
      * @param isDefault if true, this is the default storage for collections.
      */
-    public DSStorage(String id, String scheme, String host, int port, String basepath, boolean isDefault) {
+    public DSStorage(String id, String recordBase,
+                     String scheme, String host, int port, String basepath,
+                     int batchCount, boolean isDefault) {
         this.id = id;
 
         this.scheme = scheme;
         this.host = host;
         this.port = port;
         this.basepath = basepath;
+        this.batchCount = batchCount;
+        this.recordBase = recordBase;
 
         this.isDefault = isDefault;
 
@@ -77,18 +92,68 @@ public class DSStorage implements Storage {
     }
 
     @Override
-    public String getRecord(String id) throws IOException {
+    public String getRecord(String id) {
         return getDSRecord(id).getData();
     }
 
     @Override
-    public DsRecordDto getDSRecord(String id) throws IOException {
+    public DsRecordDto getDSRecord(String id){
         try {
             return dsStorageClient.getRecord(id);
         } catch (ApiException e) {
             log.debug("Unable to retrieve record '" + id + "' from " + serverHuman + "...", e);
-            throw new IOException("Unable to retrieve record '" + id + "'", e);
+            throw new NotFoundServiceException("Unable to retrieve record '" + id + "'", e);
         }
+    }
+
+    @Override
+    public Stream<DsRecordDto> getDSRecords(long mTime, long maxRecords) {
+
+        // Unfortunately the OpenAPI generator creates a client which requests all records as a list in a single call
+        // instead of doing streaming, so we need to page.
+
+        Iterator<DsRecordDto> iterator = new Iterator<DsRecordDto>() {
+            long pending = maxRecords == -1 ? Long.MAX_VALUE : maxRecords; // -1 = all records
+            final AtomicLong lastMTime = new AtomicLong(mTime);
+            List<DsRecordDto> records = null;
+            boolean finished = pending == 0;
+
+            void ensureFilled() {
+                if (finished || !records.isEmpty()) {
+                    return;
+                }
+                if (pending <= 0) {
+                    finished = true;
+                    return;
+                }
+
+                long request = pending < batchCount ? (int) pending : batchCount;
+                try {
+                    records = dsStorageClient.getRecordsModifiedAfter(recordBase, lastMTime.get(), request);
+                } catch (ApiException e) {
+                    throw new InternalServiceException(
+                            "Exception making remote call to ds-storage client.getRecordsModifiedAfter", e);
+                }
+                pending -= records.size();
+                finished = records.isEmpty();
+            }
+            @Override
+            public boolean hasNext() {
+                ensureFilled();
+                return !finished;
+            }
+
+            @Override
+            public DsRecordDto next() {
+                ensureFilled();
+                if (finished) {
+                    throw new NoSuchElementException("No more records");
+                }
+                return records.remove(0);
+            }
+        };
+
+        return StreamSupport.stream(((Iterable<DsRecordDto>) () -> iterator).spliterator(), false);
     }
 
     @Override
@@ -114,6 +179,7 @@ public class DSStorage implements Storage {
                ", port=" + port +
                ", basepath='" + basepath + '\'' +
                ", scheme='" + scheme + '\'' +
+               ", batchCount='" + batchCount + '\'' +
                ", isDefault=" + isDefault +
                ')';
     }

--- a/src/main/java/dk/kb/present/storage/DSStorage.java
+++ b/src/main/java/dk/kb/present/storage/DSStorage.java
@@ -100,11 +100,13 @@ public class DSStorage implements Storage {
 
     @Override
     public String getRecord(String id) {
+        log.debug("getRecord(id='{}') called", id);
         return getDSRecord(id).getData();
     }
 
     @Override
     public DsRecordDto getDSRecord(String id){
+        log.debug("getDSRecord(id='{}') called", id);
         try {
             return dsStorageClient.getRecord(id);
         } catch (ApiException e) {
@@ -115,6 +117,7 @@ public class DSStorage implements Storage {
 
     @Override
     public Stream<DsRecordDto> getDSRecords(final String recordBase, long mTime, long maxRecords) {
+        log.debug("getDSRecords(recordBase='{}', mTime={}, maxRecords={}) called", recordBase, mTime, maxRecords);
         String finalRecordBase = recordBase == null ? this.recordBase : recordBase;
 
         if (finalRecordBase == null || finalRecordBase.isEmpty()) {

--- a/src/main/java/dk/kb/present/storage/DSStorage.java
+++ b/src/main/java/dk/kb/present/storage/DSStorage.java
@@ -17,6 +17,7 @@ package dk.kb.present.storage;
 import dk.kb.present.backend.api.v1.DsStorageApi;
 import dk.kb.present.backend.invoker.v1.ApiClient;
 import dk.kb.present.backend.invoker.v1.ApiException;
+import dk.kb.present.backend.model.v1.DsRecordDto;
 import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,8 +78,13 @@ public class DSStorage implements Storage {
 
     @Override
     public String getRecord(String id) throws IOException {
+        return getDSRecord(id).getData();
+    }
+
+    @Override
+    public DsRecordDto getDSRecord(String id) throws IOException {
         try {
-            return dsStorageClient.getRecord(id).getData();
+            return dsStorageClient.getRecord(id);
         } catch (ApiException e) {
             log.debug("Unable to retrieve record '" + id + "' from " + serverHuman + "...", e);
             throw new IOException("Unable to retrieve record '" + id + "'", e);

--- a/src/main/java/dk/kb/present/storage/DSStorage.java
+++ b/src/main/java/dk/kb/present/storage/DSStorage.java
@@ -114,9 +114,10 @@ public class DSStorage implements Storage {
     }
 
     @Override
-    public Stream<DsRecordDto> getDSRecords(long mTime, long maxRecords) {
+    public Stream<DsRecordDto> getDSRecords(final String recordBase, long mTime, long maxRecords) {
+        String finalRecordBase = recordBase == null ? this.recordBase : recordBase;
 
-        if (recordBase == null || recordBase.isEmpty()) {
+        if (finalRecordBase == null || finalRecordBase.isEmpty()) {
             throw new InternalServiceException(
                     "recordBase not defined for DSStorage '" + getID() + "'. Only single record lookups are possible");
         }
@@ -141,13 +142,13 @@ public class DSStorage implements Storage {
 
                 long request = pending < batchCount ? (int) pending : batchCount;
                 try {
-                    records = dsStorageClient.getRecordsModifiedAfter(recordBase, lastMTime.get(), request);
+                    records = dsStorageClient.getRecordsModifiedAfter(finalRecordBase, lastMTime.get(), request);
                 } catch (ApiException e) {
                     String message = String.format(
                             Locale.ROOT,
                             "Exception making remote call to ds-storage client " +
                             "getRecordsModifiedAfter(base='%s', mTime=%d, maxRecords=%d)",
-                            recordBase, mTime, maxRecords);
+                            finalRecordBase, mTime, maxRecords);
                     throw new InternalServiceException(message, e);
                 }
                 pending -= records.size();

--- a/src/main/java/dk/kb/present/storage/DSStorageFactory.java
+++ b/src/main/java/dk/kb/present/storage/DSStorageFactory.java
@@ -24,12 +24,15 @@ import org.slf4j.LoggerFactory;
 public class DSStorageFactory implements StorageFactory {
     private static final Logger log = LoggerFactory.getLogger(DSStorageFactory.class);
 
+    private static final String RECORD_BASE_KEY = "base";
     private static final String HOST_KEY = "host";
     private static final String PORT_KEY = "port";
     private static final String BASEPATH_KEY = "basepath";
     private static final String BASEPATH_DEFAULT = "ds-storage/v1/";
     private static final String SCHEME_KEY = "scheme";
     private static final String SCHEME_DEFAULT = "https"; // Special handling: Will be 'http' if host = localhost
+    public static final String BATCH_COUNT_KEY = "batch.count";
+    public static final int BATCH_COUNT_DEFAULT = 100;
 
     @Override
     public String getStorageType() {
@@ -38,12 +41,17 @@ public class DSStorageFactory implements StorageFactory {
 
     @Override
     public Storage createStorage(String id, YAML conf, boolean isDefault) throws Exception {
+        String recordBase = conf.getString(RECORD_BASE_KEY, null);
+        if (recordBase == null) {
+            log.warn("For the DSStorage '" + id + "', the recordBase==null, calls to getRecords will fail");
+        }
         String host = conf.getString(HOST_KEY);
         int port = conf.getInteger(PORT_KEY);
         String basepath = conf.getString(BASEPATH_KEY, BASEPATH_DEFAULT);
         String scheme = conf.getString(SCHEME_KEY,
                                        "localhost".equals(host) || "127.0.0.1".equals(host) ? "http" : SCHEME_DEFAULT);
+        int batchCount = conf.getInteger(BATCH_COUNT_KEY, BATCH_COUNT_DEFAULT);
 
-        return new DSStorage(id, scheme, host, port, basepath, isDefault);
+        return new DSStorage(id, recordBase, scheme, host, port, basepath, batchCount, isDefault);
     }
 }

--- a/src/main/java/dk/kb/present/storage/FailStorage.java
+++ b/src/main/java/dk/kb/present/storage/FailStorage.java
@@ -14,6 +14,7 @@
  */
 package dk.kb.present.storage;
 
+import dk.kb.present.backend.model.v1.DsRecordDto;
 import dk.kb.present.webservice.exception.NotFoundServiceException;
 import dk.kb.util.Resolver;
 import dk.kb.util.yaml.YAML;
@@ -49,15 +50,14 @@ public class FailStorage implements Storage {
         log.info("Created " + this);
     }
 
-    /**
-     * Locate a file where the name is the recordID and deliver the content. Works with sub-folders.
-     * @param recordID the ID (aka file name) for a record.
-     * @return the content of the file with the given name.
-     * @throws IOException if the file could not be located or the content not delivered.
-     */
     @Override
     public String getRecord(String recordID) throws IOException {
         throw new NotFoundServiceException("Unable to locate record '" + recordID + "': " + message);
+    }
+
+    @Override
+    public DsRecordDto getDSRecord(String id) throws IOException {
+        throw new NotFoundServiceException("Unable to locate record '" + id + "': " + message);
     }
 
     @Override

--- a/src/main/java/dk/kb/present/storage/FailStorage.java
+++ b/src/main/java/dk/kb/present/storage/FailStorage.java
@@ -57,7 +57,7 @@ public class FailStorage implements Storage {
     }
 
     @Override
-    public Stream<DsRecordDto> getDSRecords(long mTime, long maxRecords) {
+    public Stream<DsRecordDto> getDSRecords(String recordBase, long mTime, long maxRecords) {
         throw new NotFoundServiceException("Unable to locate any records after mTime " + mTime);
     }
 

--- a/src/main/java/dk/kb/present/storage/FailStorage.java
+++ b/src/main/java/dk/kb/present/storage/FailStorage.java
@@ -16,14 +16,10 @@ package dk.kb.present.storage;
 
 import dk.kb.present.backend.model.v1.DsRecordDto;
 import dk.kb.present.webservice.exception.NotFoundServiceException;
-import dk.kb.util.Resolver;
-import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.stream.Stream;
 
 /**
  * Storage that always fails. Can  used for signalling unsupported formats.
@@ -51,13 +47,18 @@ public class FailStorage implements Storage {
     }
 
     @Override
-    public String getRecord(String recordID) throws IOException {
+    public String getRecord(String recordID) {
         throw new NotFoundServiceException("Unable to locate record '" + recordID + "': " + message);
     }
 
     @Override
-    public DsRecordDto getDSRecord(String id) throws IOException {
+    public DsRecordDto getDSRecord(String id) {
         throw new NotFoundServiceException("Unable to locate record '" + id + "': " + message);
+    }
+
+    @Override
+    public Stream<DsRecordDto> getDSRecords(long mTime, long maxRecords) {
+        throw new NotFoundServiceException("Unable to locate any records after mTime " + mTime);
     }
 
     @Override

--- a/src/main/java/dk/kb/present/storage/FileStorage.java
+++ b/src/main/java/dk/kb/present/storage/FileStorage.java
@@ -266,17 +266,17 @@ public class FileStorage implements Storage {
      * @param maxRecords the maximum number of records to deliver. -1 means no limit.
      * @return a list of records in the folder satisfying the constraints.
      */
+    @SuppressWarnings("ConstantConditions")
     private List<DsRecordDto> getShallow(long mTime, long maxRecords) {
-        try {
-            //noinspection ConstantConditions
-            return Files.list(folder)
+        try (Stream<Path> fileStream = Files.list(folder)) {
+            return fileStream
                     .filter(path -> path.toString().endsWith(extension))
                     .filter(path -> isAllowed(path.getFileName().toString()))
                     .map(Path::toFile)
-                    .filter(f -> mTime/1000 < f.lastModified())
+                    .filter(f -> mTime / 1000 < f.lastModified())
                     .map(this::getShallow)
                     .sorted(Comparator.comparingLong(DsRecordDto::getmTime)) // We know it is always set in getShallow
-                    .limit(maxRecords == -1 ?Long.MAX_VALUE : maxRecords)
+                    .limit(maxRecords == -1 ? Long.MAX_VALUE : maxRecords)
                     .collect(Collectors.toList());
         } catch (IOException e) {
             throw new InternalServiceException("Unable to resolve records");

--- a/src/main/java/dk/kb/present/storage/FileStorage.java
+++ b/src/main/java/dk/kb/present/storage/FileStorage.java
@@ -15,19 +15,23 @@
 package dk.kb.present.storage;
 
 import dk.kb.present.backend.model.v1.DsRecordDto;
+import dk.kb.present.webservice.exception.InternalServiceException;
 import dk.kb.present.webservice.exception.NotFoundServiceException;
 import dk.kb.util.Resolver;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Simple storage backed by static files on the file system.
@@ -54,15 +58,21 @@ public class FileStorage implements Storage {
      * @param isDefault if true, this is the default storage for collections.
      * @throws IOException if the given folder could not be accessed.
      */
-    public FileStorage(String id, Path folder, boolean stripPrefix, boolean isDefault) throws IOException {
+    public FileStorage(String id, Path folder, boolean stripPrefix, boolean isDefault){
         this.id = id;
+        String current;
+        try {
+            current = new File(".").getCanonicalPath();
+        } catch (IOException e) {
+            current = "<unable to determine current folder>";
+        };
         if (!Files.isReadable(folder)) {
             // We accept non-readable folders as the FileStorage is only intended for testing
             log.warn(String.format(Locale.ROOT, "Unable to access the configured folder '%s'. Current folder is '%s'",
-                                   folder, new java.io.File(".").getCanonicalPath()));
+                                   folder, current));
         } else {
             log.info(String.format(Locale.ROOT, "The configured folder '%s' is readable with current folder being '%s'",
-                                   folder, new java.io.File(".").getCanonicalPath()));
+                                   folder, current));
         }
         this.folder = folder;
         this.stripPrefix = stripPrefix;
@@ -77,9 +87,18 @@ public class FileStorage implements Storage {
      * @throws IOException if the file could not be located or the content not delivered.
      */
     @Override
-    public String getRecord(String recordID) throws IOException {
-        Path file = getPath(recordID);
-        return Resolver.resolveUTF8String(file.toAbsolutePath().toString());
+    public String getRecord(String recordID) {
+        Path file;
+        try {
+            file = getPath(recordID);
+        } catch (IOException e) {
+            throw new NotFoundServiceException("Unable to locate file for '" + recordID + "'");
+        }
+        try {
+            return Resolver.resolveUTF8String(file.toAbsolutePath().toString());
+        } catch (IOException e) {
+            throw new NotFoundServiceException("Located file for '" + recordID + "' but could not fetch content");
+        }
     }
 
     /**
@@ -89,16 +108,29 @@ public class FileStorage implements Storage {
      * @throws IOException if the file could not be located or the content not delivered.
      */
     @Override
-    public DsRecordDto getDSRecord(String recordID) throws IOException {
-        Path path = getPath(recordID);
+    public DsRecordDto getDSRecord(String recordID) {
+        Path path = null;
+        try {
+            path = getPath(recordID);
+        } catch (IOException e) {
+            throw new NotFoundServiceException("Unable to locate file for '" + recordID + "'");
+        }
         long mTime = path.toFile().lastModified()*1000; // DsRecordDto used epoch * 1000
 
         return new DsRecordDto()
                 .id(recordID)
-                .data(IOUtils.toString(path.toUri(), StandardCharsets.UTF_8))
+                .data(safeRead(path))
                 .deleted(false)
                 .mTime(mTime)
                 .mTimeHuman(DATE_FORMAT.format(new Date(mTime / 1000)));
+    }
+
+    private String safeRead(Path path) {
+        try {
+            return IOUtils.toString(path.toUri(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new NotFoundServiceException("Unable to read content for '" + path.toFile().getName() + "'");
+        }
     }
 
     @Override
@@ -116,6 +148,12 @@ public class FileStorage implements Storage {
         return isDefault;
     }
 
+    /**
+     * Resolves the recordID to a file path.
+     * @param recordID a record ID.
+     * @return the file path corresponding to the ID.
+     * @throws IOException if the ID could not be resolved.
+     */
     private Path getPath(String recordID) throws IOException {
         if (stripPrefix) {
             // TODO: Switch to using .config.record.id.pattern
@@ -131,6 +169,77 @@ public class FileStorage implements Storage {
             throw new NotFoundServiceException("Unable to locate record '" + recordID + "'");
         }
         return file.toAbsolutePath();
+    }
+
+    @Override
+    public Stream<DsRecordDto> getDSRecords(long mTime, long maxRecords) {
+        // To keep memory usage down we create shallow DsRecordDtos (aka without data) and only
+        // populate them when delivering the next stream element
+
+        final List<DsRecordDto> shallow = getShallow(mTime, maxRecords);
+        Iterator<DsRecordDto> iterator = new Iterator<DsRecordDto>() {
+            int pos = 0;
+
+            @Override
+            public boolean hasNext() {
+                return pos < shallow.size();
+            }
+
+            @Override
+            public DsRecordDto next() {
+                return populate(shallow.get(pos++));
+            }
+        };
+        return StreamSupport.stream(((Iterable<DsRecordDto>) () -> iterator).spliterator(), false);
+    }
+
+    /**
+     * Get a shallow (not populated with data) list of all the files under {@link #folder}, sorted ascending by mTime.
+     * @param mTime point in time (epoch * 1000) for the records to deliver, exclusive.
+     * @param maxRecords the maximum number of records to deliver. -1 means no limit.
+     * @return a list of records in the folder satisfying the constraints.
+     */
+    private List<DsRecordDto> getShallow(long mTime, long maxRecords) {
+        try {
+            //noinspection ConstantConditions
+            return Files.list(folder)
+                    .map(Path::toFile)
+                    .filter(f -> mTime/1000 < f.lastModified())
+                    .map(this::getShallow)
+                    .sorted(Comparator.comparingLong(DsRecordDto::getmTime)) // We know it is always set in getShallow
+                    .limit(maxRecords == -1 ?Long.MAX_VALUE : maxRecords)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new InternalServiceException("Unable to resolve records");
+        }
+    }
+
+    /**
+     * Load the data of the record (the file is folder + id) as UTF-8, assign it to the given shallow record
+     * and return the record.
+     * @param shallow a record with null data.
+     * @return the shallow record populated with data.
+     */
+    private DsRecordDto populate(DsRecordDto shallow) {
+        try {
+            Path path = getPath(shallow.getId());
+            return shallow.data(IOUtils.toString(path.toUri(), StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new InternalServiceException("Unable to populate record '" + shallow.getId() + "' with data");
+        }
+    }
+
+    /**
+     * Represent the file as a shallow record, containing only id (file name), mTime and mTimeHuman.
+     * @param file the file to represent.
+     * @return a shallow representation of the file.
+     */
+    private DsRecordDto getShallow(File file) {
+        return new DsRecordDto()
+                .id(file.getName()) // Only the filename itself
+                .deleted(false)
+                .mTime(file.lastModified()*1000)
+                .mTimeHuman(DATE_FORMAT.format(new Date(file.lastModified())));
     }
 
     @Override

--- a/src/main/java/dk/kb/present/storage/FileStorage.java
+++ b/src/main/java/dk/kb/present/storage/FileStorage.java
@@ -239,7 +239,7 @@ public class FileStorage implements Storage {
     }
 
     @Override
-    public Stream<DsRecordDto> getDSRecords(long mTime, long maxRecords) {
+    public Stream<DsRecordDto> getDSRecords(String recordBase, long mTime, long maxRecords) {
         // To keep memory usage down we create shallow DsRecordDtos (aka without data) and only
         // populate them when delivering the next stream element
 

--- a/src/main/java/dk/kb/present/storage/FileStorageFactory.java
+++ b/src/main/java/dk/kb/present/storage/FileStorageFactory.java
@@ -18,10 +18,7 @@ import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Locale;
 
 /**
  * Constructs {@link FileStorage}s.
@@ -30,6 +27,8 @@ public class FileStorageFactory implements StorageFactory {
     private static final Logger log = LoggerFactory.getLogger(FileStorageFactory.class);
 
     public static final String FOLDER_KEY = "root";
+    public static final String EXTENSION_KEY = "extension";
+    public static final String EXTENSION_DEFAULT = ""; // All extensions
     public static final String STRIP_PREFIX_KEY = "stripprefix";
     public static final boolean STRIP_PREFIX_DEFAULT = true;
 
@@ -46,8 +45,9 @@ public class FileStorageFactory implements StorageFactory {
                     "The root folder was not specified under the key '" + FOLDER_KEY + "' for storage '" + id + "'");
         }
         Path folder = Path.of(folderStr);
+        String extension = conf.getString(EXTENSION_KEY, EXTENSION_DEFAULT);
         boolean stripPrefix = conf.getBoolean(STRIP_PREFIX_KEY, STRIP_PREFIX_DEFAULT);
 
-        return new FileStorage(id, folder, stripPrefix, isDefault);
+        return new FileStorage(id, folder, extension, stripPrefix, isDefault);
     }
 }

--- a/src/main/java/dk/kb/present/storage/FileStorageFactory.java
+++ b/src/main/java/dk/kb/present/storage/FileStorageFactory.java
@@ -19,6 +19,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Constructs {@link FileStorage}s.
@@ -27,10 +30,15 @@ public class FileStorageFactory implements StorageFactory {
     private static final Logger log = LoggerFactory.getLogger(FileStorageFactory.class);
 
     public static final String FOLDER_KEY = "root";
+
     public static final String EXTENSION_KEY = "extension";
     public static final String EXTENSION_DEFAULT = ""; // All extensions
+
     public static final String STRIP_PREFIX_KEY = "stripprefix";
     public static final boolean STRIP_PREFIX_DEFAULT = true;
+
+    public static final String WHITELIST_KEY = "whitelist";
+    public static final String BLACKLIST_KEY = "blacklist";
 
     @Override
     public String getStorageType() {
@@ -48,6 +56,15 @@ public class FileStorageFactory implements StorageFactory {
         String extension = conf.getString(EXTENSION_KEY, EXTENSION_DEFAULT);
         boolean stripPrefix = conf.getBoolean(STRIP_PREFIX_KEY, STRIP_PREFIX_DEFAULT);
 
-        return new FileStorage(id, folder, extension, stripPrefix, isDefault);
+        List<String> whitelistStr = conf.getList(WHITELIST_KEY, null);
+        List<Pattern> whitelist = whitelistStr == null ? null :
+                whitelistStr.stream().map(Pattern::compile).collect(Collectors.toList());
+
+        List<String> blacklistStr = conf.getList(BLACKLIST_KEY, null);
+        List<Pattern> blacklist = blacklistStr == null ? null :
+                blacklistStr.stream().map(Pattern::compile).collect(Collectors.toList());
+        
+
+        return new FileStorage(id, folder, extension, stripPrefix, whitelist, blacklist, isDefault);
     }
 }

--- a/src/main/java/dk/kb/present/storage/MultiStorage.java
+++ b/src/main/java/dk/kb/present/storage/MultiStorage.java
@@ -147,7 +147,6 @@ public class MultiStorage implements Storage {
      */
     private String safeGetRecord(Storage storage, String id) {
         try {
-            System.out.println("Requesting from "+ storage);
             return storage.getRecord(id);
         } catch (Exception e) {
             log.trace("Unable to retrieve record '" + id + "' from storage " + storage.getType() +
@@ -164,7 +163,6 @@ public class MultiStorage implements Storage {
      */
     private DsRecordDto safeGetDSRecord(Storage storage, String id) {
         try {
-            System.out.println("Requesting from "+ storage);
             return storage.getDSRecord(id);
         } catch (Exception e) {
             log.trace("Unable to retrieve record '" + id + "' from storage " + storage.getType() +

--- a/src/main/java/dk/kb/present/storage/MultiStorage.java
+++ b/src/main/java/dk/kb/present/storage/MultiStorage.java
@@ -130,9 +130,9 @@ public class MultiStorage implements Storage {
     }
 
     @Override
-    public Stream<DsRecordDto> getDSRecords(long mTime, long maxRecords) {
+    public Stream<DsRecordDto> getDSRecords(String recordBase, long mTime, long maxRecords) {
         List<Stream<DsRecordDto>> providers = getStorages()
-                .map(storage -> storage.getDSRecords(mTime, maxRecords))
+                .map(storage -> storage.getDSRecords(recordBase, mTime, maxRecords))
                 .collect(Collectors.toList());
 
         return Combiner.mergeStreams(providers, Comparator.comparingLong(DsRecordDto::getmTime))

--- a/src/main/java/dk/kb/present/storage/Storage.java
+++ b/src/main/java/dk/kb/present/storage/Storage.java
@@ -15,13 +15,14 @@
 package dk.kb.present.storage;
 
 import dk.kb.present.backend.model.v1.DsRecordDto;
-import dk.kb.util.yaml.YAML;
 
-import java.io.IOException;
-import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * Provides access to records.
+ *
+ * Note that no methods uses checked Exceptions. Implementations are aimed towards web services and should throw
+ * appropriate {@link dk.kb.present.webservice.exception.ServiceException}s instead.
  */
 public interface Storage {
 
@@ -43,17 +44,23 @@ public interface Storage {
     /**
      * @param id the ID for a record.
      * @return the record with the given ID, if available.
-     * @throws IOException if the record could not be retrieved.
      */
-    String getRecord(String id) throws IOException;
+    String getRecord(String id);
 
     /**
      * Return the record as a ds-storage record. This is "best effort", as some element such as
      * {@link DsRecordDto#getcTime()} might not be available.
      * @param id the ID for a record.
      * @return the record with the given ID, if available.
-     * @throws IOException if the record could not be retrieved.
      */
-    DsRecordDto getDSRecord(String id) throws IOException;
+    DsRecordDto getDSRecord(String id);
+
+    /**
+     * Return records in mTime order, where all record.mTimes are > the given mTime.
+     * @param mTime point in time (epoch * 1000) for the records to deliver, exclusive.
+     * @param maxRecords the maximum number of records to deliver. -1 means no limit.
+     * @return a stream of records after the given mTime.
+     */
+    Stream<DsRecordDto> getDSRecords(long mTime, long maxRecords);
 
 }

--- a/src/main/java/dk/kb/present/storage/Storage.java
+++ b/src/main/java/dk/kb/present/storage/Storage.java
@@ -57,10 +57,11 @@ public interface Storage {
 
     /**
      * Return records in mTime order, where all record.mTimes are > the given mTime.
+     * @param recordBase optional (can be null) recordBase.
      * @param mTime point in time (epoch * 1000) for the records to deliver, exclusive.
      * @param maxRecords the maximum number of records to deliver. -1 means no limit.
      * @return a stream of records after the given mTime.
      */
-    Stream<DsRecordDto> getDSRecords(long mTime, long maxRecords);
+    Stream<DsRecordDto> getDSRecords(String recordBase, long mTime, long maxRecords);
 
 }

--- a/src/main/java/dk/kb/present/storage/Storage.java
+++ b/src/main/java/dk/kb/present/storage/Storage.java
@@ -14,6 +14,7 @@
  */
 package dk.kb.present.storage;
 
+import dk.kb.present.backend.model.v1.DsRecordDto;
 import dk.kb.util.yaml.YAML;
 
 import java.io.IOException;
@@ -39,12 +40,20 @@ public interface Storage {
      */
     boolean isDefault();
 
-    // TODO: Use DtoRecord from ds-storage as return type to enrich meta data information
     /**
      * @param id the ID for a record.
      * @return the record with the given ID, if available.
      * @throws IOException if the record could not be retrieved.
      */
     String getRecord(String id) throws IOException;
+
+    /**
+     * Return the record as a ds-storage record. This is "best effort", as some element such as
+     * {@link DsRecordDto#getcTime()} might not be available.
+     * @param id the ID for a record.
+     * @return the record with the given ID, if available.
+     * @throws IOException if the record could not be retrieved.
+     */
+    DsRecordDto getDSRecord(String id) throws IOException;
 
 }

--- a/src/main/java/dk/kb/present/transform/XSLTTransformer.java
+++ b/src/main/java/dk/kb/present/transform/XSLTTransformer.java
@@ -86,7 +86,7 @@ public class XSLTTransformer extends DSTransformer {
             }
             return out.toString(StandardCharsets.UTF_8);
         } catch (IOException | TransformerException e) {
-            throw new RuntimeTransformerException("Excaption transforming with stylesheet '" + stylesheet + "'", e);
+            throw new RuntimeTransformerException("Exception transforming with stylesheet '" + stylesheet + "'", e);
         }
     }
 

--- a/src/main/java/dk/kb/present/util/Combiner.java
+++ b/src/main/java/dk/kb/present/util/Combiner.java
@@ -1,0 +1,145 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.present.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.BaseStream;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Helper class for combining streams, iterators and collections.
+ */
+public class Combiner {
+    private static final Logger log = LoggerFactory.getLogger(Combiner.class);
+
+    /**
+     * Merge multiple ordered streams into a single ordered stream.
+     * The input ordering must match the order of the comparator.
+     * This implementation uses streaming processing and has minimal memory overhead.
+     * @param streams zero or more streams where the order of the delivered elements matches comparator.
+     * @param comparator a comparator that matches the order in the given streams.
+     */
+    public static <T> Stream<T> mergeStreams(Collection<Stream<T>> streams, Comparator<T> comparator) {
+        Collection<Iterator<T>> iterators = streams.stream()
+                .map(BaseStream::iterator)
+                .collect(Collectors.toList());
+        Iterator<T> iterator = mergeIterators(iterators, comparator);
+
+        return StreamSupport.stream(((Iterable<T>) () -> iterator).spliterator(), false);
+    }
+
+    /**
+     * Merge multiple ordered collections into a single ordered list.
+     * The input ordering must match the order of the comparator.
+     * This collection delivers the result as a List which implies a memory overhead which is the sum of all the
+     * elements from the given collections.
+     * See {@link #mergeStreams(Collection, Comparator)} or {@link #mergeIterators(Collection, Comparator)} for
+     * low-memory merging of pre-ordered collections.
+     * @param collections zero or more collections where the order of the elements matches comparator.
+     * @param comparator a comparator that matches the order in the given collections.
+     */
+    public static <T> List<T> mergeCollections(Collection<Collection<T>> collections, Comparator<T> comparator) {
+        Collection<Iterator<T>> iterators = collections.stream()
+                .map(Collection::iterator)
+                .collect(Collectors.toList());
+        Iterator<T> iterator = mergeIterators(iterators, comparator);
+
+        return StreamSupport.stream(((Iterable<T>) () -> iterator).spliterator(), false).collect(Collectors.toList());
+    }
+
+    /**
+     * Merge multiple ordered iterators into a single ordered iterator.
+     * The input ordering must match the order of the comparator.
+     * This implementation uses streaming processing and has minimal memory overhead.
+     * @param iterators zero or more iterators where the order of the delivered elements matches comparator.
+     * @param comparator a comparator that matches the order of the elements delivered by the given iterators.
+     */
+    public static <T> Iterator<T> mergeIterators(Collection<Iterator<T>> iterators, Comparator<T> comparator) {
+        final PriorityQueue<Source<T>> pq = new PriorityQueue<>(new SourceComparator<>(comparator));
+        iterators.stream()
+                .map(Source::new)
+                .filter(Source::hasValue)
+                .forEach(pq::add);
+
+        return new Iterator<>() {
+            @Override
+            public boolean hasNext() {
+                return !pq.isEmpty();
+            }
+
+            @Override
+            public T next() {
+                Source<T> source = pq.poll();
+                if (source == null) {
+                    throw new NullPointerException("No more values");
+                }
+                T value = source.value;
+                if (source.moveToNext()) {
+                    // Source is not empty so we put it back
+                    pq.add(source);
+                }
+                return value;
+            }
+        };
+    }
+
+    private static class SourceComparator<T> implements Comparator<Source<T>> {
+        final Comparator<T> valueComparator;
+
+        public SourceComparator(Comparator<T> valueComparator) {
+            this.valueComparator = valueComparator;
+        }
+
+        @Override
+        public int compare(Source<T> s1, Source<T> s2) {
+            return valueComparator.compare(s1.getValue(), s2.getValue());
+        }
+    }
+
+    /**
+     * Peekable wrapper for iterators.
+     */
+    private static class Source<T> {
+        final Iterator<T> iterator;
+        T value;
+        boolean hasValue = true;
+
+        public Source(Iterator<T> iterator) {
+            this.iterator = iterator;
+            moveToNext();
+        }
+
+        public boolean moveToNext() {
+            if (!iterator.hasNext()) {
+                return hasValue = false;
+            }
+            value = iterator.next();
+            return true;
+        }
+
+        public boolean hasValue() {
+            return hasValue;
+        }
+
+        public T getValue() {
+            return value;
+        }
+    }
+}

--- a/src/main/java/dk/kb/present/webservice/ExportWriterFactory.java
+++ b/src/main/java/dk/kb/present/webservice/ExportWriterFactory.java
@@ -38,7 +38,19 @@ public class ExportWriterFactory {
 
     /**
      * Wrap the given OutputStream and return an ExportWriter, serializing to the export format derived from httpHeaders
-     * and format.
+     * and format. Sample usage from ServiceImpl:
+     * <pre>
+     public StreamingOutput getRecordsModifiedAfter(String recordBase, Long mTime, Long maxRecords, String format) {
+         return output -> {
+             try (ExportWriter writer = ExportWriterFactory.wrap(
+                     output, httpServletResponse, httpHeaders,
+                     format, ExportWriterFactory.FORMAT.jsonl, false, "records")) {
+             Stream<RecordDto> records = Store.getRecordStream(recordBase, mTime, maxRecords);
+             records.forEach(record -> writer.write(record);
+         }
+        };
+     * </pre>
+     *
      * @param output      the destination stream.
      * @param response    used for setting the proper contentType.
      * @param httpHeaders headers from the calling client. The {@code accept} MIME types are used to determine the
@@ -47,12 +59,16 @@ public class ExportWriterFactory {
      *                    httpHeaders. Acceptable formats are stated in {@link FORMAT}.
      * @param defaultType if no export format could be derived from httpHeaders or format, use this format.
      * @param writeNulls  if true, null-values are exported as {@code "key":null} for JSON and JSONL.
-     *                    If false, null-values are not stated. For CSV export this has no effect.
-     * @return
+     *                    If false, null-values are not stated.
+     *                    For CSV export this has no effect.
+     * @param rootElement the name of the outer element containing the data elements
+     *                    {@code <outer> <inner>1</inner> <inner>2</inner> ... </outer>}
+     *                    Only used with XML.
+     * @return a writer that takes Jackson annotated objects and streams a serialization to output.
      */
     public static ExportWriter wrap(
             OutputStream output, HttpServletResponse response, HttpHeaders httpHeaders,
-            String format, FORMAT defaultType, boolean writeNulls) {
+            String format, FORMAT defaultType, boolean writeNulls, String rootElement) {
         FORMAT streamFormat = null;
         try {
             streamFormat = format == null ? null : FORMAT.valueOf(format.toLowerCase(Locale.ROOT));
@@ -67,13 +83,46 @@ public class ExportWriterFactory {
                     "Unable to determine streaming export format and default was null");
         }
 
-        streamFormat.setContentType(response);
+        return wrap(output, response, streamFormat, writeNulls, rootElement);
+    }
+
+    /**
+     * Wrap the given OutputStream and return an ExportWriter, serializing to the given export format.
+     * Consider using {@link #wrap(OutputStream, HttpServletResponse, FORMAT, boolean, String)} to support
+     * CSV, JSON, JSONL as well as XML as export formats.
+     * Sample usage from ServiceImpl:
+     * <pre>
+     public StreamingOutput getRecordsModifiedAfter(String recordBase, Long mTime, Long maxRecords) {
+         return output -> {
+             try (ExportWriter writer = ExportWriterFactory.wrap(
+                     output, httpServletResponse, ExportWriterFactory.FORMAT.json, false, "records")) {
+                 Stream<RecordDto> records = Store.getRecordStream(recordBase, mTime, maxRecords);
+                 records.forEach(record -> writer.write(record);
+             }
+         };
+     }
+     * </pre>
+     * @param output      the destination stream.
+     * @param response    used for setting the proper contentType.
+     * @param format      the format to export to.
+     * @param writeNulls  if true, null-values are exported as {@code "key":null} for JSON and JSONL.
+     *                    If false, null-values are not stated.
+     *                    For CSV export this has no effect.
+     * @param rootElement the name of the outer element containing the data elements
+     *                    {@code <outer> <inner>1</inner> <inner>2</inner> ... </outer>}
+     *                    Only used with XML.
+     * @return a writer that takes Jackson annotated objects and streams a serialization to output.
+     */
+    public static ExportWriter wrap(OutputStream output, HttpServletResponse response,
+                                    FORMAT format, boolean writeNulls, String rootElement) {
+        format.setContentType(response);
         Writer writer = new OutputStreamWriter(output, StandardCharsets.UTF_8);
-        switch (streamFormat) {
-            case json: return new JSONStreamWriter(writer, JSONStreamWriter.FORMAT.json, writeNulls);
+        switch (format) {
             case jsonl: return new JSONStreamWriter(writer, JSONStreamWriter.FORMAT.jsonl, writeNulls);
+            case json: return new JSONStreamWriter(writer, JSONStreamWriter.FORMAT.json, writeNulls);
+            case xml: return new ExportXMLStreamWriter(writer, rootElement, writeNulls);
             case csv: return new CSVStreamWriter(writer);
-            default: throw new InternalServiceException("The export format '" + streamFormat + "' is unsupported");
+            default: throw new InternalServiceException("The export format '" + format + "' is unsupported");
         }
     }
 
@@ -83,6 +132,7 @@ public class ExportWriterFactory {
     public enum FORMAT {
         jsonl("application", "x-ndjson"),
         json("application", "json"),
+        xml("application", "xml"),
         csv("text", "csv");
 
         private final MediaType mime;

--- a/src/main/java/dk/kb/present/webservice/ExportWriterFactory.java
+++ b/src/main/java/dk/kb/present/webservice/ExportWriterFactory.java
@@ -115,7 +115,11 @@ public class ExportWriterFactory {
      */
     public static ExportWriter wrap(OutputStream output, HttpServletResponse response,
                                     FORMAT format, boolean writeNulls, String rootElement) {
-        format.setContentType(response);
+        if (response == null) {
+            log.warn("warp: No HttpServletResponse given so the content MIME type could not be set");
+        } else {
+            format.setContentType(response);
+        }
         Writer writer = new OutputStreamWriter(output, StandardCharsets.UTF_8);
         switch (format) {
             case jsonl: return new JSONStreamWriter(writer, JSONStreamWriter.FORMAT.jsonl, writeNulls);

--- a/src/main/java/dk/kb/present/webservice/ExportXMLStreamWriter.java
+++ b/src/main/java/dk/kb/present/webservice/ExportXMLStreamWriter.java
@@ -1,0 +1,124 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.present.webservice;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Wrapper that handles streamed output of a entries as XML. This differs from the standard XMLStreamWriter by
+ * supporting the Jackson annotated POJOs as input.
+ *
+ * Use the method {@link #write(Object)} and remember to call {@link #close} when finished.
+ */
+public class ExportXMLStreamWriter extends ExportWriter {
+    private static final Logger log = LoggerFactory.getLogger(ExportXMLStreamWriter.class);
+    private final XmlMapper xmlMapper = new XmlMapper();
+
+    private final boolean writeNulls;
+    private final String wrapperElement;
+    private boolean first = true;
+    private boolean isclosing = false; // If the writer is in the process of closing (breaks infinite recursion)
+
+    /**
+     * Wrap the given inner Writer in the ExportXMLStreamWriter. Calls to {@link #write(Object)} writes directly to
+     * inner, so the ExportXMLStreamWriter holds no cached data. The inner {@link Writer#flush()} is not called during
+     * write.
+     * null-values in objects given to {@link #write(Object)} will not be written. To control this, use
+     * the {@link ExportXMLStreamWriter (Writer, FORMAT, boolean)} constructor.
+     * @param rootElement the name of the element that wraps XML for the given Jackson annotated Objects.
+     * @param inner  the Writer to send the result to.
+     */
+    public ExportXMLStreamWriter(Writer inner, String rootElement) {
+        this(inner, rootElement, false);
+    }
+
+    /**
+     * Wrap the given inner Writer in the ExportXMLStreamWriter. Calls to {@link #write(Object)} writes directly to
+     * inner, so the ExportXMLStreamWriter holds no cached data. The inner {@link Writer#flush()} is not called during
+     * write.
+     * @param inner  the Writer to send the result to.
+     * @param rootElement the name of the element that wraps XML for the given Jackson annotated Objects.
+     * @param writeNulls if true, null values are written as {@code "key" : null}, if false they are skipped.
+     */
+    public ExportXMLStreamWriter(Writer inner, String rootElement, boolean writeNulls) {
+        super(inner);
+        this.writeNulls = writeNulls;
+        this.wrapperElement = rootElement;
+
+        xmlMapper.setSerializationInclusion(writeNulls ? JsonInclude.Include.ALWAYS : JsonInclude.Include.NON_NULL);
+        xmlMapper.enable(SerializationFeature.INDENT_OUTPUT);
+//        xmlWriter = mapper.writer(new MinimalPrettyPrinter()).withoutRootName();
+        
+    }
+
+    /**
+     * Write an XML expression that has already been serialized to String.
+     * It is the responsibility of the caller to ensure that the XML in xmlStr is valid.
+     * @param xmlStr a valid XML represented as a String.
+     */
+    @Override
+    public void write(String xmlStr) {
+        if (first) {
+            super.write("<" + wrapperElement + ">");
+            first = false;
+        } else {
+            super.write("\n");
+        }
+        super.write(xmlStr);
+    }
+
+    /**
+     * Use {@link #xmlMapper} to serialize the given object to String XML and write the result.
+     * @param annotatedObject a Jackson annotated Object.
+     */
+    @Override
+    public void write(Object annotatedObject) {
+        if (annotatedObject == null) {
+            log.warn("Internal inconsistency: write(null) called. This should not happen");
+            return;
+        }
+        try {
+            write(xmlMapper.writeValueAsString(annotatedObject));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JsonProcessingException attempting to write " + annotatedObject, e);
+        } catch (IOException e) {
+            throw new RuntimeException("IOException attempting to write " + annotatedObject, e);
+        }
+    }
+
+    /**
+     * Finishes the XML stream by writing closing statements (if needed).
+     */
+    @Override
+    public void close() {
+        if (isclosing) {
+            return; // Avoid infinite recursion
+        }
+        isclosing = true;
+        if (first) {
+            super.write("<" + wrapperElement + ">");
+        }
+        super.write("\n</" + wrapperElement + ">\n");
+        super.close();
+    }
+}

--- a/src/main/java/dk/kb/present/webservice/exception/ForbiddenServiceException.java
+++ b/src/main/java/dk/kb/present/webservice/exception/ForbiddenServiceException.java
@@ -1,0 +1,41 @@
+package dk.kb.present.webservice.exception;
+
+import javax.ws.rs.core.Response;
+
+/*
+ * Custom web-exception class (401)
+ */
+public class ForbiddenServiceException extends ServiceException {
+
+    //Constant fields for the OpenApi
+    public static final String description = "ForbiddenServiceException";
+    public static final String responseCode = "403";
+
+    private static final long serialVersionUID = 27152722L;
+    private static final Response.Status responseStatus = Response.Status.FORBIDDEN; // 401
+
+    public ForbiddenServiceException() {
+        super(responseStatus);
+    }
+
+    public ForbiddenServiceException(String message) {
+        super(message, responseStatus);
+    }
+
+    public ForbiddenServiceException(String message, Throwable cause) {
+        super(message, cause, responseStatus);
+    }
+
+    public ForbiddenServiceException(Throwable cause) {
+        super(cause, responseStatus);
+    }
+
+    public ForbiddenServiceException(String mimeType, Object entity) {
+        super(mimeType, entity, responseStatus);
+    }
+
+    public ForbiddenServiceException(String mimeType, Object entity, Throwable cause) {
+        super(mimeType, entity, cause, responseStatus);
+    }
+
+}

--- a/src/main/openapi/openapi_v1.yaml
+++ b/src/main/openapi/openapi_v1.yaml
@@ -253,7 +253,11 @@ components:
         id:
           description: 'The ID of the collection'
           type: string
-          example: 'images.dsfl'
+          example: 'images-DSFL'
+        prefix:
+          description: 'The prefix used by all records in the collection'
+          type: string
+          example: 'images.dsfl:'
         description:
           description: 'A human readable description fo the collection'
           type: string

--- a/src/main/openapi/openapi_v1.yaml
+++ b/src/main/openapi/openapi_v1.yaml
@@ -92,19 +92,20 @@ paths:
     get:
       tags:
         - '${project.name}'
-      summary: 'Extract records from a record base after a given mTime and up to a defined maximum. The records are returned in sorted order by mTime increasing. Records marked for delete will also be returned.'
+      summary: 'Extract records from a collection after a given mTime and up to a defined maximum. The records are returned in sorted order by mTime increasing. Records marked for delete will also be returned.'
       operationId: getRecords
       x-streamingOutput: true
       parameters:
-        - name: recordBase
+        - name: collection
           in: query
-          description: 'RecordBase . Will only extract records from this recordbase'
+          description: 'The collection to extract records from'
           required: true
           schema:
             type: string
+            example: 'images_hca'
         - name: mTime
           in: query
-          description: 'mTime. Format is millis with 3 added digits. It is up to the caller to keep track of mTime when batching the extracting for retrieval between seperate calls'
+          description: 'Epoch milliseconds with 3 added digits. It is up to the caller to keep track of mTime when batching the extracting for retrieval between seperate calls'
           required: false
           schema:
             type: integer

--- a/src/main/openapi/openapi_v1.yaml
+++ b/src/main/openapi/openapi_v1.yaml
@@ -15,7 +15,7 @@ servers:
     description: 'Version 1'
 
 paths:
-  /ping:
+  /monitor/ping:
     get:
       tags:
         - '${project.name}'

--- a/src/main/openapi/openapi_v1.yaml
+++ b/src/main/openapi/openapi_v1.yaml
@@ -88,12 +88,99 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  # TODO: Specify records/ (multiple records)
-  # The tricky part is how to represent multiple entries as the source can be both JSON & XML (and unknown in the form
-  # of raw but maybe raw should not be available here?).
-  # Another thing is that JSON can be delivered both as a large array and as JSON-Lines. Likewise, the packing of
-  # multiple SolrXMLs is already defined in https://solr.apache.org/guide/8_8/uploading-data-with-index-handlers.html#xml-formatted-index-updates
-  # but there is no defined packing of multiole MODS (Sub-TODO: Check is this is true)
+  /records:
+    get:
+      tags:
+        - '${project.name}'
+      summary: 'Extract records from a record base after a given mTime and up to a defined maximum. The records are returned in sorted order by mTime increasing. Records marked for delete will also be returned.'
+      operationId: getRecords
+      x-streamingOutput: true
+      parameters:
+        - name: recordBase
+          in: query
+          description: 'RecordBase . Will only extract records from this recordbase'
+          required: true
+          schema:
+            type: string
+        - name: mTime
+          in: query
+          description: 'mTime. Format is millis with 3 added digits. It is up to the caller to keep track of mTime when batching the extracting for retrieval between seperate calls'
+          required: false
+          schema:
+            type: integer
+            format: int64
+            example: 0
+            # Default values for longs does not work with the current version of OpenAPI generator
+            #default: 0
+        - name: maxRecords
+          in: query
+          description: 'Maximum number of records to return. -1 means no limit'
+          required: false
+          schema:
+            type: integer
+            format: int64
+            example: 1000
+            # Default values for longs does not work with the current version of OpenAPI generator
+            #default: 1000
+        - name: format
+          in: query
+          description: |
+            The delivery format for the record:
+            * JSON-LD: [Linked Data in JSON](https://json-ld.org/) (default)
+            * JSON-LD-Lines: [Linked Data in JSON-Lines](https://json-ld.org/)
+            * MODS: [Metadata Object Description Schema](http://www.loc.gov/standards/mods/)
+            * SolrJSON: [Solr JSON Formatted Index Updates](https://solr.apache.org/guide/8_8/uploading-data-with-index-handlers.html#json-formatted-index-updates)
+            * StorageRecord: [ds-storage](https://github.com/kb-dk/ds-storage/) record in JSON
+            * StorageRecord-Lines: [ds-storage](https://github.com/kb-dk/ds-storage/) record in JSON-Lines
+            Note that deleted records are only represented in the SolrJSON and StorageRecord formats.
+            For the other formats, deleted records are skipped silently.
+          required: false
+          schema:
+            type: string
+            enum:  ['JSON-LD', 'JSON-LD-Lines', 'MODS', 'SolrJSON', "StorageRecord", "StorageRecord-Lines"]
+            example: 'JSON-LD'
+            default: 'JSON-LD'
+      responses:
+        '200':
+          description: 'List of records in the requested format'
+          content:
+            application/ld+json:
+              schema:
+                description: |
+                  JSON-compliant representation of records as linked data. Note that the structure can be unwieldy for
+                  parsing large exports, if the receiver does not use a streaming parser.
+                  Consider using application/x-ndjson instead
+                type: array
+                items:
+                  type: string
+            application/x-ndjson:
+              schema:
+                description: |
+                  Newline separated single-line JSON representations of linked data content.\n
+                  See https://json-ld.org/ https://github.com/ndjson/ndjson-spec or https://jsonlines.org/ for the formats
+                type: string
+            application/xml:
+              schema:
+                description: 'XML-compliant representation of as MODS records.'
+                type: array
+                items:
+                  type: string
+            application/x-solrjsondocuments:
+              schema:
+                description: |
+                  SolrJSONDocuments representation of content, directly indexable in Solr.
+                  See [Solr JSON Formatted Index Updates](https://solr.apache.org/guide/8_8/uploading-data-with-index-handlers.html#json-formatted-index-updates)
+                type: string
+            application/x-storagerecord:
+              schema:
+                description: |
+                  [ds-storage](https://github.com/kb-dk/ds-storage/) record as JSON.
+                type: string
+            application/x-storagerecord-ndjson:
+              schema:
+                description: |
+                  [ds-storage](https://github.com/kb-dk/ds-storage/) record as JSON-Lines.
+                type: string
 
   /collection/{id}:
     get:

--- a/src/main/openapi/openapi_v1.yaml
+++ b/src/main/openapi/openapi_v1.yaml
@@ -102,7 +102,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'images_hca'
+            example: 'images_jsmss'
         - name: mTime
           in: query
           description: 'Epoch milliseconds with 3 added digits. It is up to the caller to keep track of mTime when batching the extracting for retrieval between seperate calls'

--- a/src/main/resources/xslt/mods2solr.xsl
+++ b/src/main/resources/xslt/mods2solr.xsl
@@ -208,7 +208,8 @@
                         <xsl:when test="@type">
                           <xsl:choose>
                             <xsl:when test="contains(@type,'citation/reference')">reference</xsl:when>
-                            <xsl:when test="contains( @displayLabel,'ript')">script</xsl:when>
+                            <xsl:when test="@displayLabel = 'Script'">script</xsl:when>
+                            <xsl:when test="@displayLabel = 'Script: detail'">script_detail</xsl:when>
                             <xsl:otherwise><xsl:value-of select="my:escape_stuff(@type)"/></xsl:otherwise>
                           </xsl:choose>
                         </xsl:when>

--- a/src/main/resources/xslt/mods2solr.xsl
+++ b/src/main/resources/xslt/mods2solr.xsl
@@ -517,13 +517,12 @@
   </xsl:template>
   
   <xsl:template name="make_page_field">
-    <xsl:variable name="chapter" select="m:titleInfo/m:title"/>
+<!--    <xsl:variable name="chapter" select="m:titleInfo/m:title"/>-->
     <xsl:choose>
       <xsl:when test="m:identifier[@displayLabel='iiif']">
-
         <xsl:for-each select="m:identifier[@displayLabel='iiif'][string()]">
           <xsl:call-template name="find-pages">
-            <xsl:with-param name="chapter"><xsl:value-of select="$chapter"/></xsl:with-param>
+<!--            <xsl:with-param name="chapter"><xsl:value-of select="$chapter"/></xsl:with-param>-->
           </xsl:call-template>
         </xsl:for-each>
 
@@ -534,7 +533,7 @@
       <xsl:otherwise>
         <xsl:for-each select="m:identifier[contains(.,'.tif')]">
           <xsl:call-template name="find-pages">
-            <xsl:with-param name="chapter"><xsl:value-of select="$chapter"/></xsl:with-param>
+<!--            <xsl:with-param name="chapter"><xsl:value-of select="$chapter"/></xsl:with-param>-->
           </xsl:call-template>
         </xsl:for-each>
 
@@ -547,7 +546,7 @@
   </xsl:template>
   
   <xsl:template name="find-pages">
-    <xsl:param name="chapter" select="''"/>
+<!--    <xsl:param name="chapter" select="''"/>-->
     
     <xsl:variable name="img">
       <xsl:choose>	 
@@ -572,13 +571,14 @@
 
   
     <xsl:if test="string-length($img) &gt; 0">
-      <f:map>
+<!--      <f:map>
         <xsl:if test="string-length($chapter) &gt; 0">
           <f:string key="title">
             <xsl:value-of select="$chapter"/>
           </f:string>
         </xsl:if>
-        <f:string key="url">
+        <f:string key="url">-->
+        <f:string>
 	  <xsl:choose>
 	    <xsl:when test="contains($img,'.json')">
 	      <xsl:value-of select="$img"/>
@@ -588,7 +588,7 @@
 	    </xsl:otherwise>
 	  </xsl:choose>            
         </f:string>
-      </f:map>
+<!--      </f:map>-->
     </xsl:if>
   </xsl:template>
 

--- a/src/main/webapp/api/index.html
+++ b/src/main/webapp/api/index.html
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Swagger UI</title>
+    <title>ds-present API</title>
     <link rel="stylesheet" type="text/css" href="../v1/swagger-ui.css" >
     <link rel="icon" type="image/png" href="../v1/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="../v1/favicon-16x16.png" sizes="16x16" />

--- a/src/test/java/dk/kb/present/CollectionHandlerTest.java
+++ b/src/test/java/dk/kb/present/CollectionHandlerTest.java
@@ -76,8 +76,9 @@ class CollectionHandlerTest {
     void localCorpusMODS() throws IOException {
         YAML conf = YAML.resolveLayeredConfigs("test_setup.yaml");
         CollectionHandler ch = new CollectionHandler(conf);
-        String record = ch.getRecord("local:henrik-hertz.xml", "mods");
-        assertTrue(record.contains("<forename>Henrik</forename>"));
+        String record = ch.getRecord("local:albert-einstein.xml", "mods");
+        System.out.println(record);
+        assertTrue(record.contains("<md:title>Letter from Einstein, Albert to Simonsen, David</md:title>"));
     }
 
     @Test
@@ -85,7 +86,7 @@ class CollectionHandlerTest {
         YAML conf = YAML.resolveLayeredConfigs("test_setup.yaml");
         CollectionHandler ch = new CollectionHandler(conf);
         try {
-            ch.getRecord("local_henrik-hertz.xml", "raw");
+            ch.getRecord("local_albert-einstein.xml", "raw");
             fail("Requesting record in raw format should fail");
         } catch (Exception e) {
             // Expected

--- a/src/test/java/dk/kb/present/CollectionHandlerTest.java
+++ b/src/test/java/dk/kb/present/CollectionHandlerTest.java
@@ -77,7 +77,6 @@ class CollectionHandlerTest {
         YAML conf = YAML.resolveLayeredConfigs("test_setup.yaml");
         CollectionHandler ch = new CollectionHandler(conf);
         String record = ch.getRecord("local:albert-einstein.xml", "mods");
-        System.out.println(record);
         assertTrue(record.contains("<md:title>Letter from Einstein, Albert to Simonsen, David</md:title>"));
     }
 

--- a/src/test/java/dk/kb/present/PresentFacadeTest.java
+++ b/src/test/java/dk/kb/present/PresentFacadeTest.java
@@ -1,0 +1,109 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.present;
+
+import dk.kb.present.config.ServiceConfig;
+import dk.kb.present.webservice.ExportWriter;
+import dk.kb.present.webservice.ExportWriterFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PresentFacadeTest {
+
+    @BeforeAll
+    static void setup() {
+        try {
+            ServiceConfig.initialize("test_setup.yaml");
+            PresentFacade.warmUp();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void getRecord() {
+        // Throws an Exception if not found
+        PresentFacade.getRecord("local:albert-einstein.xml", "mods");
+    }
+
+    @Test
+    void getRecordsMODS() throws IOException {
+        StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "mods");
+        String result = toString(out);
+        assertTrue(result.contains("<md:namePart>Simonsen, David</md:namePart>"));
+    }
+
+    @Test
+    void getRecordsRaw() throws IOException {
+        PresentFacade.recordView = "raw-bypass"; // We don't want to check security here
+        StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "storagerecord");
+        String result = toString(out);
+        assertTrue(result.contains("\"id\":\"tystrup-soroe.xml\",\"deleted\":false"));
+        assertTrue(result.contains(",\n"), "Result should contain a comma followed by newline as it should be a multi-entry JSON array"); // Plain JSON array
+        assertTrue(result.endsWith("]\n"), "Result should end with ']' as it should be a JSON array"); // JSON array
+    }
+
+    @Test
+    void getRecordsRawLines() throws IOException {
+        PresentFacade.recordView = "raw-bypass"; // We don't want to check security here
+        StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "storagerecord-lines");
+        String result = toString(out);
+        System.out.println(result);
+        assertTrue(result.contains("\"id\":\"tystrup-soroe.xml\",\"deleted\":false"));
+        assertFalse(result.contains(",\n"), "Result should not contain a comma followed by newline as it should be a multi-entry JSON-Lines");
+        assertFalse(result.endsWith("]\n"), "Result should not end with ']' as it should be in JSON-Lin es");
+    }
+
+    @Test
+    void getRecordsJSONLD() throws IOException {
+        StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "json-ld");
+        String result = toString(out);
+        assertTrue(result.contains("\"@value\":\"Letters to\\/from David Simonsen\"}"), "Result should contain the name David Simonsen in the expected wrapping");
+        assertTrue(result.contains(",\n"), "Result should contain a comma followed by newline as it should be a multi-entry JSON array"); // Plain JSON array
+        assertTrue(result.endsWith("]\n"), "Result should end with ']' as it should be a JSON array"); // JSON array
+    }
+
+    @Test
+    void getRecordsJSONLDLines() throws IOException {
+        StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "json-ld-lines");
+        String result = toString(out);
+        assertTrue(result.contains("\"@value\":\"Letters to\\/from David Simonsen\"}"), "Result should contain the name David Simonsen in the expected wrapping");
+        assertFalse(result.contains(",\n"), "Result should not contain a comma followed by newline as it should be a multi-entry JSON-Lines");
+        assertFalse(result.endsWith("]\n"), "Result should not end with ']' as it should be in JSON-Lin es");
+    }
+
+    @Test
+    void getRecordsSolr() throws IOException {
+        StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "SolrJSON");
+        String result = toString(out);
+        System.out.println(result);
+    }
+
+    private String toString(StreamingOutput out) throws IOException {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            out.write(os);
+            return os.toString(StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/src/test/java/dk/kb/present/PresentFacadeTest.java
+++ b/src/test/java/dk/kb/present/PresentFacadeTest.java
@@ -69,7 +69,6 @@ class PresentFacadeTest {
         PresentFacade.recordView = "raw-bypass"; // We don't want to check security here
         StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "storagerecord-lines");
         String result = toString(out);
-        System.out.println(result);
         assertTrue(result.contains("\"id\":\"tystrup-soroe.xml\",\"deleted\":false"));
         assertFalse(result.contains(",\n"), "Result should not contain a comma followed by newline as it should be a multi-entry JSON-Lines");
         assertFalse(result.endsWith("]\n"), "Result should not end with ']' as it should be in JSON-Lin es");
@@ -97,7 +96,6 @@ class PresentFacadeTest {
     void getRecordsSolr() throws IOException {
         StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "SolrJSON");
         String result = toString(out);
-        System.out.println(result);
     }
 
     private String toString(StreamingOutput out) throws IOException {

--- a/src/test/java/dk/kb/present/storage/FileStorageTest.java
+++ b/src/test/java/dk/kb/present/storage/FileStorageTest.java
@@ -29,10 +29,22 @@ class FileStorageTest {
 
     @Test
     void basicAccess() throws IOException {
+        Storage storage = getStorage();
+        assertTrue(storage.getRecord("henrik-hertz.xml").contains("Henrik"));
+    }
+
+    @Test
+    void DSRecordAccess() throws IOException {
+        Storage storage = getStorage();
+        assertTrue(storage.getDSRecord("henrik-hertz.xml").getData().contains("Henrik"));
+        System.out.println(storage.getDSRecord("henrik-hertz.xml"));
+    }
+
+    private Storage getStorage() throws IOException {
         URL albert = Resolver.resolveURL("xml/corpus/albert-einstein.xml");
         assertNotNull(albert, "The test file albert-einstein.xml should be available");
         Path rootFolder = Path.of(albert.getPath()).getParent();
         Storage storage = new FileStorage("test", rootFolder, false, false);
-        assertTrue(storage.getRecord("henrik-hertz.xml").contains("Henrik"));
+        return storage;
     }
 }

--- a/src/test/java/dk/kb/present/storage/FileStorageTest.java
+++ b/src/test/java/dk/kb/present/storage/FileStorageTest.java
@@ -35,7 +35,6 @@ class FileStorageTest {
     void DSRecordAccess() throws IOException {
         Storage storage = getStorage();
         assertTrue(storage.getDSRecord("henrik-hertz.xml").getData().contains("Henrik"));
-        System.out.println(storage.getDSRecord("henrik-hertz.xml"));
     }
 
     private Storage getStorage() throws IOException {

--- a/src/test/java/dk/kb/present/storage/FileStorageTest.java
+++ b/src/test/java/dk/kb/present/storage/FileStorageTest.java
@@ -42,7 +42,7 @@ class FileStorageTest {
         URL albert = Resolver.resolveURL("xml/corpus/albert-einstein.xml");
         assertNotNull(albert, "The test file albert-einstein.xml should be available");
         Path rootFolder = Path.of(albert.getPath()).getParent();
-        Storage storage = new FileStorage("test", rootFolder, "", false, false);
+        Storage storage = new FileStorage("test", rootFolder, "", false, null, null, false);
         return storage;
     }
 }

--- a/src/test/java/dk/kb/present/storage/FileStorageTest.java
+++ b/src/test/java/dk/kb/present/storage/FileStorageTest.java
@@ -1,16 +1,3 @@
-package dk.kb.present.storage;
-
-import dk.kb.util.Resolver;
-import dk.kb.util.yaml.YAML;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Path;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 /*
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,6 +12,17 @@ import static org.junit.jupiter.api.Assertions.*;
  *  limitations under the License.
  *
  */
+package dk.kb.present.storage;
+
+import dk.kb.util.Resolver;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 class FileStorageTest {
 
     @Test
@@ -44,7 +42,7 @@ class FileStorageTest {
         URL albert = Resolver.resolveURL("xml/corpus/albert-einstein.xml");
         assertNotNull(albert, "The test file albert-einstein.xml should be available");
         Path rootFolder = Path.of(albert.getPath()).getParent();
-        Storage storage = new FileStorage("test", rootFolder, false, false);
+        Storage storage = new FileStorage("test", rootFolder, "", false, false);
         return storage;
     }
 }

--- a/src/test/java/dk/kb/present/storage/StorageControllerTest.java
+++ b/src/test/java/dk/kb/present/storage/StorageControllerTest.java
@@ -3,6 +3,7 @@ package dk.kb.present.storage;
 import dk.kb.util.yaml.YAML;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,5 +35,26 @@ class StorageControllerTest {
         YAML multiConf = YAML.resolveMultiConfig("test_setup.yaml");
         Storage storage = StorageController.createStorage(multiConf.getYAMLList(".config.storages").get(0));
         assertTrue(storage.getRecord("albert-einstein.xml").contains("Albert"));
+    }
+
+    // Not a proper test as it requires a local ds-storage with test-data ingested as described in the README
+    void getRecordsCoreTest() throws Exception {
+        YAML localDSS = YAML.resolveMultiConfig("local_ds-storage.yaml");
+        Storage storage = StorageController.createStorage(localDSS.getYAMLList(".config.storages").get(0));
+        assertTrue(storage.getRecord("doms.radio:albert-einstein.xml").contains("Albert"));
+
+        assertEquals(2, storage.getDSRecords("doms.radio", 0, 2).count(),
+                     "Retrieving multiple records should work");
+        storage.getDSRecords("doms.radio", 0, 1).forEach(System.out::println);
+    }
+
+    // Not a proper test as it requires a local ds-storage with test-data ingested as described in the README
+    void getRecordsJSMSS() throws Exception {
+        YAML localDSS = YAML.resolveMultiConfig("local_ds-storage.yaml");
+        Storage storage = StorageController.createStorage(localDSS.getYAMLList(".config.storages").get(0));
+
+        assertEquals(2, storage.getDSRecords("kb.image.judsam.jsmss", 0, 2).count(),
+                     "Retrieving multiple records should work");
+        storage.getDSRecords("kb.image.judsam.jsmss", 0, 1).forEach(System.out::println);
     }
 }

--- a/src/test/java/dk/kb/present/storage/StorageControllerTest.java
+++ b/src/test/java/dk/kb/present/storage/StorageControllerTest.java
@@ -33,6 +33,6 @@ class StorageControllerTest {
     void multiBackend() throws Exception {
         YAML multiConf = YAML.resolveMultiConfig("test_setup.yaml");
         Storage storage = StorageController.createStorage(multiConf.getYAMLList(".config.storages").get(0));
-        assertTrue(storage.getRecord("henrik-hertz.xml").contains("Henrik"));
+        assertTrue(storage.getRecord("albert-einstein.xml").contains("Albert"));
     }
 }

--- a/src/test/java/dk/kb/present/util/CombinerTest.java
+++ b/src/test/java/dk/kb/present/util/CombinerTest.java
@@ -1,0 +1,70 @@
+package dk.kb.present.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+class CombinerTest {
+
+    @Test
+    void iterateFromStream() {
+        Stream<Integer> foreverStream = Stream.generate(() -> new Random().nextInt());
+        Iterator<Integer> foreverIterator = foreverStream.iterator();
+        System.out.println("First: " + foreverIterator.next());
+        System.out.println("Second: " + foreverIterator.next());
+    }
+
+    @Test
+    void testStream() {
+        List<Stream<Integer>> streams = Arrays.asList(
+                Stream.of(1, 3, 5),
+                Stream.of(2, 4),
+                Stream.of());
+        Stream<Integer> merged = Combiner.mergeStreams(streams, Integer::compare);
+        assertEquals("[1, 2, 3, 4, 5]", merged.collect(Collectors.toList()).toString());
+    }
+
+    @Test
+    void testCollections() {
+        List<Collection<Integer>> collections = List.of(
+                List.of(2, 4),
+                List.of(1, 3, 5),
+                List.of());
+        Collection<Integer> merged = Combiner.mergeCollections(collections, Integer::compare);
+        assertEquals("[1, 2, 3, 4, 5]", merged.toString());
+    }
+
+    @Test
+    void testEmpty() {
+        List<Collection<Integer>> collections = List.of();
+        Collection<Integer> merged = Combiner.mergeCollections(collections, Integer::compare);
+        assertEquals("[]", merged.toString());
+    }
+
+    @Test
+    void testEmptyMulti() {
+        List<Collection<Integer>> collections = List.of(
+                List.of(),
+                List.of());
+        Collection<Integer> merged = Combiner.mergeCollections(collections, Integer::compare);
+        assertEquals("[]", merged.toString());
+    }
+}

--- a/src/test/java/dk/kb/present/util/CombinerTest.java
+++ b/src/test/java/dk/kb/present/util/CombinerTest.java
@@ -28,8 +28,6 @@ class CombinerTest {
     void iterateFromStream() {
         Stream<Integer> foreverStream = Stream.generate(() -> new Random().nextInt());
         Iterator<Integer> foreverIterator = foreverStream.iterator();
-        System.out.println("First: " + foreverIterator.next());
-        System.out.println("Second: " + foreverIterator.next());
     }
 
     @Test

--- a/src/test/resources/local_ds-storage.yaml
+++ b/src/test/resources/local_ds-storage.yaml
@@ -1,0 +1,72 @@
+#
+# Requires a running ds-storage and records added as described in the README
+#
+config:
+
+  # List of backing storages. The real URLs should be overridden in ds-present-environment.yaml
+  storages:
+    - main:
+        # If default is true, this will be the default storage for collections.
+        # The default storage choice can be overridden in a collection with the 'storage' property
+        default: true
+        # Backends contains a list of one or more implementations and their configuration, with the primary key being
+        # the implementation (aka type) of the backend
+        #
+        # Available backends are
+        # ds-storage: Connection to a https://github.com/kb-dk/ds-storage/ instance
+        # folder:     Local files under the stated folder. Use only for test as the implementation in unsecure
+        backends:
+          # The ds-storage backend connects to a running https://github.com/kb-dk/ds-storage/ instance
+          - ds-storage:
+              # The name of the machine running the service. Mandatory
+              host: 'localhost'
+              # The port for the service. Mandatory
+              port: 9072
+              # The path the the service. Optional, default is '/ds-storage/v1/'
+              basepath: '/ds-storage/v1/'
+              # The connection scheme: http or https. Optional, default is http for localhost, https for everything else
+              scheme: 'http'
+
+  # Settings for handling at the record level
+  record:
+    id:
+      # Pattern for acceptable record IDs. Must contain exactly 2 capturing group, the first being the collection prefix
+      # and the second being the collection-specifix par of the ID
+      # Mandatory. Suggested value: '$([a-z][0-9][.]):([a-z][0-9][.-_])$', e.g. 'images.dsfl:image1234'
+      pattern: '^([a-z0-9.]+):([a-z0-9._-]+)$'
+
+  # Generic views for images represented as MODS, used for multiple collections
+  baseviews: &MODS_IMAGE_VIEWS
+    # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
+    - raw:
+        mime: 'text/plain'
+        transformers:
+          - identity:
+    - MODS:
+        mime: 'application/xml'
+        transformers:
+          - identity: # No transformation steps as mods is the core format for images-dsfl
+    - JSON-LD:
+        mime: 'application/json'
+        transformers:
+          - xslt:
+              stylesheet: 'xslt/mods2schemaorg.xsl'
+    - SolrJSON:
+        mime: 'application/json'
+        transformers:
+          - xslt:
+              stylesheet: 'xslt/mods2solr.xsl'
+
+  # The collections available for this instance of ds-present
+  collections:
+    # Straight forward collection with the core format being MODS
+    - radio: # ds-present internal
+        prefix: 'doms.radio' # The prefix to match on incoming IDs
+        description: 'Sample records'
+        # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
+        views: *MODS_IMAGE_VIEWS
+    - images_jsmss:
+        description: 'Judaistisk Samling: Håndskrifter images from the collections at the Royal Danish Library'
+        prefix: 'kb.image.judsam.jsmss'
+        base: 'kb.image.judsam.jsmss'
+        views: *MODS_IMAGE_VIEWS

--- a/src/test/resources/local_ds-storage.yaml
+++ b/src/test/resources/local_ds-storage.yaml
@@ -34,6 +34,13 @@ config:
       # and the second being the collection-specifix par of the ID
       # Mandatory. Suggested value: '$([a-z][0-9][.]):([a-z][0-9][.-_])$', e.g. 'images.dsfl:image1234'
       pattern: '^([a-z0-9.]+):([a-z0-9._-]+)$'
+  collection:
+    prefix:
+      # Pattern for acceptable collection prefixes. This will practically always be a mirror of the first capturing
+      # group for record.id.pattern.
+      # Primarily used for verifying configuration.
+      # Mandatory. Suggested value: '[a-z0-9.]+', e.g. 'images.dsfl'
+      pattern: '[a-z0-9.]+'
 
   # Generic views for images represented as MODS, used for multiple collections
   baseviews: &MODS_IMAGE_VIEWS

--- a/src/test/resources/test_setup.yaml
+++ b/src/test/resources/test_setup.yaml
@@ -36,6 +36,13 @@ config:
       # and the second being the collection-specifix par of the ID
       # Mandatory. Suggested value: '$([a-z][0-9][.]):([a-z][0-9][.-_])$', e.g. 'images.dsfl:image1234'
       pattern: '^([a-z0-9.]+):([a-z0-9._-]+)$'
+  collection:
+    prefix:
+      # Pattern for acceptable collection prefixes. This will practically always be a mirror of the first capturing
+      # group for record.id.pattern.
+      # Primarily used for verifying configuration.
+      # Mandatory. Suggested value: '[a-z0-9.]+', e.g. 'images.dsfl'
+      pattern: '[a-z0-9.]+'
 
   # The collections available for this instance of ds-present 
   collections:

--- a/src/test/resources/test_setup.yaml
+++ b/src/test/resources/test_setup.yaml
@@ -2,6 +2,18 @@
 # Only used for unit testing
 #
 config:
+
+  # Only some of the sample files can be properly transformed to SolrJSONDocuments
+  filewhitelist: &whitelist
+     - '.*albert-einstein.xml'
+     - '.*hvidovre-teater.xml'
+     - '.*simonsen-brandes.xml'
+     - '.*tystrup-soroe.xml'
+     - '.*homiliae-super-psalmos.xml'
+     - '.*work_on_logic.xml'
+     - '.*joergen_hansens_visebog.xml'
+     - '.*responsa.xml'
+
   # List of backing storages. The real URLs should be overridden in ds-present-environment.yaml
   storages:
     - test:
@@ -11,9 +23,11 @@ config:
           - folder:
               root: 'src/test/resources/xml'
               extension: '.xml'
+              whitelist: *whitelist
           - folder:
               root: 'src/test/resources/xml/corpus'
               extension: '.xml'
+              whitelist: *whitelist
 
   # Settings for handling at the record level
   record:

--- a/src/test/resources/test_setup.yaml
+++ b/src/test/resources/test_setup.yaml
@@ -10,8 +10,10 @@ config:
           # Problematic: Can we rely on the test being started with the working folder at the root of the project?
           - folder:
               root: 'src/test/resources/xml'
+              extension: '.xml'
           - folder:
               root: 'src/test/resources/xml/corpus'
+              extension: '.xml'
 
   # Settings for handling at the record level
   record:
@@ -33,7 +35,7 @@ config:
               mime: 'application/xml'
               transformers:
                 - identity: # No transformation steps as mods is the core format for images-dsfl
-          - jsonld:
+          - json-ld:
               mime: 'application/json'
               transformers:
                 - xslt:
@@ -48,3 +50,8 @@ config:
               transformers:
                 - fail:
                     message: 'Raw format contains confidential information and cannot be delivered'
+          # For testing purposes
+          - raw-bypass:
+              mime: 'text/plain'
+              transformers:
+                - identity:

--- a/src/test/resources/xml/corpus/convert_to_solr.sh
+++ b/src/test/resources/xml/corpus/convert_to_solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+SOURCE="./"
+TRANSFORM="../../../../main/resources/xslt/mods2solr.xsl"
+
+: ${SAXON_JAR:="/home/$USER/saxon/saxon9he.jar"}
+if [[ ! -s "$SAXON_JAR" ]]; then
+    >&2 echo "$SAXON_JAR not available. Please install it from https://sourceforge.net/projects/saxon/files/Saxon-HE/"
+    exit 2
+fi
+for TOOL in jq; do
+    if [[ -z $(which $TOOL) ]]; then
+        >&2 echo "$TOOL not available. Please install it"
+        exit 3
+    fi
+done
+
+SAXON="java -jar "$SAXON_JAR" --suppressXsltNamespaceCheck:on  "
+
+# set to 1 if you want to prettyprint you json
+
+DEBUG_JSON=1
+
+mods_files=("albert-einstein.xml"
+	    "hvidovre-teater.xml"
+	    "simonsen-brandes.xml"
+	    "tystrup-soroe.xml"
+	    "homiliae-super-psalmos.xml"
+	    "work_on_logic.xml"
+	    "joergen_hansens_visebog.xml"
+	    "responsa.xml")
+
+for file in ${mods_files[@]}; do
+    json=$(sed 's/.xml$/.json/' <<< "$file")
+    echo " - Producing $json"
+    if [ "$DEBUG_JSON" = "1" ]; then
+	$SAXON -xsl:"$TRANSFORM" -s:"$SOURCE/$file" | jq . > "$json"
+    else
+	$SAXON -xsl:"$TRANSFORM" -s:"$SOURCE/$file" > "$json"
+    fi
+done

--- a/src/test/resources/xml/corpus/post_to_storage.sh
+++ b/src/test/resources/xml/corpus/post_to_storage.sh
@@ -7,7 +7,7 @@
 : ${FILE:="illum.xml"}
 
 : ${STORAGE:="http://localhost:8080/ds-storage/v1"}
-: ${ENDPOINT:="$STORAGE/record/createOrUpdateRecord"}
+: ${ENDPOINT:="$STORAGE/record"}
 
 ID="doms.radio:$FILE"
 

--- a/src/test/resources/xml/corpus/post_to_storage.sh
+++ b/src/test/resources/xml/corpus/post_to_storage.sh
@@ -4,7 +4,7 @@
 # with default test setup
 
 : ${RECORD_FILES:="$@"}
-: ${RECORD_FILES:="illum.xml"}
+: ${RECORD_FILES:="albert-einstein.xml hvidovre-teater.xml simonsen-brandes.xml tystrup-soroe.xml homiliae-super-psalmos.xml work_on_logic.xml joergen_hansens_visebog.xml responsa.xml"}
 
 : ${STORAGE:="http://localhost:9072/ds-storage/v1"}
 : ${ENDPOINT:="$STORAGE/record"}


### PR DESCRIPTION
This implements the `/records` endpoint, making it possible to export batches of records with a given view. The primary use case it to export [JSON Formatted Index Updates](https://solr.apache.org/guide/8_8/uploading-data-with-index-handlers.html#json-formatted-index-updates), making it trivial to populate a running Solr.

The `/records` also allows for mass exports of `JSON-LD` and raw, but those are simple concatenations of the same representations than `/record/{id}` gives. `/records` is special for Solr as it requires qualified output (`add` / `delete`), depending on record state.