### PR TITLE
WOK 318 xml declaration

### DIFF
--- a/src/main/java/dk/kb/present/PresentFacade.java
+++ b/src/main/java/dk/kb/present/PresentFacade.java
@@ -20,6 +20,7 @@ import dk.kb.present.backend.model.v1.DsRecordDto;
 import dk.kb.present.config.ServiceConfig;
 import dk.kb.present.model.v1.CollectionDto;
 import dk.kb.present.model.v1.ViewDto;
+import dk.kb.present.util.DataCleanup;
 import dk.kb.present.webservice.ExportWriter;
 import dk.kb.present.webservice.ExportWriterFactory;
 import dk.kb.present.webservice.JSONStreamWriter;
@@ -162,6 +163,7 @@ public class PresentFacade {
                     output, httpServletResponse, deliveryFormat, false, "records")) {
                 collection.getDSRecords(mTime, maxRecords, recordFormat)
                         .map(DsRecordDto::getData)
+                        .map(DataCleanup::removeXMLDeclaration)
                         .forEach(writer::write);
             }
         };
@@ -176,6 +178,7 @@ public class PresentFacade {
             try (ExportWriter writer = ExportWriterFactory.wrap(
                     output, httpServletResponse, deliveryFormat, false, "records")) {
                 collection.getDSRecords(mTime, maxRecords, recordView) // Does not contain deleted records
+                        .peek(record -> record.setData(DataCleanup.removeXMLDeclaration(record.getData())))
                         .forEach(writer::write);
             }
         };

--- a/src/main/java/dk/kb/present/util/DataCleanup.java
+++ b/src/main/java/dk/kb/present/util/DataCleanup.java
@@ -1,0 +1,50 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.present.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Helper methods for cleaning data before passing it on.
+ */
+public class DataCleanup {
+    private static final Logger log = LoggerFactory.getLogger(DataCleanup.class);
+
+    /**
+     * If the XML block starts with an XML declaration (https://www.tutorialspoint.com/xml/xml_declaration.htm)
+     * it will be removed. This is typically used for representing multiple XML blocks as a list of elements.
+     *
+     * The method uses a regular expression: It is fast, but does not validate the input.
+     * Only the first declaration is removed and only if it positioned at the start of the XML.
+     * @param xml a single XML block.
+     * @return the XML block without declaration.
+     */
+    public static String removeXMLDeclaration(String xml) {
+        Matcher m = XML_DECLARATION.matcher(xml);
+        if (!m.find()) {
+            return xml;
+        }
+        if (m.start() != 0) {
+            log.warn("Found XML declaration at index " + m.start() + " with expected index 0. Skipping removal");
+            return xml;
+        }
+        return m.replaceFirst("");
+    }
+    private static final Pattern XML_DECLARATION = Pattern.compile("[\n ]*<[?]xml [^?]*[?]>\n?", Pattern.DOTALL);
+}

--- a/src/test/java/dk/kb/present/PresentFacadeTest.java
+++ b/src/test/java/dk/kb/present/PresentFacadeTest.java
@@ -25,6 +25,8 @@ import javax.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,6 +54,20 @@ class PresentFacadeTest {
         StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "mods");
         String result = toString(out);
         assertTrue(result.contains("<md:namePart>Simonsen, David</md:namePart>"));
+    }
+
+    @Test
+    void getRecordsMODSDeclaration() throws IOException {
+        StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "mods");
+        String result = toString(out);
+
+        Pattern DECLARATION = Pattern.compile("<[?]xml version=\"1.0\" encoding=\"UTF-8\"[?]>", Pattern.DOTALL);
+        Matcher m = DECLARATION.matcher(result);
+        int count = 0;
+        while (m.find()) {
+            count++;
+        }
+        assertTrue(count <= 1, "There should be at most 1 XML declaration but there was " + count);
     }
 
     @Test

--- a/src/test/java/dk/kb/present/util/DataCleanupTest.java
+++ b/src/test/java/dk/kb/present/util/DataCleanupTest.java
@@ -1,0 +1,48 @@
+package dk.kb.present.util;
+
+import dk.kb.util.Resolver;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+class DataCleanupTest {
+
+    @Test
+    public void testDeclarationRemoval() throws IOException {
+        String xmlWithDeclaration = Resolver.resolveUTF8String("xml/corpus/albert-einstein.xml");
+        assertTrue(xmlWithDeclaration.startsWith("<?xml version"), "The test XML should have a declaration");
+        String stripped = DataCleanup.removeXMLDeclaration(xmlWithDeclaration);
+        assertTrue(stripped.startsWith("<rss"), "The cleaned test XML should not have a declaration");
+    }
+
+    @Test
+    public void testDeclarationRemovalNonExisting() {
+        String xml = "<foo>bar</foo>";
+        assertEquals(xml, DataCleanup.removeXMLDeclaration(xml),
+                     "XML without declaration should be left unchanged");
+    }
+
+    @Test
+    public void testDeclarationRemovalFaulty() {
+        String xml = "<foo>bar</foo>\n" +
+                     "<?xml encoding=\"UTF-8\"   version=\"1.0\" ?>";
+        assertEquals(xml, DataCleanup.removeXMLDeclaration(xml),
+                     "XML with faulty declaration should be left unchanged");
+    }
+}


### PR DESCRIPTION
**Important:** This pull request asks for merging into the `records`-branch. It is recommended to finish reviewing https://github.com/kb-dk/ds-present/pull/2 first and then change the target to `master`.

When the endpoint `/records` was called with `MODS` or `StorageRecord` as export type, the XML blocks could be prefaced with declarations `<?xml version="1.0" encoding="UTF-8"?>`. This is only valid at the beginning of the full XML dump and not scattered inside the XML.

This pull request uses a regexp to remove the declaration.