### PR TITLE
DISC-12 abstract imageserver

### DIFF
--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -9,6 +9,28 @@
 #
 #
 config:
+
+  # Image server URLs are injected into transformations.
+  # These should be overridden in environment specific config files for all environments, meaning local test,
+  # shared devel, stage and production
+  #
+  # Sample override:
+  #
+  # config:
+  #   imageservers:
+  #     devel:
+  #       url: "https://example.com/devel/iipimage"
+  #       default: true
+  #
+  # Note: The server marked with "default: true" is used in the base configuration ds-present-kb-collections.yaml
+  imageservers:
+    example:
+      url: "https://example.com"
+
+    invalid:
+      url: "invalid://url"
+      default: true
+
   # List of backing storages. This information should be overridden in ds-present-environment.yaml
 
   # The storages defined in this file are

--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -24,12 +24,13 @@ config:
   #
   # Note: The server marked with "default: true" is used in the base configuration ds-present-kb-collections.yaml
   imageservers:
-    example:
-      url: "https://example.com"
+    # Note: The servers are in a list to ensure the full list of servers can be fully overwritten in subsequent configs
+    - example:
+        url: "https://example.com"
 
-    invalid:
-      url: "invalid://url"
-      default: true
+    - invalid:
+        url: "invalid://url"
+        default: true
 
   # List of backing storages. This information should be overridden in ds-present-environment.yaml
 

--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -24,7 +24,7 @@ config:
           - xslt:
               stylesheet: 'xslt/mods2schemaorg.xsl'
               injections:
-                - imageserver: 'https://example.com/imageserver'
+                - imageserver: ${path:config.imageservers[default=true].url}
     - SolrJSON:
         mime: 'application/json'
         transformers:
@@ -32,7 +32,7 @@ config:
           - xslt:
               stylesheet: 'xslt/mods2solr.xsl'
               injections:
-                - imageserver: 'https://example.com/imageserver'
+                - imageserver: ${path:config.imageservers[default=true].url}
   # The collections available for this instance of ds-present
   collections:
     # General note: All collections are expected to support at least the views raw, mods, jsonld and solrjson.
@@ -87,14 +87,14 @@ config:
                 - xslt:
                     stylesheet: 'xslt/mods2schemaorg.xsl'
                     injections:
-                      - imageserver: 'https://example.com/imageserver'
+                      - imageserver: ${path:config.imageservers[default=true].url}
           - SolrJSON:
               mime: 'application/json'
               transformers:
                 - xslt:
                     stylesheet: 'xslt/mods2solr.xsl'
                     injections:
-                      - imageserver: 'https://example.com/imageserver'
+                      - imageserver: ${path:config.imageservers[default=true].url}
 
     # Straight forward collection with the core format being MODS, using test data
     - local: # ds-present internal
@@ -117,11 +117,11 @@ config:
                 - xslt:
                     stylesheet: 'xslt/mods2schemaorg.xsl'
                     injections:
-                      - imageserver: 'https://example.com/imageserver'
+                      - imageserver: ${path:config.imageservers[default=true].url}
           - SolrJSON:
               mime: 'application/json'
               transformers:
                 - xslt:
                     stylesheet: 'xslt/mods2solr.xsl'
                     injections:
-                      - imageserver: 'https://example.com/imageserver'
+                      - imageserver: ${path:config.imageservers[default=true].url}

--- a/conf/ds-present-logback.xml
+++ b/conf/ds-present-logback.xml
@@ -1,7 +1,7 @@
 <included>
     <contextName>ds-present</contextName>
 
-    <property name="LOGFILE" value="${catalina.home}/logs/template-app.log" />
+    <property name="LOGFILE" value="${catalina.home}/logs/ds-present.log" />
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOGFILE}</file>
@@ -20,7 +20,7 @@
     </appender>
 
     <root level="INFO">
-      <appender-ref ref="STDOUT" />
+      <appender-ref ref="FILE" />
     </root>
     <logger name="dk.kb" level="DEBUG" />
  

--- a/conf/ocp/ds-present.xml
+++ b/conf/ocp/ds-present.xml
@@ -2,7 +2,7 @@
 <Context override="true" docBase="/app/tomcat-apps/ds-present.war">
 
     <Environment name="ds-present-logback-config"
-        value="/app/conf/logback.xml"
+        value="/app/conf/ds-present-logback.xml"
         type="java.lang.String"
         override="false"/>
     <Environment name="application-config"

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.12</version>
+            <version>1.4.13</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.13</version>
+            <version>1.4.14</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->

--- a/src/main/java/dk/kb/present/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/present/config/ServiceConfig.java
@@ -18,14 +18,15 @@ public class ServiceConfig {
     private static YAML serviceConfig;
 
     /**
-     * Initialized the configuration from the provided configFile.
+     * Initialized the configuration from the provided configFiles.
      * This should normally be called from {@link dk.kb.present.webservice.ContextListener} as
      * part of web server initialization of the container.
-     * @param configFile the configuration to load.
-     * @throws IOException if the configuration could not be loaded or parsed.
+     * @param configFiles globs for the configurations to load.
+     * @throws IOException if the configurations could not be loaded or parsed.
      */
-    public static synchronized void initialize(String configFile) throws IOException {
-        serviceConfig = YAML.resolveLayeredConfigs(configFile);
+    public static synchronized void initialize(String... configFiles) throws IOException {
+        serviceConfig = YAML.resolveLayeredConfigs(configFiles);
+        serviceConfig.setExtrapolate(true);
     }
 
     /**

--- a/src/main/java/dk/kb/present/storage/DSStorage.java
+++ b/src/main/java/dk/kb/present/storage/DSStorage.java
@@ -138,6 +138,7 @@ public class DSStorage implements Storage {
                             "Exception making remote call to ds-storage client " +
                             "getRecordsModifiedAfter(base='%s', mTime=%d, maxRecords=%d)",
                             finalRecordBase, mTime, maxRecords);
+                    log.warn(message, e);
                     throw new InternalServiceException(message, e);
                 }
                 pending -= records.size();

--- a/src/main/java/dk/kb/present/transform/XSLTFactory.java
+++ b/src/main/java/dk/kb/present/transform/XSLTFactory.java
@@ -47,8 +47,9 @@ public class XSLTFactory implements DSTransformerFactory {
                             "Expected a single entry (key-value pair) in injection '" + yInjection +
                             "' but got " + yInjection.size());
                 }
-                Map.Entry<String, Object> entry = yInjection.entrySet().stream().findFirst().get();
-                injections.put(entry.getKey(), entry.getValue().toString());
+                // TODO: Move away from the strange "listed maps with one entry" way of stating injections
+                String firstKey = yInjection.keySet().stream().findFirst().get();
+                injections.put(firstKey, yInjection.getString(firstKey));
             }
         }
         return new XSLTTransformer(conf.getString(STYLESHEET_KEY), injections);

--- a/src/test/java/dk/kb/present/config/ServiceConfigTest.java
+++ b/src/test/java/dk/kb/present/config/ServiceConfigTest.java
@@ -53,7 +53,7 @@ class ServiceConfigTest {
     }
 
     @Test
-    void testImageserver() throws IOException {
+    void testImageserverAbstraction2() throws IOException {
         Path knownFile = Path.of(Resolver.resolveURL("logback-test.xml").getPath());
         String projectRoot = knownFile.getParent().getParent().getParent().toString();
 
@@ -72,5 +72,19 @@ class ServiceConfigTest {
         assertEquals("invalid://url",
                 yaml.getString("config.collections[4].samlingsbilleder.views[3].SolrJSON.transformers[1].xslt.injections[0].imageserver"),
                 "The correct URL should be substitution-extracted from the 'samlingsbilleder' view SolrJSON injection");
+
+        assertEquals("invalid://url",
+                yaml.getSubMap("config.collections[4].samlingsbilleder.views[3].SolrJSON").
+                        getString("transformers[1].xslt.injections[0].imageserver"),
+                "Requesting path substituted values from a sub map should work");
+
+        // Reset the YAML structure to ensure clean test of submap
+        ServiceConfig.initialize(behaviour.toString(), collections.toString());
+        yaml = ServiceConfig.getConfig();
+
+        assertEquals("invalid://url",
+                yaml.getSubMap("config.collections[4].samlingsbilleder.views[3].SolrJSON").
+                        getString("transformers[1].xslt.injections[0].imageserver"),
+                "Requesting path substituted values from a sub map should work on a newly loaded config");
     }
 }

--- a/src/test/java/dk/kb/present/config/ServiceConfigTest.java
+++ b/src/test/java/dk/kb/present/config/ServiceConfigTest.java
@@ -1,6 +1,7 @@
 package dk.kb.present.config;
 
 import dk.kb.util.Resolver;
+import dk.kb.util.yaml.YAML;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -49,5 +50,27 @@ class ServiceConfigTest {
 
         // Real value in environment
         assertEquals("real_dbpassword", ServiceConfig.getConfig().getString("config.backend.password"));
+    }
+
+    @Test
+    void testImageserver() throws IOException {
+        Path knownFile = Path.of(Resolver.resolveURL("logback-test.xml").getPath());
+        String projectRoot = knownFile.getParent().getParent().getParent().toString();
+
+        Path behaviour = Path.of(projectRoot, "conf/ds-present-behaviour.yaml");
+        Path collections = Path.of(projectRoot, "conf/ds-present-kb-collections.yaml");
+
+        ServiceConfig.initialize(behaviour.toString(), collections.toString());
+        YAML yaml = ServiceConfig.getConfig();
+
+        assertEquals("true", yaml.getString("config.imageservers.invalid.default"),
+                "The imageserver 'invalid' should have 'default: true'");
+
+        assertEquals("invalid://url", yaml.getString("config.imageservers[default=true].url"),
+                "The correct URL should be extracted from the default imageserver using yaml.get with conditional");
+
+        assertEquals("invalid://url",
+                yaml.getString("config.collections[4].samlingsbilleder.views[3].SolrJSON.transformers[1].xslt.injections[0].imageserver"),
+                "The correct URL should be substitution-extracted from the 'samlingsbilleder' view SolrJSON injection");
     }
 }

--- a/src/test/java/dk/kb/present/config/ServiceConfigTest.java
+++ b/src/test/java/dk/kb/present/config/ServiceConfigTest.java
@@ -67,9 +67,9 @@ class ServiceConfigTest {
         YAML yaml = ServiceConfig.getConfig();
 
         // Behaviour has an 'invalid' imageserver, but Servers overrides the list to only contain 'local'
-        System.out.println(yaml.getSubMap("config.imageservers"));
-        //assertEquals("true", yaml.getString("config.imageservers.local.default"),
-        //        "The imageserver 'invalid' should have 'default: true'");
+        //System.out.println(yaml.getYAMLList("config.imageservers"));
+        assertEquals("true", yaml.getString("config.imageservers[0].local.default"),
+                "The imageserver 'local' should have 'default: true'");
 
         assertEquals("the_right_url", yaml.getString("config.imageservers[default=true].url"),
                 "The correct URL should be extracted from the default imageserver using yaml.get with conditional");

--- a/src/test/java/dk/kb/present/config/ServiceConfigTest.java
+++ b/src/test/java/dk/kb/present/config/ServiceConfigTest.java
@@ -60,30 +60,34 @@ class ServiceConfigTest {
         // Note: These are test configs to avoid locking the structure of the real configs
         Path behaviour = Resolver.getPathFromClasspath("config/imageserver/ds-present-behaviour.yaml");
         Path collections = Resolver.getPathFromClasspath("config/imageserver/ds-present-kb-collections.yaml");
+        Path servers = Resolver.getPathFromClasspath("config/imageserver/ds-present-servers.yaml");
 
         ServiceConfig.initialize(behaviour.toString(), collections.toString());
+        ServiceConfig.initialize(behaviour.toString(), collections.toString(), servers.toString());
         YAML yaml = ServiceConfig.getConfig();
 
-        assertEquals("true", yaml.getString("config.imageservers.invalid.default"),
-                "The imageserver 'invalid' should have 'default: true'");
+        // Behaviour has an 'invalid' imageserver, but Servers overrides the list to only contain 'local'
+        System.out.println(yaml.getSubMap("config.imageservers"));
+        //assertEquals("true", yaml.getString("config.imageservers.local.default"),
+        //        "The imageserver 'invalid' should have 'default: true'");
 
-        assertEquals("invalid://url", yaml.getString("config.imageservers[default=true].url"),
+        assertEquals("the_right_url", yaml.getString("config.imageservers[default=true].url"),
                 "The correct URL should be extracted from the default imageserver using yaml.get with conditional");
 
-        assertEquals("invalid://url",
+        assertEquals("the_right_url",
                 yaml.getString("config.collections[4].samlingsbilleder.views[3].SolrJSON.transformers[1].xslt.injections[0].imageserver"),
                 "The correct URL should be substitution-extracted from the 'samlingsbilleder' view SolrJSON injection");
 
-        assertEquals("invalid://url",
+        assertEquals("the_right_url",
                 yaml.getSubMap("config.collections[4].samlingsbilleder.views[3].SolrJSON").
                         getString("transformers[1].xslt.injections[0].imageserver"),
                 "Requesting path substituted values from a sub map should work");
 
         // Reset the YAML structure to ensure clean test of submap
-        ServiceConfig.initialize(behaviour.toString(), collections.toString());
+        ServiceConfig.initialize(behaviour.toString(), collections.toString(), servers.toString());
         yaml = ServiceConfig.getConfig();
 
-        assertEquals("invalid://url",
+        assertEquals("the_right_url",
                 yaml.getSubMap("config.collections[4].samlingsbilleder.views[3].SolrJSON").
                         getString("transformers[1].xslt.injections[0].imageserver"),
                 "Requesting path substituted values from a sub map should work on a newly loaded config");

--- a/src/test/java/dk/kb/present/config/ServiceConfigTest.java
+++ b/src/test/java/dk/kb/present/config/ServiceConfigTest.java
@@ -57,8 +57,9 @@ class ServiceConfigTest {
         Path knownFile = Path.of(Resolver.resolveURL("logback-test.xml").getPath());
         String projectRoot = knownFile.getParent().getParent().getParent().toString();
 
-        Path behaviour = Path.of(projectRoot, "conf/ds-present-behaviour.yaml");
-        Path collections = Path.of(projectRoot, "conf/ds-present-kb-collections.yaml");
+        // Note: These are test configs to avoid locking the structure of the real configs
+        Path behaviour = Resolver.getPathFromClasspath("config/imageserver/ds-present-behaviour.yaml");
+        Path collections = Resolver.getPathFromClasspath("config/imageserver/ds-present-kb-collections.yaml");
 
         ServiceConfig.initialize(behaviour.toString(), collections.toString());
         YAML yaml = ServiceConfig.getConfig();

--- a/src/test/jetty/jetty-env.xml
+++ b/src/test/jetty/jetty-env.xml
@@ -5,7 +5,7 @@
     <New id="logback" class="org.eclipse.jetty.plus.jndi.EnvEntry">
         <Arg>${project.artifactId}-logback-config</Arg>
         <Arg type="java.lang.String">
-            ${basedir}/target/jetty-res/logback.xml
+            ${basedir}/target/jetty-res/ds-present-logback.xml
         </Arg>
         <Arg type="boolean">true</Arg>
     </New>

--- a/src/test/resources/config/imageserver/ds-present-behaviour.yaml
+++ b/src/test/resources/config/imageserver/ds-present-behaviour.yaml
@@ -1,0 +1,154 @@
+#
+# This config contains behaviour data: Thread allocation, allowed fields for lookup, limits for arguments etc.
+#
+# The behaviour config is normally controlled by developers and is part of the code repository.
+# Sensitive information such as machine names and user/passwords should not be part of this config.
+#
+# It will be automatically merged with the environment config when accessed through the
+# application config system.
+#
+#
+config:
+
+  # Image server URLs are injected into transformations.
+  # These should be overridden in environment specific config files for all environments, meaning local test,
+  # shared devel, stage and production
+  #
+  # Sample override:
+  #
+  # config:
+  #   imageservers:
+  #     devel:
+  #       url: "https://example.com/devel/iipimage"
+  #       default: true
+  #
+  # Note: The server marked with "default: true" is used in the base configuration ds-present-kb-collections.yaml
+  imageservers:
+    example:
+      url: "https://example.com"
+
+    invalid:
+      url: "invalid://url"
+      default: true
+
+  # List of backing storages. This information should be overridden in ds-present-environment.yaml
+
+  # The storages defined in this file are
+  # * ds-storage, expecting https://github.com/kb-dk/ds-storage/ to be running locally with the default port
+  # * folder, serving sample files
+  storages:
+    # There can be multiple defined storages. The outer YAML key is used as the ID for the storage.
+    - main:
+        # If default is true, this will be the default storage for collections.
+        # The default storage choice can be overridden in a collection with the 'storage' property
+        default: true
+        # Backends contains a list of one or more implementations and their configuration, with the primary key being
+        # the implementation (aka type) of the backend
+        #
+        # Available backends are
+        # ds-storage: A local instance of https://github.com/kb-dk/ds-storage/
+        # folder:     Local files under the stated folder. Use only for test as the implementation in unsecure
+        backends:
+          # The ds-storage backend connects to a running https://github.com/kb-dk/ds-storage/ instance
+          - ds-storage:
+              # The name of the machine running the service. Mandatory
+              dbserverurl: 'http://localhost:9072/ds-storage/v1/'                            
+                            
+    - test:
+        # If there is more that one backend implementation, the property 'order' controls how they are queried:
+        # * parallel:   All backends are queried in parallel. Whoever answers with a record first wins.
+        # * sequential: All backends are queried one at a time in the order in this configuration.
+        #               When a backend responds with a record, itertaion is stopped and the record is returned
+        # Optional, default value is 'sequential'
+        order: sequential
+        backends:
+          # The folder backend expects content to be stored in a local folder. The ID is used as the file name.
+          # WARNING: Insecure implementation (files outside of the folder can be read). Do not use for production!
+          # The src/test/resources/xml/corpus contains a small sample corpus. this is only likely to work when
+          # running with `mvn jetty:run` and even the we're unsure of the current folder, so we se up alternatives.
+          - folder:
+              root: 'src/test/resources/xml/corpus' # Expected
+              # Whether or not remove ID-prefix (the part from the beginning to the first `:` (inclusive) of the ID)
+              # from the ID when perforaing the lookup. Optional, default is true.
+              stripprefix: true
+          - folder:
+              root: '../src/test/resources/xml/corpus' # Maybe PWD is target/
+          - folder:
+              root: 'ds-present/src/test/resources/xml/corpus' # Maybe PWD is outsid eof the checkout (unlikely)
+
+  # Settings for handling at the record level
+  record:
+    id:
+      # Pattern for acceptable record IDs. Must contain exactly 2 capturing group, the first being the collection prefix
+      # and the second being the collection specific par of the ID
+      # Mandatory. Suggested value: '([a-z0-9.]+):([a-zA-Z0-9:._-]+)', e.g. 'images.dsfl:Image1234:2_3-b'
+      pattern: '([a-z0-9.]+):([a-zA-Z0-9:._-]+)'
+  collection:
+    prefix:
+      # Pattern for acceptable collection prefixes. This will practically always be a mirror of the first capturing
+      # group for record.id.pattern.
+      # Primarily used for verifying configuration.
+      # Mandatory. Suggested value: '[a-z0-9.]+', e.g. 'images.dsfl'
+      pattern: '[a-z0-9.]+'
+
+  # Collections are to be set in ds-present-kb-collections-yaml if possible, as that file overwrites the collections defined here
+  # The collections available for this instance of ds-present
+  #collections:
+    # General note: All collections are expected to support at least the views raw, mods, jsonld and solrjson.
+    # If any of those are not supported, the transformer 'fail' should be used with a telling message.
+
+    # Straight forward collection with the core format being MODS
+    # Uses the default storage, which connects to a running ds-storage instance
+  #  - remote: # ds-present internal
+  #      prefix: 'doms.radio' # The prefix to match on incoming IDs. Selectet to use ds-storage without any tweaks
+  #      description: 'Images from the collections at the Royal Danish Library'
+      #   Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
+  #      views:
+  #        - raw:
+  #            mime: 'text/plain'
+  #            transformers:
+  #              - identity:
+  #        - MODS:
+  #            mime: 'application/xml'
+  #            transformers:
+  #             - identity: # No transformation steps as mods is the core format for images-dsfl
+  #        - JSON-LD:
+  #            mime: 'application/json'
+  #            transformers:
+  #              - xslt:
+  #                  stylesheet: 'xslt/mods2schemaorg.xsl'
+  #                  injections:
+  #                    - imageserver: 'https://example.com/imageserver'
+  #        - SolrJSON:
+  #            mime: 'application/json'
+  #            transformers:
+  #              - xslt:
+  #                  stylesheet: 'xslt/mods2solr.xsl'
+  #                  injections:
+  #                    - imageserver: 'https://example.com/imageserver'
+
+    # Straight forward collection with the core format being MODS, using test data
+    #- local: # ds-present internal
+    #    prefix: 'local.test' # The prefix to match on incoming IDs
+    #    description: 'Selected image data from the collections at the Royal Danish Library'
+    #    storage: 'test' # Not production here
+    #    # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
+    #    views:
+    #      - raw:
+    #          mime: 'text/plain'
+    #          transformers:
+    #            - identity:
+    #      - MODS:
+    #          mime: 'application/xml'
+    #          transformers:
+    #            - identity: # No transformation steps as mods is the core format for images-dsfl
+    #      - JSON-LD:
+    #          mime: 'application/json'
+    #          transformers:
+    #            - xslt:
+    #                stylesheet: 'xslt/mods2schemaorg.xsl'
+    #      - SolrJSON:
+    #          mime: 'application/json'
+    #          transformers:
+    #            - xslt:
+    #                stylesheet: 'xslt/mods2solr.xsl'

--- a/src/test/resources/config/imageserver/ds-present-behaviour.yaml
+++ b/src/test/resources/config/imageserver/ds-present-behaviour.yaml
@@ -28,6 +28,10 @@ config:
       url: "https://example.com"
 
     invalid:
+      # Important:
+      # Maps are merged, not overwritten, when using multiple YAMLs (not sure this is the best behaviour)
+      # so the "invalid" imageserver needs to be marked as no longer being the default when specifying the
+      # real map with imageservers
       url: "invalid://url"
       default: true
 

--- a/src/test/resources/config/imageserver/ds-present-behaviour.yaml
+++ b/src/test/resources/config/imageserver/ds-present-behaviour.yaml
@@ -24,16 +24,12 @@ config:
   #
   # Note: The server marked with "default: true" is used in the base configuration ds-present-kb-collections.yaml
   imageservers:
-    example:
-      url: "https://example.com"
+    - example:
+        url: "https://example.com"
 
-    invalid:
-      # Important:
-      # Maps are merged, not overwritten, when using multiple YAMLs (not sure this is the best behaviour)
-      # so the "invalid" imageserver needs to be marked as no longer being the default when specifying the
-      # real map with imageservers
-      url: "invalid://url"
-      default: true
+    - invalid:
+        url: "invalid://url"
+        default: true
 
   # List of backing storages. This information should be overridden in ds-present-environment.yaml
 

--- a/src/test/resources/config/imageserver/ds-present-kb-collections.yaml
+++ b/src/test/resources/config/imageserver/ds-present-kb-collections.yaml
@@ -1,0 +1,127 @@
+#
+# This config contains definitions for image collections at the Royal Danish Library.
+#
+# If used by another institution the collections should be overwritten by another config sorted alphanumerically
+# later than "ds-present-kb-collections.yaml". Optionally this config file should also be deleted.
+#
+config:
+
+  # Generic views for images represented as MODS, used for multiple collections
+  baseviews: &MODS_IMAGE_VIEWS
+    # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
+    - raw:
+        mime: 'text/plain'
+        transformers:
+          - identity:
+    - MODS:
+        mime: 'application/xml'
+        transformers:
+          - identity: # No transformation steps as mods is the core format for images-dsfl
+    - JSON-LD:
+        mime: 'application/json'
+        transformers:
+          - imagerights: # KB specific rules for image rights stated in MODS
+          - xslt:
+              stylesheet: 'xslt/mods2schemaorg.xsl'
+              injections:
+                - imageserver: ${path:config.imageservers[default=true].url}
+    - SolrJSON:
+        mime: 'application/json'
+        transformers:
+          - imagerights: # KB specific rules for image rights stated in MODS
+          - xslt:
+              stylesheet: 'xslt/mods2solr.xsl'
+              injections:
+                - imageserver: ${path:config.imageservers[default=true].url}
+  # The collections available for this instance of ds-present
+  collections:
+    # General note: All collections are expected to support at least the views raw, mods, jsonld and solrjson.
+    # If any of those are not supported, the transformer 'fail' should be used with a telling message.
+
+    # Royal Danish Library image collection with the core format being MODS
+    # Uses the default storage, which connects to a running ds-storage instance
+    - imageshca:
+        description: 'Hans Christian Andersen images from the collections at the Royal Danish Library'
+        prefix: 'kb.images.billed.hca' # The prefix to match on incoming IDs. Selected to use ds-storage without any tweaks
+        base: 'kb.images.billed.hca' # Overrides the default base for the storage
+        views: *MODS_IMAGE_VIEWS
+    - imagesjsmss:
+        description: 'Judaistisk Samling: Håndskrifter images from the collections at the Royal Danish Library'
+        prefix: 'kb.image.judsam.jsmss'
+        base: 'kb.image.judsam.jsmss'
+        views: *MODS_IMAGE_VIEWS
+    - imagesluftfoto:
+        description: 'Luftfoto (arial photographs) images from the collections at the Royal Danish Library'
+        prefix: 'kb.image.luftfo.luftfoto'
+        base: 'kb.images.luftfo.luftfoto'
+        views: *MODS_IMAGE_VIEWS
+    - imagessmaatryk:
+        description: 'Småtryk images from the collections at the Royal Danish Library'
+        prefix: 'kb.pamphlets.dasmaa.smaatryk'
+        base: 'kb.pamphlets.dasmaa.smaatryk'
+        views: *MODS_IMAGE_VIEWS
+    - samlingsbilleder:
+        description: 'Diverse images from image collections at the Royal Danish Library'
+        prefix: 'ds.samlingsbilleder'
+        base: 'ds.samlingsbilleder'
+        views: *MODS_IMAGE_VIEWS
+
+    # Straight forward collection with the core format being MODS
+    # Uses the default storage, which connects to a running ds-storage instance
+    - remote: # ds-present internal
+        prefix: 'doms.radio' # The prefix to match on incoming IDs. Selectet to use ds-storage without any tweaks
+        description: 'Images from the collections at the Royal Danish Library'
+        # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
+        views:
+          - raw:
+              mime: 'text/plain'
+              transformers:
+                - identity:
+          - MODS:
+              mime: 'application/xml'
+              transformers:
+                - identity: # No transformation steps as mods is the core format for images-dsfl
+          - JSON-LD:
+              mime: 'application/json'
+              transformers:
+                - xslt:
+                    stylesheet: 'xslt/mods2schemaorg.xsl'
+                    injections:
+                      - imageserver: ${path:config.imageservers[default=true].url}
+          - SolrJSON:
+              mime: 'application/json'
+              transformers:
+                - xslt:
+                    stylesheet: 'xslt/mods2solr.xsl'
+                    injections:
+                      - imageserver: ${path:config.imageservers[default=true].url}
+
+    # Straight forward collection with the core format being MODS, using test data
+    - local: # ds-present internal
+        prefix: 'local.test' # The prefix to match on incoming IDs
+        description: 'Selected image data from the collections at the Royal Danish Library'
+        storage: 'test' # Not production here
+        # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
+        views:
+          - raw:
+              mime: 'text/plain'
+              transformers:
+                - identity:
+          - MODS:
+              mime: 'application/xml'
+              transformers:
+                - identity: # No transformation steps as mods is the core format for images-dsfl
+          - JSON-LD:
+              mime: 'application/json'
+              transformers:
+                - xslt:
+                    stylesheet: 'xslt/mods2schemaorg.xsl'
+                    injections:
+                      - imageserver: ${path:config.imageservers[default=true].url}
+          - SolrJSON:
+              mime: 'application/json'
+              transformers:
+                - xslt:
+                    stylesheet: 'xslt/mods2solr.xsl'
+                    injections:
+                      - imageserver: ${path:config.imageservers[default=true].url}

--- a/src/test/resources/config/imageserver/ds-present-servers.yaml
+++ b/src/test/resources/config/imageserver/ds-present-servers.yaml
@@ -14,12 +14,8 @@ config:
   #
   # Note: The server marked with "default: true" is used in the base configuration ds-present-kb-collections.yaml
   imageservers:
-    invalid:
-      # Maps are merged, not overwritten, when using multiple YAMLs (not sure this is the best behaviour)
-      # so the "invalid" imageserver from behaviour needs to be marked as no longer being the default
-      default: false
-    local:
-      # This overrides the one in ds-present-behavious
-      url: "the_right_url"
-      default: true
+    - local:
+        # This overrides the one in ds-present-behaviour
+        url: "the_right_url"
+        default: true
 

--- a/src/test/resources/config/imageserver/ds-present-servers.yaml
+++ b/src/test/resources/config/imageserver/ds-present-servers.yaml
@@ -1,0 +1,25 @@
+config:
+
+  # Image server URLs are injected into transformations.
+  # These should be overridden in environment specific config files for all environments, meaning local test,
+  # shared devel, stage and production
+  #
+  # Sample override:
+  #
+  # config:
+  #   imageservers:
+  #     devel:
+  #       url: "https://example.com/devel/iipimage"
+  #       default: true
+  #
+  # Note: The server marked with "default: true" is used in the base configuration ds-present-kb-collections.yaml
+  imageservers:
+    invalid:
+      # Maps are merged, not overwritten, when using multiple YAMLs (not sure this is the best behaviour)
+      # so the "invalid" imageserver from behaviour needs to be marked as no longer being the default
+      default: false
+    local:
+      # This overrides the one in ds-present-behavious
+      url: "the_right_url"
+      default: true
+


### PR DESCRIPTION
This moves specification of the imageserver URL used as injection to the transformers to a central property in the configuration flow, as opposed to duplicating the URL.