### PR TITLE
Make IIIF Manifest handle IDs with slash

### DIFF
--- a/src/main/java/dk/kb/present/api/v1/impl/IiifPresentationApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/IiifPresentationApiServiceImpl.java
@@ -153,8 +153,7 @@ public class IiifPresentationApiServiceImpl extends ImplBase implements IiifPres
      */
     @Override
     public ManifestDto getPresentationManifest(String identifier) throws ServiceException {
-        // Note the replace that handles double encoding (%252F) of '/' being single-decoded to '%2F'
-        return rawGetPresentationManifest(identifier.replace("%2F", "/"));
+        return rawGetPresentationManifest(identifier);
     }
 
     /*
@@ -169,8 +168,7 @@ public class IiifPresentationApiServiceImpl extends ImplBase implements IiifPres
         @ApiResponse(code = 200, message = "OK", response = ManifestDto.class) })
     public ManifestDto getPresentationManifestNonescaped(@PathParam("nonescaped") String nonescaped)
             throws ServiceException {
-        log.debug("Re-routing nonescaped IIIF Manifest request for '" + nonescaped + "'");
-        return rawGetPresentationManifest(nonescaped.replace("%2F", "/"));
+        return rawGetPresentationManifest(nonescaped);
     }
     /**
      * The implementation of {@link #getPresentationManifest(String)}.
@@ -181,9 +179,11 @@ public class IiifPresentationApiServiceImpl extends ImplBase implements IiifPres
      * @throws ServiceException if lookup failed.
      */
     private ManifestDto rawGetPresentationManifest(String identifier) throws ServiceException {
-        // TODO: Implement...
+        // This replace handles double encoding (%252F) of '/' being single-decoded to '%2F'
+        identifier = identifier.replace("%2F", "/");
         log.debug("rawGetPresentationManifest(identifier='{}') called with call details: {}",
                   identifier, getCallDetails());
+        // TODO: Implement...
 
         try { 
             ManifestDto response = new ManifestDto();

--- a/src/main/java/dk/kb/present/api/v1/impl/IiifPresentationApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/IiifPresentationApiServiceImpl.java
@@ -169,7 +169,7 @@ public class IiifPresentationApiServiceImpl extends ImplBase implements IiifPres
      * @return a Manifest for the image.
      * @throws ServiceException if lookup failed.
      */
-    public ManifestDto rawGetPresentationManifest(String identifier) throws ServiceException {
+    private ManifestDto rawGetPresentationManifest(String identifier) throws ServiceException {
         // TODO: Implement...
         log.debug("rawGetPresentationManifest(identifier='{}') called with call details: {}",
                   identifier, getCallDetails());


### PR DESCRIPTION
OpenAPI does not handle nonescaped slashed inside of paths (and rightly so as it is against the standard) and the IIIF standard [requires encoding](https://iiif.io/api/image/3.0/#3-identifier). Nevertheless it is accepted practice in the wild to not escape such IDs.

The OpenAPI 3 generator produces a method with this annotation:
```
    @Path("/IIIF/{identifier}/manifest")
```
and thus requires `identifier` to be escaped.

This pull request works around thisby creating a parallel endpoint with manual generated Apache CXF annotation instead of the OpenAPI generated one. CXF has no problem with wildcards in the `Path`, so by annotating a new endpoint with
```
    @Path("/IIIF/{nonescaped:.*}/manifest")
```
the `nonescaped` parameter can contain both escaped and nonescaped slashes.

The version is deployed on the devel server. The manifest returned is just a sample, so asking for any random ID (with or without slashed with or without encoding) should work.

Two things that does not work:

1. jetty does not like _leading_ slashes in the IDs. Or rather, it does not like consecutive slashes `http://example.com/foo//bar`. It is possible to make jetty accept it (See `AMBIGUOUS_EMPTY_SEGMENT` on https://stackoverflow.com/questions/74395500/jetty-returns-400-when-uri-has-2-slashes-in-a-row-while-tomcat-doesnt-care) but I have not discovered how to do so with the Maven Jatty Plugin.
2. Single-escaping `foo%2Fbar` still does not work and produces `Invalid URI: noSlash` in Tomcat (works fine with Jetty). We might be able to to convince our devel-Tomcat to accept it, but I have not explored that.
