### PR TITLE
Disc 76 update solr schema

### DIFF
--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -116,10 +116,46 @@
         <xsl:value-of select="$end-date"/>
       </f:string>
 
-      <!-- TODO: Format time as something actually readable-->
+      <!-- Schema.org refers to the wiki page for ISO8601 and actually wants the duration in the format PT12M50S
+           for a duration of 12 minutes and 50 seconds -->
       <f:string key="duration">
         <xsl:value-of select="xs:dateTime($end-date) - xs:dateTime($start-date)"/>
       </f:string>
+
+      <!-- Construct keywords list from all genre fields. Seperates entries by comma and removes last comma.-->
+      <xsl:if test="pbcoreGenre">
+        <xsl:variable name="keywords">
+          <xsl:for-each select="pbcoreGenre">
+            <xsl:value-of select="remove(concat(normalize-space(f:substring-after(., ': ')), ', '), 2)"/>
+          </xsl:for-each>
+        </xsl:variable>
+        <!-- Length used to delete last comma from keyword list.-->
+        <xsl:variable name="keywords-length" select="string-length($keywords)"/>
+
+        <f:string key="keywords">
+          <xsl:value-of select="substring($keywords, 1, $keywords-length - 2)"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Construct identifiers for accession_number, ritzau_id and tvmeter_id -->
+      <xsl:if test="pbcoreIdentifier">
+        <f:array key="identifier">
+          <!-- TODO: Filter away empty identifiers -->
+          <!-- TODO: Update template to require parameters containing identifers from the xip level of the metadata -->
+          <xsl:for-each select="pbcoreIdentifier">
+            <f:map>
+              <f:string key="@type">PropertyValue</f:string>
+              <f:string key="PropertyID">
+                <xsl:value-of select="./identifierSource"/>
+              </f:string>
+              <f:string key="value">
+                <xsl:value-of select="./identifier"/>
+              </f:string>
+            </f:map>
+          </xsl:for-each>
+        </f:array>
+      </xsl:if>
+
 
     </xsl:if>
 

--- a/src/main/resources/xslt/preservica2solr.xsl
+++ b/src/main/resources/xslt/preservica2solr.xsl
@@ -106,7 +106,7 @@
         <!--Some docs have this duration field. Others doesn't. Then we need to extract the duration from pbcoreDateAvailable-->
         <xsl:choose>
           <xsl:when test="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatDuration">
-            <f:string key="duration">
+            <f:string key="duration_ms">
               <xsl:value-of select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatDuration"/>
             </f:string>
           </xsl:when>
@@ -122,7 +122,7 @@
               <xsl:value-of select="my:toMilliseconds($startTime, $endTime)"/>
             </xsl:variable>
 
-            <f:string key="duration">
+            <f:string key="duration_ms">
               <xsl:value-of select="$durationInMilliseconds"/>
             </f:string>
           </xsl:otherwise>

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -238,7 +238,9 @@ public class EmbeddedSolrTest {
 
         //Single value field
         assertEquals("Uldall_186_2_Foborg.tif",record.getFieldValue("filename_local"));
-        assertEquals("Topografi",record.getFieldValue("genre"));
+
+        //assertEquals("Topografi",record.getFieldValue("genre"));
+        assertMultivalueField(record, "genre", "Topografi");
 
         // Title field
         assertMultivalueField(record, "title", "Foborg, Foburgum");
@@ -334,7 +336,7 @@ public class EmbeddedSolrTest {
     @Test
     void testPreservicaDuration() throws Exception {
         SolrDocument record = singlePreservicaIndex(PRESERVICA_RECORD_44979f67);
-        assertEquals(950000L,  record.getFieldValue("duration"));
+        assertEquals(950000L,  record.getFieldValue("duration_ms"));
     }
 
     /*

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -39,22 +39,23 @@ public class EmbeddedSolrTest {
     private static EmbeddedSolrServer embeddedServer = null;
 
     public static final String MODS2SOLR = "xslt/mods2solr.xsl";
-    public static final String RECORD_05fea810 = "xml/copyright_extraction/05fea810-7181-11e0-82d7-002185371280.xml";
-    public static final String RECORD_3956d820 = "xml/copyright_extraction/3956d820-7b7d-11e6-b2b3-0016357f605f.xml";
-    public static final String RECORD_096c9090 = "xml/copyright_extraction/096c9090-717f-11e0-82d7-002185371280.xml";
-    public static final String RECORD_aaf3b130 = "xml/copyright_extraction/aaf3b130-e6e7-11e6-bdbe-00505688346e.xml";
-    public static final String RECORD_54b34b50 = "xml/copyright_extraction/54b34b50-2ce6-11ed-81b4-005056882ec3.xml";
-    public static final String RECORD_8e608940 = "xml/copyright_extraction/8e608940-d6db-11e3-8d2e-0016357f605f.xml";
-    public static final String RECORD_ANSK = "xml/copyright_extraction/ANSK_11614.tif.xml";
-    public static final String RECORD_e2519ce0 = "xml/copyright_extraction/e2519ce0-9fb0-11e8-8891-00505688346e.xml";
-    public static final String RECORD_FM = "xml/copyright_extraction/FM103703H.tif.xml";
-    public static final String RECORD_DB_hans = "xml/copyright_extraction/25461fb0-f664-11e0-9d29-0016357f605f.xml";
-    public static final String RECORD_770379f0 = "xml/copyright_extraction/770379f0-8a0d-11e1-805f-0016357f605f.xml";
-    public static final String RECORD_40221e30 = "xml/copyright_extraction/40221e30-1414-11e9-8fb8-00505688346e.xml";
-    public static final String RECORD_0c02aa10 = "xml/copyright_extraction/0c02aa10-b657-11e6-aedf-00505688346e.xml";
-    public static final String RECORD_9c17a440 = "xml/copyright_extraction/9c17a440-fe1a-11e8-9044-00505688346e.xml";
-    public static final String RECORD_226d41a0 = "xml/copyright_extraction/226d41a0-5a83-11e6-8b8d-0016357f605f.xml";
-
+    public static final String PRESERVICA2SOLR = "xslt/preservica2solr.xsl";
+    public static final String MODS_RECORD_05fea810 = "xml/copyright_extraction/05fea810-7181-11e0-82d7-002185371280.xml";
+    public static final String MODS_RECORD_3956d820 = "xml/copyright_extraction/3956d820-7b7d-11e6-b2b3-0016357f605f.xml";
+    public static final String MODS_RECORD_096c9090 = "xml/copyright_extraction/096c9090-717f-11e0-82d7-002185371280.xml";
+    public static final String MODS_RECORD_aaf3b130 = "xml/copyright_extraction/aaf3b130-e6e7-11e6-bdbe-00505688346e.xml";
+    public static final String MODS_RECORD_54b34b50 = "xml/copyright_extraction/54b34b50-2ce6-11ed-81b4-005056882ec3.xml";
+    public static final String MODS_RECORD_8e608940 = "xml/copyright_extraction/8e608940-d6db-11e3-8d2e-0016357f605f.xml";
+    public static final String MODS_RECORD_ANSK = "xml/copyright_extraction/ANSK_11614.tif.xml";
+    public static final String MODS_RECORD_e2519ce0 = "xml/copyright_extraction/e2519ce0-9fb0-11e8-8891-00505688346e.xml";
+    public static final String MODS_RECORD_FM = "xml/copyright_extraction/FM103703H.tif.xml";
+    public static final String MODS_RECORD_DB_hans = "xml/copyright_extraction/25461fb0-f664-11e0-9d29-0016357f605f.xml";
+    public static final String MODS_RECORD_770379f0 = "xml/copyright_extraction/770379f0-8a0d-11e1-805f-0016357f605f.xml";
+    public static final String MODS_RECORD_40221e30 = "xml/copyright_extraction/40221e30-1414-11e9-8fb8-00505688346e.xml";
+    public static final String MODS_RECORD_0c02aa10 = "xml/copyright_extraction/0c02aa10-b657-11e6-aedf-00505688346e.xml";
+    public static final String MODS_RECORD_9c17a440 = "xml/copyright_extraction/9c17a440-fe1a-11e8-9044-00505688346e.xml";
+    public static final String MODS_RECORD_226d41a0 = "xml/copyright_extraction/226d41a0-5a83-11e6-8b8d-0016357f605f.xml";
+    public static final String PRESERVICA_RECORD_5a5357be = "internal_test_files/tvMetadata/5a5357be-5890-472a-a294-41a99f108936.xml";
     @BeforeAll
     public static void startEmbeddedSolrServer() {
 
@@ -86,7 +87,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testRecord000332() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_05fea810);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_05fea810);
 
         //Single value field
         assertEquals("000332.tif",record.getFieldValue("filename_local"));
@@ -103,7 +104,7 @@ public class EmbeddedSolrTest {
      */
     @Test
     void testRecordDPK() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_3956d820);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_3956d820);
 
         assertContentAllSingleValues(record, "DPK000107.tif", "da",
                 "Billedsamlingen. Postkortsamlingen, Vestindien, Sankt Thomas, Charlotte Amalie, Det gamle fort/politistation",
@@ -128,7 +129,7 @@ public class EmbeddedSolrTest {
      */
     @Test
     void testRecord096c9090() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_096c9090);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_096c9090);
 
         assertContentAllSingleValues(record,"000225.tif", "da",
                 "Billedsamlingen. Danske portrætter, 4°, Egede, Poul (1708-1789)",
@@ -184,7 +185,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testRecordDt005031() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_aaf3b130);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_aaf3b130);
 
         //Single value field
         assertEquals("DT005031.tif",record.getFieldValue("filename_local"));
@@ -194,7 +195,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testRecordANSK() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_ANSK);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_ANSK);
 
         //Single value field
         assertEquals("ANSK_11614.tif",record.getFieldValue("filename_local"));
@@ -204,7 +205,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testRecordSkfF0137() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_54b34b50);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_54b34b50);
 
         //Single value field
         assertEquals("SKF_f_0137.tif",record.getFieldValue("filename_local"));
@@ -219,7 +220,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testRecordKhp() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_8e608940);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_8e608940);
 
         //Single value field
         assertEquals("KHP0001-049.tif",record.getFieldValue("filename_local"));
@@ -233,7 +234,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testRecordUldallForTitleAndPlaceOfProductionAndGenre() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_e2519ce0);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_e2519ce0);
 
         //Single value field
         assertEquals("Uldall_186_2_Foborg.tif",record.getFieldValue("filename_local"));
@@ -248,7 +249,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testAccessionNumberExtraction() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_FM);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_FM);
 
         //Single value field
         assertEquals("2000-3/7",record.getFieldValue("accession_number"));
@@ -256,7 +257,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testPublishedInAndCollection() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_DB_hans);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_DB_hans);
 
         //Single value field
         assertEquals("Bladtegnersamlingen",record.getFieldValue("collection"));
@@ -265,7 +266,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testTitle() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_770379f0);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_770379f0);
 
         assertMultivalueField(record, "title", "Romeo og Julie");
         assertEquals(1, record.getFieldValue("title_count"));
@@ -273,7 +274,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testResourceId() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_40221e30);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_40221e30);
 
         //Single value field
         assertMultivalueField(record, "resource_id", "DAMJP2/DAM/Samlingsbilleder/0000/624/420/KE070592");
@@ -281,7 +282,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testMapScale() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_0c02aa10);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_0c02aa10);
 
         //Single value field
         assertEquals("Målestok 1:75 000",record.getFieldValue("map_scale"));
@@ -289,7 +290,7 @@ public class EmbeddedSolrTest {
 
     @Test
     void testSubjectStrict() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_9c17a440);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_9c17a440);
 
         String[] testName = Arrays.copyOf(
                 record.getFieldValues("subject_full_name_strict").toArray(),
@@ -301,14 +302,14 @@ public class EmbeddedSolrTest {
 
     @Test
     void testSingleProductionDate() throws IOException{
-        SolrDocument record = singleMODSIndex(RECORD_226d41a0);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_226d41a0);
 
         assertEquals("1971", record.getFieldValue("production_date"));
     }
 
     @Test
     void testCountsCreatedBySolr() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_05fea810);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_05fea810);
 
         assertEquals(3, record.getFieldValue("creator_count"));
         assertEquals(6, record.getFieldValue("topic_count"));
@@ -319,9 +320,15 @@ public class EmbeddedSolrTest {
 
     @Test
     void testNotesLength() throws IOException {
-        SolrDocument record = singleMODSIndex(RECORD_DB_hans);
+        SolrDocument record = singleMODSIndex(MODS_RECORD_DB_hans);
 
         assertEquals(93, record.getFieldValue("notes_length"));
+    }
+
+    @Test
+    void firstPreservicaTest() throws IOException {
+        SolrDocument record = singlePreservicaIndex(PRESERVICA_RECORD_5a5357be);
+        System.out.println(record);
     }
 
     /*
@@ -374,15 +381,37 @@ public class EmbeddedSolrTest {
      * @return the indexed record.
      */
     private SolrDocument singleMODSIndex(String modsFile) throws IOException {
-        indexRecord(modsFile);
+        indexModsRecord(modsFile);
         assertEquals(1, getNumberOfTotalDocuments(),
                 "After indexing '" + modsFile + "' the index should only hold a single record");
         return getRecordByDerivedId(modsFile);
     }
 
-    private void indexRecord(String recordXml) throws IOException {
+    private SolrDocument singlePreservicaIndex(String preservicaFile) throws IOException {
+        indexPreservicaRecord(preservicaFile);
+        assertEquals(1, getNumberOfTotalDocuments(),
+                "After indexing '" + preservicaFile + "' the index should only hold a single record");
+        return getRecordByDerivedId(preservicaFile);
+    }
+
+    private void indexModsRecord(String recordXml) throws IOException {
         String solrString = TestUtil.getTransformedWithAccessFieldsAdded(MODS2SOLR, recordXml);
 
+        addRecordToEmbeddedServer(recordXml, solrString);
+    }
+
+    private void indexPreservicaRecord(String preservicaRecord) throws IOException{
+        String solrString = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SOLR, preservicaRecord);
+
+        addRecordToEmbeddedServer(preservicaRecord, solrString);
+    }
+
+    /**
+     * Adds a SolrJSON document to the embedded solr server.
+     * @param recordXml     that the solrJson has been created from.
+     * @param solrString    containing the solr json representation of the record.
+     */
+    private void addRecordToEmbeddedServer(String recordXml, String solrString) throws IOException {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         JsonElement je = JsonParser.parseString(solrString);
         String prettyJsonString = gson.toJson(je);

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -55,7 +55,7 @@ public class EmbeddedSolrTest {
     public static final String MODS_RECORD_0c02aa10 = "xml/copyright_extraction/0c02aa10-b657-11e6-aedf-00505688346e.xml";
     public static final String MODS_RECORD_9c17a440 = "xml/copyright_extraction/9c17a440-fe1a-11e8-9044-00505688346e.xml";
     public static final String MODS_RECORD_226d41a0 = "xml/copyright_extraction/226d41a0-5a83-11e6-8b8d-0016357f605f.xml";
-    public static final String PRESERVICA_RECORD_5a5357be = "internal_test_files/tvMetadata/5a5357be-5890-472a-a294-41a99f108936.xml";
+    public static final String PRESERVICA_RECORD_44979f67 = "internal_test_files/tvMetadata/44979f67-b563-462e-9bf1-c970167a5c5f.xml";
     @BeforeAll
     public static void startEmbeddedSolrServer() {
 
@@ -326,9 +326,15 @@ public class EmbeddedSolrTest {
     }
 
     @Test
-    void firstPreservicaTest() throws IOException {
-        SolrDocument record = singlePreservicaIndex(PRESERVICA_RECORD_5a5357be);
-        System.out.println(record);
+    void testPreservicaPremiere() throws Exception {
+        SolrDocument record = singlePreservicaIndex(PRESERVICA_RECORD_44979f67);
+        assertFalse((Boolean) record.getFieldValue("premiere"));
+    }
+
+    @Test
+    void testPreservicaDuration() throws Exception {
+        SolrDocument record = singlePreservicaIndex(PRESERVICA_RECORD_44979f67);
+        assertEquals(950000L,  record.getFieldValue("duration"));
     }
 
     /*
@@ -387,7 +393,7 @@ public class EmbeddedSolrTest {
         return getRecordByDerivedId(modsFile);
     }
 
-    private SolrDocument singlePreservicaIndex(String preservicaFile) throws IOException {
+    private SolrDocument singlePreservicaIndex(String preservicaFile) throws Exception {
         indexPreservicaRecord(preservicaFile);
         assertEquals(1, getNumberOfTotalDocuments(),
                 "After indexing '" + preservicaFile + "' the index should only hold a single record");
@@ -400,9 +406,9 @@ public class EmbeddedSolrTest {
         addRecordToEmbeddedServer(recordXml, solrString);
     }
 
-    private void indexPreservicaRecord(String preservicaRecord) throws IOException{
+    private void indexPreservicaRecord(String preservicaRecord) throws Exception {
         String solrString = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SOLR, preservicaRecord);
-
+        //TestUtil.prettyPrintSolrJsonFromMetadata(PRESERVICA2SOLR, preservicaRecord);
         addRecordToEmbeddedServer(preservicaRecord, solrString);
     }
 

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -33,12 +33,12 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
 
     @Test
     public void testDirectDuration() {
-        assertContains(RECORD_44979f67,"\"duration\":\"950000\"");
+        assertContains(RECORD_44979f67,"\"duration_ms\":\"950000\"");
     }
 
     @Test
     public void testCalculatedDuration() {
-        assertContains(RECORD_5a5357be,"\"duration\":\"1800000\"");
+        assertContains(RECORD_5a5357be,"\"duration_ms\":\"1800000\"");
     }
 
     @Test

--- a/src/test/resources/solr/dssolr/conf/schema.xml
+++ b/src/test/resources/solr/dssolr/conf/schema.xml
@@ -90,7 +90,8 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     Aktuelt?>
   </field>
 
-  <field name="genre" type="string" docValues="true">
+  <!-- TODO: Extract main genre from preservica to this field and make single valued. Collect other genres in a new multivalued field-->
+  <field name="genre" type="string" docValues="true" multiValued="true">
     <?description The genre of the resource?>
     <?example     For a photograph: Portrait?>
     <?example     For a book: novel?>
@@ -433,6 +434,11 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <field name="premiere" type="boolean">
     <?description Boolean that tells if this record is the first showing of the broadcast.?>
     <?example     false?>
+  </field>
+
+  <field name="aspect_ratio" type="string">
+    <?description The aspect ratio of the video?>
+    <?example     16:9?>
   </field>
 
 

--- a/src/test/resources/solr/dssolr/conf/schema.xml
+++ b/src/test/resources/solr/dssolr/conf/schema.xml
@@ -21,28 +21,28 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
    <!-- Default solr field -->
   <field name="_version_" type="plong" indexed="false" stored="false"/>
 
-  <field name="id" type="string" multiValued="false" indexed="true" required="true" stored="true">
+  <field name="id" type="string" multiValued="false" required="true">
     <?description The ID derived from UUID in database.?>
     <?example     770379f0-8a0d-11e1-805f-0016357f605f?>
   </field>
 
-  <field name="filename_local" type="string"  stored="true">
+  <field name="filename_local" type="string" >
     <?description The name of the file, which contains the digital resource that this metadata is about.?>
     <?examaple    JB000132_114.tif?>
   </field>
 
-  <field name="accession_number" type="string" stored="true">
+  <field name="accession_number" type="string">
   <?description The unique number given to each new acquisition
                 as it is entered in the catalog of a library or museum ?>
   <?example     1911-7507?>
   </field>
 
-  <field name="cataloging_language" type="string"  stored="true">
+  <field name="cataloging_language" type="string">
   <?description The language used for the catalogue entry.?>
   <?example     da?>
   </field>
 
-  <field name="location" type="string"  stored="true">
+  <field name="location" type="string">
     <?description Describes where the physical object is located.?>
     <?example     KBK Depot?>
     <?example     Billedsamlingen. John R. Johnsen. Balletfotografier?>
@@ -55,7 +55,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <!-- TODO: Investigate if this field is ever in use and add example if it is to be kept. -->
   </field>
 
-  <field name="categories" type="string" docValues="true" stored="true">
+  <field name="categories" type="string" docValues="true">
     <?description The categories field can contain many different values.
                   Metadata in this field are different entries seperated by space and commas.
                   The field list_of_categories contain the same values,
@@ -65,7 +65,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
                   Kirk, Mette-Ida, Romeo og Julie, Johnsen, John R., CAR- BLO katagori?>
   </field>
 
-  <field name="list_of_categories" type="string"  multiValued="true" docValues="true" stored="true">
+  <field name="list_of_categories" type="string"  multiValued="true" docValues="true">
     <?description The list_of_categories field can contain many different values.
                   This field is multivalued and contains a single category per
                   entry in the list.?>
@@ -79,12 +79,12 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?query_example ?>
   </field>
 
-  <field name="collection" type="string" docValues="true" stored="true">
+  <field name="collection" type="string" docValues="true">
     <?description The original collection.?>
     <?example     Billedsamlingen?>
   </field>
 
-  <field name="published_in" type="string" docValues="true" stored="true">
+  <field name="published_in" type="string" docValues="true">
     <?description If the object has been published in a journal, newspaper, book etc.
                   this field contains the name of that publication.?>
     <?example     Aktuelt?>
@@ -260,13 +260,13 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     Montering: opklæbet på karton og monteret i passepartout?>
   </field>
 
-  <field name="catalog" type="string" stored="true" docValues="true">
+  <field name="catalog" type="string" docValues="true">
     <?description The catalog, which this resource is a part of.?>
     <?example     Samlingsbilleder?>
   </field>
 
   <!-- Fields on production of physical and digital object. -->
-  <field name="production_date" type="string" stored="true">
+  <field name="production_date" type="string">
     <?description   The date when the resource was produced.?>
     <?example       1971?>
     <?query_example production_date:[1980 TO 1991] can be used to query for resources that have been produced in the
@@ -275,7 +275,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
                     respective documentation for examples.?>
   </field>
 
-  <field name="production_date_start" type="string" stored="true">
+  <field name="production_date_start" type="string">
     <?description   The date when production of the resource started.?>
     <?example       1850?>
     <?query_example production_date_start:[1780 TO 1800] will return resources where production
@@ -285,7 +285,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
                     production_date_start:[1780 TO 1800] AND production_date_end:[1780 TO 1800]?>
   </field>
 
-  <field name="production_date_end" type="string" stored="true">
+  <field name="production_date_end" type="string">
     <?description   The date when production of the resource finished.?>
     <?example       1899?>
     <?query_example production_date_end:[1780 TO 1800] will return resources where production ended during the
@@ -295,12 +295,12 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
                     production_date_start:[1780 TO 1800] AND production_date_end:[1780 TO 1800]?>
   </field>
 
-  <field name="production_place" type="string" stored="true">
+  <field name="production_place" type="string">
     <?description Info about where the resource was produced?>
     <?example     Denmark?>
   </field>
 
-  <field name="production_date_digital_surrogate" type="string" stored="true">
+  <field name="production_date_digital_surrogate" type="string">
     <?description The date when the digital surrogate of the resource was produced.?>
     <?example     2019-07-03T09:36:17.000+02:00?>
   </field>
@@ -315,7 +315,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     Johnsen, John R.?>
   </field>
 
-  <field name="subject_full_name" type="string" multiValued="true" stored="true" docValues="true">
+  <field name="subject_full_name" type="string" multiValued="true" docValues="true">
     <?description The name of the subject written as given name family name.?>
     <?example     John R. Johnsen?>
   </field>
@@ -336,12 +336,12 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     Hans Christian?>
   </field>
 
-  <field name="subject_date_of_birth" type="string" multiValued="true" stored="true">
+  <field name="subject_date_of_birth" type="string" multiValued="true">
     <?description the subjects date of birth?>
     <?example     1748-11-29?>
   </field>
 
-  <field name="subject_date_of_death" type="string" multiValued="true" stored="true">
+  <field name="subject_date_of_death" type="string" multiValued="true">
     <?description the date of death of the subject.?>
     <?example     1831-11-5?>
   </field>
@@ -357,17 +357,17 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     3?>
   </field>
 
-  <field name="map_scale" type="string" stored="true">
+  <field name="map_scale" type="string" >
     <?description The scale of the resource map.?>
     <?example     Målestok 1:75 000?>
   </field>
 
-  <field name="resource_id" type="string" multiValued="true" stored="true">
+  <field name="resource_id" type="string" multiValued="true" >
     <?description ID used to construct URI for resource.?>
     <?example     exampleCollection/examplePart/exampleCatalog/0000/123/456/AA123456?>
   </field>
 
-  <field name="thumbnail" type="string" stored="true">
+  <field name="thumbnail" type="string">
     <?description URI pointing to the thumbnail representation of the resource.?>
     <?example     https://example.com/imageserver/exampleCollection/examplePart/exampleCatalog/0000/123/456/AA123456/full/400%2C/0/default.jpg?>
   </field>
@@ -399,24 +399,24 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 
   <!-- Not in test data. Part of MODS and might be in other collections
        Called 'Audience' in dublin core.-->
-  <field name="audience" type="string" stored="true">
+  <field name="audience" type="string">
     <?description The target audience for the resource.?>
     <?example     Children?>
   </field>
 
   <!-- Fields that only apply to tv metadata -->
 
-  <field name="original_title" type="string" indexed="true" stored="true">
+  <field name="original_title" type="string">
     <?description The original title of the resource.?>
     <?example     TV-Avisen?>
   </field>
 
-  <field name="ritzau_id" type="string" indexed="true">
+  <field name="ritzau_id" type="string">
     <?description Identifier from ritzau?>
     <?example     7f42b813-690e-4897-9553-f6eefe9c4070?>
   </field>
 
-  <field name="tvmeter_id" type="string" indexed="true">
+  <field name="tvmeter_id" type="string">
     <?description Identifier from tvmeter?>
     <?example     78e74634-bec1-4cea-a984-20192c97b743?>
   </field>

--- a/src/test/resources/solr/dssolr/conf/schema.xml
+++ b/src/test/resources/solr/dssolr/conf/schema.xml
@@ -470,11 +470,11 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?description ?>
     <?example     ?>
   </field>
-  <field name="access_foto_aftale" type="boolean"   indexed="true" required="true"  docValues="true" stored="true">
+  <field name="access_foto_aftale" type="boolean"   indexed="true" required="false"  docValues="true" stored="true">
     <?description ?>
     <?example     ?>
   </field>
-  <field name="access_billede_aftale" type="boolean"  indexed="true" required="true" docValues="true" stored="true">
+  <field name="access_billede_aftale" type="boolean"  indexed="true" required="false" docValues="true" stored="true">
     <?description ?>
     <?example     ?>
   </field>
@@ -606,5 +606,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <copyField source="title" dest="freetext"/>
   <copyField source="subtitle" dest="freetext"/>
   <copyField source="alternative_title" dest="freetext"/>
+  <copyField source="original_title" dest="freetext"/>
+
   <!-- END COPYFIELDS  -->
  </schema>

--- a/src/test/resources/solr/dssolr/conf/schema.xml
+++ b/src/test/resources/solr/dssolr/conf/schema.xml
@@ -421,7 +421,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     78e74634-bec1-4cea-a984-20192c97b743?>
   </field>
 
-  <field name="duration" type="plong" indexed="true" stored="true">
+  <field name="duration_ms" type="plong" indexed="true" stored="true">
     <?description The duration of the broadcast in milliseconds.?>
     <?example     950000?>
   </field>

--- a/src/test/resources/solr/dssolr/conf/schema.xml
+++ b/src/test/resources/solr/dssolr/conf/schema.xml
@@ -403,6 +403,39 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     Children?>
   </field>
 
+  <!-- Fields that only apply to tv metadata -->
+
+  <field name="original_title" type="string" indexed="true" stored="true">
+    <?description The original title of the resource.?>
+    <?example     TV-Avisen?>
+  </field>
+
+  <field name="ritzau_id" type="string" indexed="true">
+    <?description Identifier from ritzau?>
+    <?example     7f42b813-690e-4897-9553-f6eefe9c4070?>
+  </field>
+
+  <field name="tvmeter_id" type="string" indexed="true">
+    <?description Identifier from tvmeter?>
+    <?example     78e74634-bec1-4cea-a984-20192c97b743?>
+  </field>
+
+  <field name="duration" type="plong" indexed="true" stored="true">
+    <?description The duration of the broadcast in milliseconds.?>
+    <?example     950000?>
+  </field>
+
+  <field name="color" type="boolean">
+    <?description Describes wether or not the broadcast is in color. color=true, greytone=false?>
+    <?example     true?>
+  </field>
+
+  <field name="premiere" type="boolean">
+    <?description Boolean that tells if this record is the first showing of the broadcast.?>
+    <?example     false?>
+  </field>
+
+
   <!--  Fields related to copyright and access conditions -->
   <!-- TODO: Documentation for access fields. -->
   <field name="access_blokeret" type="boolean" multiValued="false" indexed="true" required="false" stored="true">


### PR DESCRIPTION
Update solr schema to contain current fields from presevica transformation. 
Please note that some of the license fields from picture metadata had required="true". These have been changed, because they are not present in preservica metadata as it stands for now.