### PR TITLE
Extend the transformer chain with metadata for the record

### DIFF
--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -109,7 +109,7 @@ public class DSCollection {
     public String getRecord(String recordID, String format) throws ServiceException {
         View view = getView(format);
         String record = storage.getRecord(recordID);
-        return view.apply(record);
+        return view.apply(recordID, record);
     }
 
     /**
@@ -140,7 +140,7 @@ public class DSCollection {
             return storage.getDSRecords(recordBase, mTime, maxRecords)
                     .peek(record -> {
                         try {
-                            record.data(view.apply(record.getData()));
+                            record.data(view.apply(record.getId(), record.getData()));
                         } catch (Exception e) {
                             throw new RuntimeTransformerException(
                                     "Exception transforming record '" + record.getId() + "' to format '" + format + "'");

--- a/src/main/java/dk/kb/present/transform/DSTransformer.java
+++ b/src/main/java/dk/kb/present/transform/DSTransformer.java
@@ -14,14 +14,18 @@
  */
 package dk.kb.present.transform;
 
-import dk.kb.util.yaml.YAML;
-
-import java.util.function.Function;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 /**
- * Takes a textual input and transforms it to another textual input.
+ * Takes a textual input and a map of metadata and transforms it to another textual input.
+ * The metadata map will initially contain the pair {@code recordID:<recordID>}.
+ * Changes to metadata will be passed through the chain of {@code DSTransformer}s.
+ * One example of chaining it to have one transformer resolve copyright rules, store them as key-values in the
+ * metadata and pass the input unchanged, then having another transformer responsible for transforming to Solr-JSON
+ * with extra fields added from the metadata delivered by the copyright extractor.
  */
-public abstract class DSTransformer implements Function<String, String> {
+public abstract class DSTransformer implements BiFunction<String, Map<String, String>, String> {
 
     /**
      * @return the ID for the transformer, e.g. {@code mods2solr}.

--- a/src/main/java/dk/kb/present/transform/FailTransformer.java
+++ b/src/main/java/dk/kb/present/transform/FailTransformer.java
@@ -14,11 +14,10 @@
  */
 package dk.kb.present.transform;
 
-import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.naming.ServiceUnavailableException;
+import java.util.Map;
 
 /**
  * The fail transformer always fails. Used to signal unavailable views.
@@ -31,7 +30,7 @@ public class FailTransformer extends DSTransformer {
 
     /**
      * Construct a transformer that always fails with the given message.
-     * @param message the message to throw in a {@link RuntimeException} when {@link #apply(String)} is called.
+     * @param message the message to throw in a {@link RuntimeException} when {@link #apply(String, Map)} is called.
      */
     public FailTransformer(String message) {
         this.message = message;
@@ -44,7 +43,7 @@ public class FailTransformer extends DSTransformer {
     }
 
     @Override
-    public String apply(String s) {
+    public String apply(String s, Map<String, String> metadata) {
         throw new RuntimeException(message);
     }
 

--- a/src/main/java/dk/kb/present/transform/IdentityTransformer.java
+++ b/src/main/java/dk/kb/present/transform/IdentityTransformer.java
@@ -14,9 +14,10 @@
  */
 package dk.kb.present.transform;
 
-import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 /**
  * The identity transformer returns the given input unchanged.
@@ -39,7 +40,7 @@ public class IdentityTransformer extends DSTransformer {
 
     // A "real" transformer would do something here
     @Override
-    public String apply(String s) {
+    public String apply(String s, Map<String, String> metadata) {
         return s;
     }
 

--- a/src/main/java/dk/kb/present/transform/RuntimeTransformerException.java
+++ b/src/main/java/dk/kb/present/transform/RuntimeTransformerException.java
@@ -14,11 +14,6 @@
  */
 package dk.kb.present.transform;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.xml.transform.TransformerException;
-
 /**
  * As the transformers use the functional interfaces, they cannot throw checked exceptions.
  * This is an unchecked wrapper for {@link javax.xml.transform.TransformerException}.

--- a/src/main/java/dk/kb/present/transform/XSLTTransformer.java
+++ b/src/main/java/dk/kb/present/transform/XSLTTransformer.java
@@ -33,6 +33,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 /**
  * XSLT transformer using Saxon HE 3.
@@ -79,14 +80,17 @@ public class XSLTTransformer extends DSTransformer {
     }
 
     @Override
-    public synchronized String apply(String s) {
+    public synchronized String apply(String s, Map<String, String> metadata) {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             try (Reader in = new StringReader(s)) {
+                transformer.clearParameters();
+                metadata.forEach(transformer::setParameter);
                 transformer.transform(new StreamSource(in), new StreamResult(out));
             }
             return out.toString(StandardCharsets.UTF_8);
         } catch (IOException | TransformerException e) {
-            throw new RuntimeTransformerException("Exception transforming with stylesheet '" + stylesheet + "'", e);
+            throw new RuntimeTransformerException(
+                    "Exception transforming with stylesheet '" + stylesheet + "' and metadata '" + metadata + "'", e);
         }
     }
 

--- a/src/test/java/dk/kb/present/ViewTest.java
+++ b/src/test/java/dk/kb/present/ViewTest.java
@@ -27,7 +27,7 @@ class ViewTest {
         YAML conf = YAML.resolveLayeredConfigs("test_setup.yaml");
         YAML dsflConf = conf.getYAMLList(".config.collections").get(0);
         View view = new View(dsflConf.getSubMap("dsfl").getYAMLList("views").get(0));
-        assertEquals("SameAsInput", view.apply("SameAsInput")); // Identity view
+        assertEquals("SameAsInput", view.apply("someID", "SameAsInput")); // Identity view
     }
 
     @Test
@@ -36,7 +36,7 @@ class ViewTest {
         YAML dsflConf = conf.getYAMLList(".config.collections").get(0);
         View jsonldView = new View(dsflConf.getSubMap("dsfl").getYAMLList("views").get(1));
         String mods = Resolver.resolveUTF8String("xml/corpus/albert-einstein.xml");
-        String jsonld = jsonldView.apply(mods);
+        String jsonld = jsonldView.apply("albert-einstein", mods);
         assertTrue(jsonld.contains("\"name\":{\"@language\":\"en\",\"@value\":\"Einstein, Albert"));
     }
 
@@ -46,7 +46,7 @@ class ViewTest {
         YAML dsflConf = conf.getYAMLList(".config.collections").get(0);
         View jsonldView = new View(dsflConf.getSubMap("dsfl").getYAMLList("views").get(2));
         String mods = Resolver.resolveUTF8String("xml/corpus/albert-einstein.xml");
-        String solrjson = jsonldView.apply(mods);
+        String solrjson = jsonldView.apply("albert-einstein", mods);
         assertTrue(solrjson.contains("\"subject_name_da\":\"Einstein, Albert\","));
     }
 }

--- a/src/test/java/dk/kb/present/transform/XSLTTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTTransformerTest.java
@@ -52,6 +52,6 @@ class XSLTTransformerTest {
     private String getTransformed(String xsltResource, String xmlResource) throws IOException {
         XSLTTransformer transformer = new XSLTTransformer(xsltResource);
         String mods = Resolver.resolveUTF8String(xmlResource);
-        return transformer.apply(mods);
+        return transformer.apply(mods, Map.of("recordID", xmlResource));
     }
 }


### PR DESCRIPTION
This pull request adds metadata to the chain of DSTransformer`s and is connected to the [extract_copyright_rules](https://github.com/kb-dk/ds-present/tree/extract_copyright_rules) branch.

With thus update, the copyright extractor becomes a `DSTransformer` like the rest. The copyright extractor should

* Derive the needed copyright values from the given xml
* Store the values in the provided `metadata` map
* Return the given xml unchanged

Subsequent `DSTransformer`, such as the one responsible for creating SolrJSON documents, can then use the copyright key-value pairs in the `metadata` map when creating the SolrJSON document.

The setup for such a chain would be something like
```
    - SolrJSON:
        mime: 'application/json'
        transformers:
          - billedsamlingrights:
          - xslt:
              stylesheet: 'xslt/mods2solr.xsl'
```
where the `billedsamlingrights` is the ID for the copyright extractor implementation.

I checked the `extract_copyright_rules` branch and the class `XsltCopyrightMapper` does exactly what is needed. It is only a matter of adjusting how it is called by making that class a `DSTransformer` and adjusting the method signature a bit. I'll do that when this pull request has passed.