### PR TITLE
Generalize parameter injection in XSLTTransformer

### DIFF
--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -94,6 +94,10 @@ config:
               transformers:
                 - xslt:
                     stylesheet: 'xslt/mods2schemaorg.xsl'
+                    injections:
+                        # Imageserver to be used when constructing URLs to be shown in Schema.org XSLT transformation
+                        # This has to be set before image URLs are working.
+                      - imageserver: 'http:/example/imageserver'
           - SolrJSON:
               mime: 'application/json'
               transformers:

--- a/src/main/java/dk/kb/present/transform/XSLTFactory.java
+++ b/src/main/java/dk/kb/present/transform/XSLTFactory.java
@@ -17,12 +17,15 @@ package dk.kb.present.transform;
 import dk.kb.util.yaml.YAML;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Constructs {@link IdentityTransformer}s.
  */
 public class XSLTFactory implements DSTransformerFactory {
     public static final String STYLESHEET_KEY = "stylesheet";
+    public static final String INJECTIONS_KEY = "injections";
 
     @Override
     public String getTransformerID() {
@@ -35,6 +38,19 @@ public class XSLTFactory implements DSTransformerFactory {
             throw new IllegalArgumentException(
                     "Expected the property '" + STYLESHEET_KEY + "' to be present in the config");
         }
-        return new XSLTTransformer(conf.getString(STYLESHEET_KEY));
+        Map<String, String> injections = null;
+        if (conf.containsKey(INJECTIONS_KEY)) {
+            injections = new HashMap<>();
+            for (YAML yInjection: conf.getYAMLList(INJECTIONS_KEY)) {
+                if (yInjection.size() != 1) {
+                    throw new IllegalArgumentException(
+                            "Expected a single entry (key-value pair) in injection '" + yInjection +
+                            "' but got " + yInjection.size());
+                }
+                Map.Entry<String, Object> entry = yInjection.entrySet().stream().findFirst().get();
+                injections.put(entry.getKey(), entry.getValue().toString());
+            }
+        }
+        return new XSLTTransformer(conf.getString(STYLESHEET_KEY), injections);
     }
 }

--- a/src/main/resources/xslt/mods2schemaorg.xsl
+++ b/src/main/resources/xslt/mods2schemaorg.xsl
@@ -14,26 +14,11 @@
 
     <xsl:output method="text"/>
     <xsl:param name="sep_string" select="'/'"/>
-    <!--Loading properties from config-->
-
-
-    <xsl:variable name="properties">
-        <xsl:choose>
-            <xsl:when test="unparsed-text('conf/ds-present-local.yaml')">
-                <xsl:value-of select="unparsed-text('conf/ds-present-local.yaml')"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="unparsed-text('conf/ds-present-behaviour.yaml')"/>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:variable>
+    <!--Properties injected from config -->
+    <xsl:param name="imageserver"/>
 
     <!--Used to escape single quotes from config-->
     <xsl:variable name="singlequote"><xsl:text>'</xsl:text></xsl:variable>
-    <!--get imageserver property from config-->
-    <xsl:variable name="imageserver">
-        <xsl:value-of select="my:getProperty('imageserver')"/>
-    </xsl:variable>
     <xsl:variable name="roles">
         <roles>
             <role key="act" href="https://schema.org/actor">actor</role>
@@ -120,7 +105,7 @@
                         </xsl:variable>
                         <xsl:choose>
                             <xsl:when test="$server = ''">
-                                <xsl:value-of select="concat('https://example.com/imageserver/', f:substring-before($imageIdentifier, '.jp'))"/>
+                                <xsl:value-of select="concat($imageserver, f:substring-before($imageIdentifier, '.jp'))"/>
                             </xsl:when>
                             <xsl:otherwise>
                                 <xsl:value-of select="concat($server, f:substring-before($imageIdentifier, '.jp'))"/>
@@ -940,17 +925,5 @@
                 <xsl:value-of select="replace($arg,'\s',$sep_string,'s')"/>
             </xsl:otherwise>
         </xsl:choose>
-    </xsl:function>
-    <!--Function to get property from config file.
-        Used to get imageserver to construct URLs for images.
-        Created with inspiration from this stackoverflow thread: https://stackoverflow.com/questions/4326138/how-to-read-a-properties-file-inside-a-xsl-file-->
-    <xsl:function name="my:getProperty" as="xs:string?">
-        <xsl:param name="key" as="xs:string"/>
-        <xsl:variable name="lines" as="xs:string*" select="
-          for $x in
-            for $i in tokenize($properties, '\n')[matches(., '^[^!#]')] return
-              tokenize($i, ': ')
-            return translate(normalize-space($x), '\', '')"/>
-        <xsl:sequence select="$lines[index-of($lines, $key)+1]"/>
     </xsl:function>
 </xsl:transform>

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -5,8 +5,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import dk.kb.present.copyright.XsltCopyrightMapper;
+import dk.kb.present.transform.DSTransformer;
+import dk.kb.present.transform.XSLTFactory;
 import dk.kb.present.transform.XSLTTransformer;
 import dk.kb.util.Resolver;
+import dk.kb.util.yaml.YAML;
 
 public class TestUtil {
 
@@ -50,6 +53,21 @@ public class TestUtil {
 	public static String getTransformedWithAccessFieldsAdded(
             String xsltResource, String xmlResource, Map<String, String> injections) throws Exception {
 		XSLTTransformer transformer = new XSLTTransformer(xsltResource, injections);
+		String mods = Resolver.resolveUTF8String(xmlResource);
+		HashMap<String, String> accessFields = XsltCopyrightMapper.applyXsltCopyrightTransformer(mods);
+		//System.out.println("access fields:"+accessFields);
+		return transformer.apply(mods, accessFields);
+	}
+
+    /**
+     * Implicit test of {@link dk.kb.present.transform.XSLTFactory}.
+     * @param config XSLTFactory compliant YAML.
+     * @return the result generating a {@link dk.kb.present.transform.DSTransformer} using XSLTFactory and
+     *         transforming the {@code xmlResource} with that, including access fields resolved using
+     *         {@link XsltCopyrightMapper}.
+     */
+	public static String getTransformedFromConfigWithAccessFields(YAML config, String xmlResource) throws Exception {
+		DSTransformer transformer = new XSLTFactory().createTransformer(config);
 		String mods = Resolver.resolveUTF8String(xmlResource);
 		HashMap<String, String> accessFields = XsltCopyrightMapper.applyXsltCopyrightTransformer(mods);
 		//System.out.println("access fields:"+accessFields);

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -12,27 +12,46 @@ public class TestUtil {
 
 
 	public static String getTransformed(String xsltResource, String xmlResource) throws IOException {
-		XSLTTransformer transformer = new XSLTTransformer(xsltResource);
+		XSLTTransformer transformer = new XSLTTransformer(xsltResource, null);
 		String mods = Resolver.resolveUTF8String(xmlResource);
 		return transformer.apply(mods, new HashMap<String,String>());
 	}	
 
 
-	public static String getTransformed(String xsltResource, String xmlResource, Map<String,String> injections) throws IOException {
-		XSLTTransformer transformer = new XSLTTransformer(xsltResource);
+	public static String getTransformed(String xsltResource, String xmlResource, Map<String,String> metadata) throws IOException {
+		XSLTTransformer transformer = new XSLTTransformer(xsltResource, null);
 		String mods = Resolver.resolveUTF8String(xmlResource);
-		if (injections == null) {
-			injections = new HashMap<String,String>();
+		if (metadata == null) {
+			metadata = new HashMap<String,String>();
 		}        
-		return transformer.apply(mods, injections);
+		return transformer.apply(mods, metadata);
+	}
+
+	public static String getTransformed(String xsltResource, String xmlResource, Map<String,String> fixedInjections,
+                                        Map<String,String> metadata) throws IOException {
+		XSLTTransformer transformer = new XSLTTransformer(xsltResource, fixedInjections);
+		String mods = Resolver.resolveUTF8String(xmlResource);
+		if (metadata == null) {
+			metadata = new HashMap<String,String>();
+		}
+		return transformer.apply(mods, metadata);
 	}
 
 
 
 	public static String getTransformedWithAccessFieldsAdded(String xsltResource, String xmlResource) throws Exception {
-		XSLTTransformer transformer = new XSLTTransformer(xsltResource);	       	        		   
+		XSLTTransformer transformer = new XSLTTransformer(xsltResource, null);
 		String mods = Resolver.resolveUTF8String(xmlResource);
 		HashMap<String, String> accessFields = XsltCopyrightMapper.applyXsltCopyrightTransformer(mods);		        
+		//System.out.println("access fields:"+accessFields);
+		return transformer.apply(mods, accessFields);
+	}
+
+	public static String getTransformedWithAccessFieldsAdded(
+            String xsltResource, String xmlResource, Map<String, String> injections) throws Exception {
+		XSLTTransformer transformer = new XSLTTransformer(xsltResource, injections);
+		String mods = Resolver.resolveUTF8String(xmlResource);
+		HashMap<String, String> accessFields = XsltCopyrightMapper.applyXsltCopyrightTransformer(mods);
 		//System.out.println("access fields:"+accessFields);
 		return transformer.apply(mods, accessFields);
 	}

--- a/src/test/java/dk/kb/present/transform/XSLTSchemaDotOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTSchemaDotOrgTransformerTest.java
@@ -5,8 +5,13 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import dk.kb.present.TestUtil;
+import dk.kb.present.config.ServiceConfig;
+import dk.kb.util.Resolver;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -15,12 +20,14 @@ import java.io.FileWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Locale;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class XSLTSchemaDotOrgTransformerTest {
+    private static final Logger log = LoggerFactory.getLogger(XSLTSchemaDotOrgTransformerTest.class);
+
     public static final String MODS2SCHEMAORG = "xslt/mods2schemaorg.xsl";
     public static final String RECORD_000332 = "xml/copyright_extraction/000332.tif.xml";
     public static final String RECORD_JB000132 = "xml/copyright_extraction/JB000132_114.tif.xml";
@@ -31,125 +38,59 @@ public class XSLTSchemaDotOrgTransformerTest {
     public static final String RECORD_DNF = "xml/copyright_extraction/DNF_1951-00352_00052.tif.xml";
     public static final String RECORD_40221e = "xml/copyright_extraction/40221e30-1414-11e9-8fb8-00505688346e.xml";
 
+    // Does not seem to be needed for these tests
+    @BeforeAll
+    public static void fixConfiguration() throws IOException {
+        String CONFIG = Resolver.resolveGlob("conf/ds-present-behaviour.yaml").get(0).toString();
+        if ("[]".equals(CONFIG)) {
+            throw new IllegalStateException("Unable to locate config");
+        }
+
+        log.info("Fixing config to '{}'", CONFIG);
+        ServiceConfig.initialize(CONFIG);
+    }
+
     @Test
     void testDateCreatedAndTemporal() throws Exception {
-
-        String schemaOrgString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SCHEMAORG, RECORD_000332);
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        JsonElement je = JsonParser.parseString(schemaOrgString);
-        String prettyJsonString = gson.toJson(je);
-        //System.out.println(prettyJsonString);
-        //System.out.println(schemaOrgString);
-
-        String correctString = importTestFile("src/test/resources/schemaOrgJsonTestFiles/schemaOrg_000332.json");
-
-        Assertions.assertEquals(schemaOrgString, correctString);
-        }
+        assertJSONTransformation(MODS2SCHEMAORG, RECORD_000332, "schemaOrg_000332.json");
+    }
 
     @Test
     void testDateCreatedNoTemporal() throws Exception {
-        String schemaOrgString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SCHEMAORG, RECORD_KHP0001_001);
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        JsonElement je = JsonParser.parseString(schemaOrgString);
-        String prettyJsonString = gson.toJson(je);
-        //System.out.println(prettyJsonString);
-        //System.out.println(schemaOrgString);
-
-        String correctString = importTestFile("src/test/resources/schemaOrgJsonTestFiles/schemaOrg_KHP0001-001.json");
-
-        Assertions.assertEquals(schemaOrgString, correctString);
+        assertJSONTransformation(MODS2SCHEMAORG, RECORD_KHP0001_001, "schemaOrg_KHP0001-001.json");
     }
 
     @Test
     void testCreatorsAndHeadline() throws Exception {
-        String schemaOrgString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SCHEMAORG, RECORD_JB000132);
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        JsonElement je = JsonParser.parseString(schemaOrgString);
-        String prettyJsonString = gson.toJson(je);
-        //System.out.println(prettyJsonString);
-        //System.out.println(schemaOrgString);
-
-        String correctString = importTestFile("src/test/resources/schemaOrgJsonTestFiles/schemaOrg_JB000132_114.json");
-
-        Assertions.assertEquals(schemaOrgString, correctString);
+        assertJSONTransformation(MODS2SCHEMAORG, RECORD_JB000132, "schemaOrg_JB000132_114.json");
     }
 
 
     @Test
     void testCreatorDescriptionAndContentNoteToAbout() throws Exception {
-        String schemaOrgString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SCHEMAORG, RECORD_KE066530);
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        JsonElement je = JsonParser.parseString(schemaOrgString);
-        String prettyJsonString = gson.toJson(je);
-        //System.out.println(prettyJsonString);
-        //System.out.println(schemaOrgString);
-
-        String correctString = importTestFile("src/test/resources/schemaOrgJsonTestFiles/schemaOrg_KE066530.json");
-        Assertions.assertEquals(schemaOrgString, correctString);
+        assertJSONTransformation(MODS2SCHEMAORG, RECORD_KE066530, "schemaOrg_KE066530.json");
     }
 
     @Test
     void testContentLocationAndKeywords() throws Exception {
-        String schemaOrgString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SCHEMAORG, RECORD_DPK000107);
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        JsonElement je = JsonParser.parseString(schemaOrgString);
-        String prettyJsonString = gson.toJson(je);
-        //System.out.println(prettyJsonString);
-        //System.out.println(schemaOrgString);
-
-        String correctString = importTestFile("src/test/resources/schemaOrgJsonTestFiles/schemaOrg_DPK000107.json");
-        Assertions.assertEquals(schemaOrgString, correctString);
+        assertJSONTransformation(MODS2SCHEMAORG, RECORD_DPK000107, "schemaOrg_DPK000107.json");
     }
 
 
     @Test
     void testMaterialSize() throws Exception {
-        String schemaOrgString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SCHEMAORG, RECORD_ANSK);
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        JsonElement je = JsonParser.parseString(schemaOrgString);
-        String prettyJsonString = gson.toJson(je);
-        //System.out.println(prettyJsonString);
-        //System.out.println(schemaOrgString);
-
-        String correctString = importTestFile("src/test/resources/schemaOrgJsonTestFiles/schemaOrg_ANSK_11614.json");
-        Assertions.assertEquals(schemaOrgString, correctString);
+        assertJSONTransformation(MODS2SCHEMAORG, RECORD_ANSK, "schemaOrg_ANSK_11614.json");
     }
 
     @Test
     void testInternalNotesToKbAdmin() throws Exception {
-        String schemaOrgString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SCHEMAORG, RECORD_DNF);
-
-        Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
-        JsonElement je = JsonParser.parseString(schemaOrgString);
-        String prettyJsonString = gson.toJson(je);
-        //System.out.println(prettyJsonString);
-        //System.out.println(schemaOrgString);
-
-        String correctString = importTestFile("src/test/resources/schemaOrgJsonTestFiles/schemaOrg_DNF_1951-00352_00052.json");
-        Assertions.assertEquals(schemaOrgString, correctString);
+        assertJSONTransformation(MODS2SCHEMAORG, RECORD_DNF, "schemaOrg_DNF_1951-00352_00052.json");
     }
 
     @Test
     void testImageUrlCreation () throws Exception {
-        String schemaOrgString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SCHEMAORG, RECORD_40221e);
-
-        Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
-        JsonElement je = JsonParser.parseString(schemaOrgString);
-        String prettyJsonString = gson.toJson(je);
-        //System.out.println(prettyJsonString);
-        //System.out.println(schemaOrgString);
-
-        String correctString = importTestFile("src/test/resources/schemaOrgJsonTestFiles/schemaOrg_40221e30-1414-11e9-8fb8-00505688346e.json");
-        Assertions.assertEquals(schemaOrgString, correctString);
-
+        assertJSONTransformation(MODS2SCHEMAORG, RECORD_40221e, "schemaOrg_40221e30-1414-11e9-8fb8-00505688346e.json");
     }
-
 
     /**
      * Update test files when XSLT changes.
@@ -159,8 +100,14 @@ public class XSLTSchemaDotOrgTransformerTest {
                 RECORD_ANSK, RECORD_DNF, RECORD_40221e);
     }
     private void createTestFiles(String... records) throws Exception {
+        if (1 == 1) {
+            throw new IllegalStateException(
+                    "The MODS2SCHEMAORG XSTL isa faulty and do not generate the proper URL to images (the image ID + " +
+                    "more is missing). This must be fixed before generating new testfiles.");
+        }
         for (String record : records) {
-            String schemaOrgString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SCHEMAORG, record);
+            Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/");
+            String schemaOrgString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SCHEMAORG, record, injections);
             String filename = record.replaceAll("xml/copyright_extraction/", "schemaOrg_");
             String completeFilename = filename.replaceAll("\\..+", ".json");
             //String completeFilename = filename.replaceAll("\\.tif\\.xml", ".json");
@@ -181,4 +128,30 @@ public class XSLTSchemaDotOrgTransformerTest {
 
         return jsonString;
     }
+
+    /**
+     * Perform a transformation of the given {@code xml} using the given {@code xslt}.
+     * The {@link XSLTTransformer} is used with injection {@code imageserver: "https://example.com/imageserver/"}.
+     * <br/>
+     * The helper expects the output to be JSON and comparison is done with pretty printed JSON for easy visuel
+     * comparison.
+     * @param xslt the transforming stylesheet.
+     * @param xml  the xml to transform.
+     * @param expectedJSONFile the expected result, relative to {@code src/test/resources/schemaOrgJsonTestFiles/}.
+     */
+    private void assertJSONTransformation(String xslt, String xml, String expectedJSONFile) throws Exception {
+        Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/");
+
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(xslt, xml, injections);
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        JsonElement je = JsonParser.parseString(transformedJSON);
+        String transformedPrettyJSON = gson.toJson(je);
+
+        String expectedJSON = importTestFile("src/test/resources/schemaOrgJsonTestFiles/" + expectedJSONFile);
+        String expectedPrettyJSON = gson.toJson(JsonParser.parseString(expectedJSON));
+
+        Assertions.assertEquals(expectedPrettyJSON, transformedPrettyJSON);
+    }
+
 }


### PR DESCRIPTION
Loading and parsing configuration YAMLs from XSLT is impressive magic but only works when the location and the names of the config files is known. This pull request expands the generic `XSLTTransformer` to handle fixed injections of variables from the config.