### PR TITLE
 Add the collection 'radiotv' to ds-present

### DIFF
--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -69,8 +69,8 @@ config:
 
         # Temporary hack to make the Preservica XML block well-formed (it is missing a namespace declaration)
         testdatahack: &TEST_DATA_HACK
-          regexp: '<xip:DeliverableUnit +status="([^"]+)" *>'
-          replacement: '<xip:DeliverableUnit status="$1" xmlns:xip="http://example.com/">'
+          regexp: '<xip:(DeliverableUnit|Collection|Manifestation) +status="([^"]+)" *>'
+          replacement: '<xip:$1 status="$2" xmlns:xip="http://example.com/">'
           replaceall: false
 
         description: 'Radio and television records from the Preservica system at the Royal Danish Library'

--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -65,6 +65,42 @@ config:
         prefix: 'ds.samlingsbilleder'
         base: 'ds.samlingsbilleder'
         views: *MODS_IMAGE_VIEWS
+    - radiotv:
+
+        # Temporary hack to make the Preservica XML block well-formed (it is missing a namespace declaration)
+        testdatahack: &TEST_DATA_HACK
+          regexp: '<xip:DeliverableUnit +status="([^"]+)" *>'
+          replacement: '<xip:DeliverableUnit status="$1" xmlns:xip="http://example.com/">'
+          replaceall: false
+
+        description: 'Radio and television records from the Preservica system at the Royal Danish Library'
+        prefix: 'ds.radiotv'
+        base: 'pvica.devel'
+        views:
+          - raw:
+              mime: 'text/plain'
+              transformers:
+                - identity:
+          - JSON-LD:
+              mime: 'application/json'
+              transformers:
+                - replace: *TEST_DATA_HACK
+                - xslt:
+                    stylesheet: 'xslt/preservica2schemaorg.xsl'
+                    injections:
+                      #- imageserver: ${path:config.imageservers[default=true].url}
+                      - streamingserver: "here_should_be_a_wowza_url"
+          - SolrJSON:
+              mime: 'application/json'
+              transformers:
+                - replace: *TEST_DATA_HACK
+                - xslt:
+                    stylesheet: 'xslt/preservica2solr.xsl'
+                    injections:
+                      # - imageserver: ${path:config.imageservers[default=true].url}
+                      - streamingserver: "here_should_be_a_wowza_url"
+
+
 
     # Straight forward collection with the core format being MODS
     # Uses the default storage, which connects to a running ds-storage instance

--- a/src/test/java/dk/kb/present/transform/ReplaceTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/ReplaceTransformerTest.java
@@ -51,6 +51,22 @@ class ReplaceTransformerTest {
         assertEquals("<mystructure id=\"foo-123\">...", replacer.apply("<mystructure id=\"123-foo\">...", null));
     }
 
+    @Test
+    void testXIP() {
+        DSTransformer replacer = new ReplaceTransformer(
+                "<xip:(DeliverableUnit|Collection|Manifestation) +status=\"([^\"]+)\" *>",
+                "<xip:$1 status=\"$2\" xmlns:xip=\"http://example.com/\">", false);
+
+        for (String element : new String[]{"DeliverableUnit", "Collection", "Manifestation"}) {
+            assertEquals("<xip:" + element + " status=\"foo\" xmlns:xip=\"http://example.com/\">",
+                    replacer.apply("<xip:" + element + " status=\"foo\">", null),
+                    "Namespace injection should work for element '" + element + "'");
+        }
+        assertNotEquals("<xip:Selfmade status=\"foo\" xmlns:xip=\"http://example.com/\">",
+                replacer.apply("<xip:Selfmade status=\"foo\">", null),
+                "Namespace injection should NOT work for element 'Selfmade'");
+    }
+    
     /**
      * Use the {@link ReplaceFactory} to create a {@link ReplaceTransformer} with config taken from {@code yamlString}.
      * @param yamlString configuration for {@link ReplaceTransformer}.


### PR DESCRIPTION
This connects the new `radiotv` collection to the backing `ds-storage` collection `pvica.devel` and connects JSON-LD to `preservica2schemaorg.xsl` & SolrJSON to `preservica2solr.xsl`.

 A temporary replace-hack is used to inject a fake namespace for the faulty Preservica XML blocks. This should be removed when `ds-datahandler` delivers proper XML, either by fixing on the fly or by upstream fixing.

 The IDs for Preservica records does not conform to the ID standard for the DS project. This means that the `/record` endpoint cannot be used. For integration testing the `/records` endpoint can be used.