### PR TITLE
Fix failing resolve of oldimageserver url

### DIFF
--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -1,5 +1,5 @@
 #
-# This config contains behaviour data: Thread allocation, allowed fields for lookup, limits for arguments etc.
+# This imageservers.oldimageserver.url contains behaviour data: Thread allocation, allowed fields for lookup, limits for arguments etc.
 #
 # The behaviour config is normally controlled by developers and is part of the code repository.
 # Sensitive information such as machine names and user/passwords should not be part of this config.
@@ -32,8 +32,9 @@ config:
         url: "invalid://url"
         default: true
 
-    - oldimageserver:
-        url: "http://kb-images.kb.dk"
+  # The oldimageserver is special as that is used for imageIdentifier rather that bitmap delivery
+  oldimageserver:
+    url: "http://kb-images.kb.dk"
 
   # List of backing storages. This information should be overridden in ds-present-environment.yaml
 

--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -1,5 +1,5 @@
 #
-# This imageservers.oldimageserver.url contains behaviour data: Thread allocation, allowed fields for lookup, limits for arguments etc.
+# This contains behaviour data: Thread allocation, allowed fields for lookup, limits for arguments etc.
 #
 # The behaviour config is normally controlled by developers and is part of the code repository.
 # Sensitive information such as machine names and user/passwords should not be part of this config.

--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -90,7 +90,7 @@ config:
                     injections:
                       #- imageserver: ${path:config.imageservers[default=true].url}
                       - streamingserver: "here_should_be_a_wowza_url"
-                      - old_imageserver: ${path:config.imageservers.oldimageserver.url}
+                      - old_imageserver: ${path:config.oldimageserver.url}
           - SolrJSON:
               mime: 'application/json'
               transformers:
@@ -100,7 +100,7 @@ config:
                     injections:
                       # - imageserver: ${path:config.imageservers[default=true].url}
                       - streamingserver: "here_should_be_a_wowza_url"
-                      - old_imageserver: ${path:config.imageservers.oldimageserver.url}
+                      - old_imageserver: ${path:config.oldimageserver.url}
 
 
 


### PR DESCRIPTION
The old YAML-internal reference was to `${path:config.imageservers.oldimageserver.url}`, but since `imageservers`is a list, it should technically have been `${path:config.imageservers[2].oldimageserver.url}` as `oldimageserver` was the third imageserver in the list. However that was extremely ugly, so I moved `oldimageserver` one level out.