### PR TITLE
radiotv id prefix

### DIFF
--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -75,7 +75,7 @@ config:
 
         description: 'Radio and television records from the Preservica system at the Royal Danish Library'
         prefix: 'ds.radiotv'
-        base: 'pvica.devel'
+        base: 'ds.radiotv'
         views:
           - raw:
               mime: 'text/plain'

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -21,7 +21,7 @@
         <!-- TODO: Add logic for selecting more specific type -->
         <f:string key="@type">BroadcastEvent</f:string>
         <f:string key="id">
-          <xsl:value-of select="/xip:DeliverableUnit/DeliverableUnitRef"/>
+            <xsl:value-of select="$recordID"/>
         </f:string>
 
         <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument">


### PR DESCRIPTION
This pull request adjusts the setup to match the ds-storage setup, with the old base `pvica.devel` renamed to the new `ds.radiotv`. This also fixes the output ID for schema.org.

* A parallel commit has been done to the `aegis`-project so that devel deploy works
* The devel server has been updated with the product from this pull request

Both the `/records` and `record/{id}` endpoints works for the `ds.radiotv`-collection after this.