### PR TITLE
Disc 200 transform manifestations

### DIFF
--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -36,6 +36,11 @@ config:
   oldimageserver:
     url: "http://kb-images.kb.dk"
 
+  relations:
+    - example:
+        url: 'http://example.com/ds-present/v1/record/'
+        default: true
+
   # List of backing storages. This information should be overridden in ds-present-environment.yaml
 
   # The storages defined in this file are

--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -36,9 +36,9 @@ config:
   oldimageserver:
     url: "http://kb-images.kb.dk"
 
-  relations:
+  endpoints:
     - example:
-        url: 'http://example.com/ds-present/v1/record/'
+        getrecord: 'http://example.com/ds-present/v1/record/'
         default: true
 
   # List of backing storages. This information should be overridden in ds-present-environment.yaml

--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -48,31 +48,26 @@ config:
         description: 'Hans Christian Andersen images from the collections at the Royal Danish Library'
         prefix: 'kb.images.billed.hca' # The prefix to match on incoming IDs. Selected to use ds-storage without any tweaks
         origin: 'kb.images.billed.hca' # Overrides the default origin for the storage
-        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views: *MODS_IMAGE_VIEWS
     - imagesjsmss:
         description: 'Judaistisk Samling: Håndskrifter images from the collections at the Royal Danish Library'
         prefix: 'kb.image.judsam.jsmss'
         origin: 'kb.image.judsam.jsmss'
-        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views: *MODS_IMAGE_VIEWS
     - imagesluftfoto:
         description: 'Luftfoto (arial photographs) images from the collections at the Royal Danish Library'
         prefix: 'kb.image.luftfo.luftfoto'
         origin: 'kb.images.luftfo.luftfoto'
-        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views: *MODS_IMAGE_VIEWS
     - imagessmaatryk:
         description: 'Småtryk images from the collections at the Royal Danish Library'
         prefix: 'kb.pamphlets.dasmaa.smaatryk'
         origin: 'kb.pamphlets.dasmaa.smaatryk'
-        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views: *MODS_IMAGE_VIEWS
     - samlingsbilleder:
         description: 'Diverse images from image collections at the Royal Danish Library'
         prefix: 'ds.samlingsbilleder'
         origin: 'ds.samlingsbilleder'
-        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views: *MODS_IMAGE_VIEWS
     - radiotv:
 
@@ -127,7 +122,6 @@ config:
         prefix: 'doms.radio' # The prefix to match on incoming IDs. Selectet to use ds-storage without any tweaks
         origin: "old.doms.radio"
         description: 'Images from the collections at the Royal Danish Library'
-        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
         views:
           - raw:
@@ -159,7 +153,6 @@ config:
         origin: 'ds.local'
         description: 'Selected image data from the collections at the Royal Danish Library'
         storage: 'test' # Not production here
-        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
         views:
           - raw:

--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -85,6 +85,7 @@ config:
         description: 'Radio and television records from the Preservica system at the Royal Danish Library'
         prefix: 'ds.radiotv'
         origin: 'ds.radiotv'
+        getchildendpoint: ${path:config.relations[default=true].url}
         views:
           - raw:
               mime: 'text/plain'

--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -48,31 +48,31 @@ config:
         description: 'Hans Christian Andersen images from the collections at the Royal Danish Library'
         prefix: 'kb.images.billed.hca' # The prefix to match on incoming IDs. Selected to use ds-storage without any tweaks
         origin: 'kb.images.billed.hca' # Overrides the default origin for the storage
-        getchildendpoint: ${path:config.relations[default=true].url}
+        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views: *MODS_IMAGE_VIEWS
     - imagesjsmss:
         description: 'Judaistisk Samling: Håndskrifter images from the collections at the Royal Danish Library'
         prefix: 'kb.image.judsam.jsmss'
         origin: 'kb.image.judsam.jsmss'
-        getchildendpoint: ${path:config.relations[default=true].url}
+        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views: *MODS_IMAGE_VIEWS
     - imagesluftfoto:
         description: 'Luftfoto (arial photographs) images from the collections at the Royal Danish Library'
         prefix: 'kb.image.luftfo.luftfoto'
         origin: 'kb.images.luftfo.luftfoto'
-        getchildendpoint: ${path:config.relations[default=true].url}
+        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views: *MODS_IMAGE_VIEWS
     - imagessmaatryk:
         description: 'Småtryk images from the collections at the Royal Danish Library'
         prefix: 'kb.pamphlets.dasmaa.smaatryk'
         origin: 'kb.pamphlets.dasmaa.smaatryk'
-        getchildendpoint: ${path:config.relations[default=true].url}
+        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views: *MODS_IMAGE_VIEWS
     - samlingsbilleder:
         description: 'Diverse images from image collections at the Royal Danish Library'
         prefix: 'ds.samlingsbilleder'
         origin: 'ds.samlingsbilleder'
-        getchildendpoint: ${path:config.relations[default=true].url}
+        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views: *MODS_IMAGE_VIEWS
     - radiotv:
 
@@ -90,7 +90,7 @@ config:
         description: 'Radio and television records from the Preservica system at the Royal Danish Library'
         prefix: 'ds.radiotv'
         origin: 'ds.radiotv'
-        getchildendpoint: ${path:config.relations[default=true].url}
+        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         views:
           - raw:
               mime: 'text/plain'
@@ -127,7 +127,7 @@ config:
         prefix: 'doms.radio' # The prefix to match on incoming IDs. Selectet to use ds-storage without any tweaks
         origin: "old.doms.radio"
         description: 'Images from the collections at the Royal Danish Library'
-        getchildendpoint: ${path:config.relations[default=true].url}
+        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
         views:
           - raw:
@@ -159,7 +159,7 @@ config:
         origin: 'ds.local'
         description: 'Selected image data from the collections at the Royal Danish Library'
         storage: 'test' # Not production here
-        getchildendpoint: ${path:config.relations[default=true].url}
+        getrecordendpoint: ${path:config.endpoints[default=true].getrecord}
         # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
         views:
           - raw:

--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -48,26 +48,31 @@ config:
         description: 'Hans Christian Andersen images from the collections at the Royal Danish Library'
         prefix: 'kb.images.billed.hca' # The prefix to match on incoming IDs. Selected to use ds-storage without any tweaks
         origin: 'kb.images.billed.hca' # Overrides the default origin for the storage
+        getchildendpoint: ${path:config.relations[default=true].url}
         views: *MODS_IMAGE_VIEWS
     - imagesjsmss:
         description: 'Judaistisk Samling: Håndskrifter images from the collections at the Royal Danish Library'
         prefix: 'kb.image.judsam.jsmss'
         origin: 'kb.image.judsam.jsmss'
+        getchildendpoint: ${path:config.relations[default=true].url}
         views: *MODS_IMAGE_VIEWS
     - imagesluftfoto:
         description: 'Luftfoto (arial photographs) images from the collections at the Royal Danish Library'
         prefix: 'kb.image.luftfo.luftfoto'
         origin: 'kb.images.luftfo.luftfoto'
+        getchildendpoint: ${path:config.relations[default=true].url}
         views: *MODS_IMAGE_VIEWS
     - imagessmaatryk:
         description: 'Småtryk images from the collections at the Royal Danish Library'
         prefix: 'kb.pamphlets.dasmaa.smaatryk'
         origin: 'kb.pamphlets.dasmaa.smaatryk'
+        getchildendpoint: ${path:config.relations[default=true].url}
         views: *MODS_IMAGE_VIEWS
     - samlingsbilleder:
         description: 'Diverse images from image collections at the Royal Danish Library'
         prefix: 'ds.samlingsbilleder'
         origin: 'ds.samlingsbilleder'
+        getchildendpoint: ${path:config.relations[default=true].url}
         views: *MODS_IMAGE_VIEWS
     - radiotv:
 
@@ -122,6 +127,7 @@ config:
         prefix: 'doms.radio' # The prefix to match on incoming IDs. Selectet to use ds-storage without any tweaks
         origin: "old.doms.radio"
         description: 'Images from the collections at the Royal Danish Library'
+        getchildendpoint: ${path:config.relations[default=true].url}
         # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
         views:
           - raw:
@@ -153,6 +159,7 @@ config:
         origin: 'ds.local'
         description: 'Selected image data from the collections at the Royal Danish Library'
         storage: 'test' # Not production here
+        getchildendpoint: ${path:config.relations[default=true].url}
         # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
         views:
           - raw:

--- a/conf/ds-present-kb-collections.yaml
+++ b/conf/ds-present-kb-collections.yaml
@@ -70,18 +70,6 @@ config:
         origin: 'ds.samlingsbilleder'
         views: *MODS_IMAGE_VIEWS
     - radiotv:
-
-        # Temporary hack to make the Preservica XML block well-formed (it is missing a namespace declaration)
-        testdatahack_xip: &TEST_DATA_HACK_XIP
-          regexp: '<xip:(DeliverableUnit|Collection|Manifestation) +status="([^"]+)" *>'
-          replacement: '<xip:$1 status="$2" xmlns:xip="http://www.tessella.com/XIP/v4">'
-          replaceall: false
-
-        testdatahack_xsi: &TEST_DATA_HACK_XSI
-          regexp: '(xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html")>'
-          replacement: '$1 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
-          replaceall: false
-
         description: 'Radio and television records from the Preservica system at the Royal Danish Library'
         prefix: 'ds.radiotv'
         origin: 'ds.radiotv'
@@ -94,8 +82,6 @@ config:
           - JSON-LD:
               mime: 'application/json'
               transformers:
-                - replace: *TEST_DATA_HACK_XIP
-                - replace: *TEST_DATA_HACK_XSI
                 - xslt:
                     stylesheet: 'xslt/preservica2schemaorg.xsl'
                     injections:
@@ -105,8 +91,6 @@ config:
           - SolrJSON:
               mime: 'application/json'
               transformers:
-                - replace: *TEST_DATA_HACK_XIP
-                - replace: *TEST_DATA_HACK_XSI
                 - xslt:
                     stylesheet: 'xslt/preservica2solr.xsl'
                     injections:

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -187,6 +187,9 @@ public class DSCollection {
      */
     private String getChildRecord(DsRecordDto record) {
 
+        // TODO: Figure how to choose correct manifestation for record, if more than one is present
+        // Return first child record, but if there are multiple presentation manifestations,
+        // the rest are currently not added to the transformation
         return record.getChildrenIds() == null ? "" :
                 record.getChildrenIds().stream()
                         .map(id -> getRawUri(id, getRecordEndpoint))

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -126,7 +126,7 @@ public class DSCollection {
     public String getRecord(String recordID, String format) throws ServiceException {
         View view = getView(format);
         DsRecordDto record = storage.getDSRecord(recordID);
-        String relation = getRelation(record);
+        String relation = getChildRecord(record);
         String recordData = record.getData();
         return view.apply(recordID, recordData, relation);
     }
@@ -180,27 +180,31 @@ public class DSCollection {
      * @param record     to extract children for.
      * @return the string value of the related record for the input record.
      */
-    private String getRelation(DsRecordDto record) {
+    private String getChildRecord(DsRecordDto record) {
 
         List<String> childrenIds = record.getChildrenIds();
-        log.warn("ChildrenIds is of length '{}' and has the following values: '{}'", childrenIds.size(), childrenIds);
         List<String> children = new ArrayList<>();
 
         if (childrenIds != null && !childrenIds.isEmpty()){
-            childrenIds.stream().map(id -> children.add(getChildUri(id)));
-            // TODO: Make method return correctly for children
+            childrenIds.forEach(id -> children.add(getRawUri(id)));
+            // TODO: Figure how to choose correct manifestation for record, if more than one is present
+            // Return first child record, but if there are multiple presentation manifestations,
+            // the rest are currently not added to the transformation
             return children.get(0);
         } else {
             return "";
         }
     }
 
-    private static String getChildUri(String id) {
-        String childId = URLEncoder.encode(id, StandardCharsets.UTF_8);
-
-        String childURI = getchildendpoint  + childId + "?format=raw";
-        log.info("ChildURI is: " + childURI);
-        return childURI;
+    /**
+     * Construct a URI for child records pointing towards the raw representation of the child record in ds-present.
+     * @param id id of record to construct URI for.
+     * @return   the URI for the input record.
+     */
+    private static String getRawUri(String id) {
+        String encodedId = URLEncoder.encode(id, StandardCharsets.UTF_8);
+        String rawRecordUri = getchildendpoint  + encodedId + "?format=raw";
+        return rawRecordUri;
     }
 
     /**

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -51,7 +51,7 @@ public class DSCollection {
     private static final String STORAGE_KEY = "storage";
     private static final String ORIGIN_KEY = "origin";
     private static final String VIEWS_KEY = "views";
-    private static final String GET_CHILD_KEY = "getchildendpoint";
+    private static final String GET_RECORD_ENDPOINT_KEY = "getrecordendpoint";
 
     /**
      * The ID of the collection, primarily used for debugging and configuration.
@@ -87,7 +87,7 @@ public class DSCollection {
      */
     private final Map<String, View> views; // keys are lowercase
 
-    private static String getchildendpoint;
+    private static String getRecordEndpoint;
 
     /**
      * Create a collection based on the given conf. The storageHandler is expected to be initialized and should contain
@@ -104,7 +104,7 @@ public class DSCollection {
             prefix = conf.getString(PREFIX_KEY);
             description = conf.getString(DESCRIPTION_KEY, null);
             storage = storageHandler.getStorage(conf.getString(STORAGE_KEY, null)); // null means default storage
-            getchildendpoint = conf.getString(GET_CHILD_KEY);
+            getRecordEndpoint = conf.getString(GET_RECORD_ENDPOINT_KEY);
             views = conf.getYAMLList(VIEWS_KEY)
                     .stream()
                     .map(yaml -> new View(yaml, origin))
@@ -203,7 +203,7 @@ public class DSCollection {
      */
     private static String getRawUri(String id) {
         String encodedId = URLEncoder.encode(id, StandardCharsets.UTF_8);
-        String rawRecordUri = getchildendpoint  + encodedId + "?format=raw";
+        String rawRecordUri = getRecordEndpoint + encodedId + "?format=raw";
         return rawRecordUri;
     }
 

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -87,7 +87,7 @@ public class DSCollection {
      */
     private final Map<String, View> views; // keys are lowercase
 
-    private final String getRecordEndpoint;
+    private String getRecordEndpoint;
 
     /**
      * Create a collection based on the given conf. The storageHandler is expected to be initialized and should contain
@@ -104,7 +104,12 @@ public class DSCollection {
             prefix = conf.getString(PREFIX_KEY);
             description = conf.getString(DESCRIPTION_KEY, null);
             storage = storageHandler.getStorage(conf.getString(STORAGE_KEY, null)); // null means default storage
-            getRecordEndpoint = conf.getString(GET_RECORD_ENDPOINT_KEY);
+
+            if (conf.containsKey(GET_RECORD_ENDPOINT_KEY)){
+                getRecordEndpoint = conf.getString(GET_RECORD_ENDPOINT_KEY);
+
+            }
+
             views = conf.getYAMLList(VIEWS_KEY)
                     .stream()
                     .map(yaml -> new View(yaml, origin))

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -181,7 +181,9 @@ public class DSCollection {
      * @return the string value of the related record for the input record.
      */
     private String getRelation(DsRecordDto record) {
+
         List<String> childrenIds = record.getChildrenIds();
+        log.warn("ChildrenIds is of length '{}' and has the following values: '{}'", childrenIds.size(), childrenIds);
         List<String> children = new ArrayList<>();
 
         if (childrenIds != null && !childrenIds.isEmpty()){

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -87,7 +87,7 @@ public class DSCollection {
      */
     private final Map<String, View> views; // keys are lowercase
 
-    private static String getRecordEndpoint;
+    private final String getRecordEndpoint;
 
     /**
      * Create a collection based on the given conf. The storageHandler is expected to be initialized and should contain
@@ -126,9 +126,9 @@ public class DSCollection {
     public String getRecord(String recordID, String format) throws ServiceException {
         View view = getView(format);
         DsRecordDto record = storage.getDSRecord(recordID);
-        String relation = getChildRecord(record);
+        String child = getChildRecord(record);
         String recordData = record.getData();
-        return view.apply(recordID, recordData, relation);
+        return view.apply(recordID, recordData, child);
     }
 
     /**
@@ -176,24 +176,16 @@ public class DSCollection {
     }
 
     /**
-     * Extract children records from storage if present in input record.
+     * Extract the first child record from storage if present in input record.
      * @param record     to extract children for.
-     * @return the string value of the related record for the input record.
+     * @return the URI value of the related raw record for the input record.
      */
     private String getChildRecord(DsRecordDto record) {
 
-        List<String> childrenIds = record.getChildrenIds();
-        List<String> children = new ArrayList<>();
-
-        if (childrenIds != null && !childrenIds.isEmpty()){
-            childrenIds.forEach(id -> children.add(getRawUri(id)));
-            // TODO: Figure how to choose correct manifestation for record, if more than one is present
-            // Return first child record, but if there are multiple presentation manifestations,
-            // the rest are currently not added to the transformation
-            return children.get(0);
-        } else {
-            return "";
-        }
+        return record.getChildrenIds() == null ? "" :
+                record.getChildrenIds().stream()
+                        .map(id -> getRawUri(id, getRecordEndpoint))
+                        .findFirst().orElse("");
     }
 
     /**
@@ -201,7 +193,7 @@ public class DSCollection {
      * @param id id of record to construct URI for.
      * @return   the URI for the input record.
      */
-    private static String getRawUri(String id) {
+    private static String getRawUri(String id, String getRecordEndpoint) {
         String encodedId = URLEncoder.encode(id, StandardCharsets.UTF_8);
         String rawRecordUri = getRecordEndpoint + encodedId + "?format=raw";
         return rawRecordUri;

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -159,8 +159,8 @@ public class DSCollection {
             return storage.getDSRecords(origin, mTime, maxRecords)
                     .peek(record -> {
                         try {
-                            // TODO: Make this method work with relations as well
-                            record.data(view.apply(record.getId(), record.getData(), ""));
+                            String relation = getChildRecord(record);
+                            record.data(view.apply(record.getId(), record.getData(), relation));
                         } catch (Exception e) {
                             throw new RuntimeTransformerException(
                                     "Exception transforming record '" + record.getId() + "' to format '" + format + "'");

--- a/src/main/java/dk/kb/present/View.java
+++ b/src/main/java/dk/kb/present/View.java
@@ -18,6 +18,7 @@ import dk.kb.present.transform.DSTransformer;
 import dk.kb.present.transform.TransformerController;
 import dk.kb.util.webservice.exception.InternalServiceException;
 import dk.kb.util.yaml.YAML;
+import org.apache.commons.lang3.function.TriFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ import java.util.function.BiFunction;
  * A view is at the core a list of {@link dk.kb.present.transform.DSTransformer}s.
  * It takes a pair of {@code recordID, recordContent} and return transformed recordContent.
  */
-public class View extends ArrayList<DSTransformer> implements BiFunction<String, String, String> {
+public class View extends ArrayList<DSTransformer> implements TriFunction<String, String, String, String> {
     private static final Logger log = LoggerFactory.getLogger(View.class);
 
     private static final String MIME_KEY = "mime";
@@ -84,10 +85,11 @@ public class View extends ArrayList<DSTransformer> implements BiFunction<String,
     }
 
     @Override
-    public String apply(String recordID, String content) {
+    public String apply(String recordID, String content, String relation) {
         final Map<String, String> metadata = new HashMap<>();
         metadata.put("recordID", recordID);
         metadata.put("origin", origin);
+        metadata.put("relation", relation);
         for (DSTransformer transformer: this) {
             try {
                 content = transformer.apply(content, metadata);

--- a/src/main/java/dk/kb/present/View.java
+++ b/src/main/java/dk/kb/present/View.java
@@ -32,7 +32,7 @@ import java.util.function.BiFunction;
 
 /**
  * A view is at the core a list of {@link dk.kb.present.transform.DSTransformer}s.
- * It takes a pair of {@code recordID, recordContent} and return transformed recordContent.
+ * It takes three values of {@code recordID, recordContent, childRecord} and return transformed recordContent.
  */
 public class View extends ArrayList<DSTransformer> implements TriFunction<String, String, String, String> {
     private static final Logger log = LoggerFactory.getLogger(View.class);
@@ -85,11 +85,11 @@ public class View extends ArrayList<DSTransformer> implements TriFunction<String
     }
 
     @Override
-    public String apply(String recordID, String content, String relation) {
+    public String apply(String recordID, String content, String child) {
         final Map<String, String> metadata = new HashMap<>();
         metadata.put("recordID", recordID);
         metadata.put("origin", origin);
-        metadata.put("relation", relation);
+        metadata.put("relation", child);
         for (DSTransformer transformer: this) {
             try {
                 content = transformer.apply(content, metadata);

--- a/src/main/resources/xslt/preservica2solr.xsl
+++ b/src/main/resources/xslt/preservica2solr.xsl
@@ -41,16 +41,18 @@
 
         <!-- Manifestations are extracted here. I would like to create a template for this.
              However, this is quite tricky when using the document() function -->
-        <f:array key="resource_id">
-          <xsl:for-each select="document($relation)/xip:Manifestation/ComponentManifestation/FileRef">
-            <f:string>
-              <xsl:value-of select="document($relation)/xip:Manifestation/ComponentManifestation/FileRef"/>
-            </f:string>
-          </xsl:for-each>
-        </f:array>
-        <f:string key="manifestation_type">
-          <xsl:value-of select="document($relation)/xip:Manifestation/ComponentManifestation/ComponentType"/>
-        </f:string>
+        <xsl:if test="$relation != ''">
+          <f:array key="resource_id">
+            <xsl:for-each select="document($relation)/xip:Manifestation/ComponentManifestation/FileRef">
+              <f:string>
+                <xsl:value-of select="document($relation)/xip:Manifestation/ComponentManifestation/FileRef"/>
+              </f:string>
+            </xsl:for-each>
+          </f:array>
+          <f:string key="manifestation_type">
+            <xsl:value-of select="document($relation)/xip:Manifestation/ComponentManifestation/ComponentType"/>
+          </f:string>
+        </xsl:if>
 
       </f:map>
     </xsl:variable>

--- a/src/main/resources/xslt/preservica2solr.xsl
+++ b/src/main/resources/xslt/preservica2solr.xsl
@@ -16,11 +16,15 @@
   <xsl:param name="streamingserver"/>
   <xsl:param name="recordID"/>
   <xsl:param name="origin"/>
+  <xsl:param name="relation"/>
 
   <xsl:template match="/" >
     <xsl:variable name="solrjson">
       <f:map>
 
+        <f:string key="relation_test">
+          <xsl:value-of select="$relation"/>
+        </f:string>
         <f:string key="id">
           <xsl:value-of select="$recordID"/>
         </f:string>

--- a/src/main/resources/xslt/preservica2solr.xsl
+++ b/src/main/resources/xslt/preservica2solr.xsl
@@ -22,9 +22,6 @@
     <xsl:variable name="solrjson">
       <f:map>
 
-        <f:string key="relation_test">
-          <xsl:value-of select="$relation"/>
-        </f:string>
         <f:string key="id">
           <xsl:value-of select="$recordID"/>
         </f:string>
@@ -39,6 +36,22 @@
         <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument">
           <xsl:call-template name="pbc-metadata"/>
         </xsl:for-each>
+
+
+
+        <!-- Manifestations are extracted here. I would like to create a template for this.
+             However, this is quite tricky when using the document() function -->
+        <f:array key="resource_id">
+          <xsl:for-each select="document($relation)/xip:Manifestation/ComponentManifestation/FileRef">
+            <f:string>
+              <xsl:value-of select="document($relation)/xip:Manifestation/ComponentManifestation/FileRef"/>
+            </f:string>
+          </xsl:for-each>
+        </f:array>
+        <f:string key="manifestation_type">
+          <xsl:value-of select="document($relation)/xip:Manifestation/ComponentManifestation/ComponentType"/>
+        </f:string>
+
       </f:map>
     </xsl:variable>
 

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -70,6 +70,7 @@ public class TestUtil {
 		HashMap<String, String> accessFields = XsltCopyrightMapper.applyXsltCopyrightTransformer(mods);
         accessFields.put("recordID", "ds.test:" + Path.of(xmlResource).getFileName().toString());
 		accessFields.put("origin", "ds.test");
+		accessFields.put("relation", "Test relation");
 		//System.out.println("access fields:"+accessFields);
 		return transformer.apply(mods, accessFields);
 	}

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -68,9 +68,11 @@ public class TestUtil {
 		DSTransformer transformer = new XSLTFactory().createTransformer(config);
 		String mods = Resolver.resolveUTF8String(xmlResource);
 		HashMap<String, String> accessFields = XsltCopyrightMapper.applyXsltCopyrightTransformer(mods);
+		String childURI = String.valueOf(Resolver.getPathFromClasspath("internal_test_files/tvMetadata/53bf323c-5a8a-48b9-a29a-0b1616a58af9.xml"));
+
         accessFields.put("recordID", "ds.test:" + Path.of(xmlResource).getFileName().toString());
 		accessFields.put("origin", "ds.test");
-		accessFields.put("relation", "Test relation");
+		accessFields.put("relation", childURI);
 		//System.out.println("access fields:"+accessFields);
 		return transformer.apply(mods, accessFields);
 	}
@@ -100,6 +102,10 @@ public class TestUtil {
 	private static void prettyPrintSolrJson(String record, String yamlStr) throws Exception {
 		YAML yaml = YAML.parse(new ByteArrayInputStream(yamlStr.getBytes(StandardCharsets.UTF_8)));
 		String solrString = getTransformedFromConfigWithAccessFields(yaml, record);
+		prettyPrintJson(solrString);
+	}
+
+	public static void prettyPrintJson(String solrString) {
 		Gson gson = new GsonBuilder().setPrettyPrinting().create();
 		JsonElement je = JsonParser.parseString(solrString);
 		String prettyJsonString = gson.toJson(je);

--- a/src/test/java/dk/kb/present/ViewTest.java
+++ b/src/test/java/dk/kb/present/ViewTest.java
@@ -27,7 +27,7 @@ class ViewTest {
         YAML conf = YAML.resolveLayeredConfigs("test_setup.yaml");
         YAML dsflConf = conf.getYAMLList(".config.collections").get(0);
         View view = new View(dsflConf.getSubMap("dsfl").getYAMLList("views").get(0), dsflConf.getSubMap("dsfl").getString("origin"));
-        assertEquals("SameAsInput", view.apply("someID", "SameAsInput")); // Identity view
+        assertEquals("SameAsInput", view.apply("someID", "SameAsInput", "")); // Identity view
     }
 
 
@@ -38,7 +38,7 @@ class ViewTest {
         YAML dsflConf = conf.getYAMLList(".config.collections").get(0);
         View jsonldView = new View(dsflConf.getSubMap("dsfl").getYAMLList("views").get(1), dsflConf.getSubMap("dsfl").getString("origin"));
         String mods = Resolver.resolveUTF8String("xml/copyright_extraction/40221e30-1414-11e9-8fb8-00505688346e.xml");
-        String jsonld = jsonldView.apply("40221e30-1414-11e9-8fb8-00505688346e", mods);
+        String jsonld = jsonldView.apply("40221e30-1414-11e9-8fb8-00505688346e", mods, "");
         assertTrue(jsonld.contains("\"headline\":[{\"value\":\"Christian VIII\",\"@language\":\"da\"}]"));
     }
 
@@ -48,7 +48,7 @@ class ViewTest {
         YAML dsflConf = conf.getYAMLList(".config.collections").get(0);
         View solrView = new View(dsflConf.getSubMap("dsfl").getYAMLList("views").get(2), dsflConf.getSubMap("dsfl").getString("origin"));
         String mods = Resolver.resolveUTF8String("xml/copyright_extraction/40221e30-1414-11e9-8fb8-00505688346e.xml");
-        String solrJson = solrView.apply("40221e30-1414-11e9-8fb8-00505688346e", mods);
+        String solrJson = solrView.apply("40221e30-1414-11e9-8fb8-00505688346e", mods, "");
         assertTrue(solrJson.contains("\"origin\":\"ds.test\""));
         assertTrue(solrJson.contains("\"resource_id\":[\"\\/DAMJP2\\/DAM\\/Samlingsbilleder\\/0000\\/624\\/420\\/KE070592\"]"), "SolrJSON does not contain correct resource_id");
         assertTrue(solrJson.contains("\"thumbnail\":\"https:\\/\\/example.com\\/imageserver\\/%2FDAMJP2%2FDAM%2FSamlingsbilleder%2F0000%2F624%2F420%2FKE070592\\/full\\/%21150%2C150\\/0\\/default.jpg\"")

--- a/src/test/java/dk/kb/present/ViewTest.java
+++ b/src/test/java/dk/kb/present/ViewTest.java
@@ -1,8 +1,17 @@
 package dk.kb.present;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import dk.kb.present.api.v1.impl.DsPresentApiServiceImpl;
+import dk.kb.present.client.v1.DsPresentApi;
 import dk.kb.util.Resolver;
 import dk.kb.util.yaml.YAML;
 import org.junit.jupiter.api.Test;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -54,6 +63,36 @@ class ViewTest {
         assertTrue(solrJson.contains("\"thumbnail\":\"https:\\/\\/example.com\\/imageserver\\/%2FDAMJP2%2FDAM%2FSamlingsbilleder%2F0000%2F624%2F420%2FKE070592\\/full\\/%21150%2C150\\/0\\/default.jpg\"")
                 , "SolrJson does not contain correct thumbnail");
     }
+
+
+    //TODO: Fix this test by creating correct test config.
+    /*
+    @Test
+    void relationInView() throws Exception {
+        YAML conf = YAML.resolveLayeredConfigs("test_setup.yaml");
+        YAML radiotvConf = conf.getYAMLList(".config.collections").get(0);
+        View solrView = new View(radiotvConf.getSubMap("dsfl").getYAMLList("views").get(2), radiotvConf.getSubMap("dsfl").getString("origin"));
+
+        // Running the unit test locally. Elsewhere, the child uri should point to a ds-present record endpoint to get the raw value.
+        String pvicaRecord = Resolver.resolveUTF8String("internal_test_files/tvMetadata/e683b0b8-425b-45aa-be86-78ac2b4ef0ca.xml");
+        String localChildUri = String.valueOf(Resolver.getPathFromClasspath("internal_test_files/tvMetadata/53bf323c-5a8a-48b9-a29a-0b1616a58af9.xml"));
+
+        // Getting child remote
+        String childEndpoint = radiotvConf.getSubMap("dsfl").getString("getchildendpoint");
+        String childId = URLEncoder.encode("ds.radiotv:oai:man:53bf323c-5a8a-48b9-a29a-0b1616a58af9", StandardCharsets.UTF_8);
+        String childURI = childEndpoint + childId + "?format=raw";
+
+
+        String solrJson = solrView.apply("40221e30-1414-11e9-8fb8-00505688346e", pvicaRecord, localChildUri);
+
+        Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+        JsonElement je = JsonParser.parseString(solrJson);
+        String prettyJsonString = gson.toJson(je);
+        System.out.println(prettyJsonString);
+    }
+
+     */
+
 
 
 }

--- a/src/test/java/dk/kb/present/ViewTest.java
+++ b/src/test/java/dk/kb/present/ViewTest.java
@@ -78,7 +78,7 @@ class ViewTest {
         String localChildUri = String.valueOf(Resolver.getPathFromClasspath("internal_test_files/tvMetadata/53bf323c-5a8a-48b9-a29a-0b1616a58af9.xml"));
 
         // Getting child remote
-        String childEndpoint = radiotvConf.getSubMap("dsfl").getString("getchildendpoint");
+        String childEndpoint = radiotvConf.getSubMap("dsfl").getString("getrecordendpoint");
         String childId = URLEncoder.encode("ds.radiotv:oai:man:53bf323c-5a8a-48b9-a29a-0b1616a58af9", StandardCharsets.UTF_8);
         String childURI = childEndpoint + childId + "?format=raw";
 

--- a/src/test/java/dk/kb/present/transform/ReplaceTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/ReplaceTransformerTest.java
@@ -50,34 +50,6 @@ class ReplaceTransformerTest {
         DSTransformer replacer = new ReplaceTransformer("id=\"([0-9]+)-([a-z]+)\"", "id=\"$2-$1\"", false);
         assertEquals("<mystructure id=\"foo-123\">...", replacer.apply("<mystructure id=\"123-foo\">...", null));
     }
-
-    @Test
-    void testXIP() {
-        DSTransformer replacer = new ReplaceTransformer(
-                "<xip:(DeliverableUnit|Collection|Manifestation) +status=\"([^\"]+)\" *>",
-                "<xip:$1 status=\"$2\" xmlns:xip=\"http://example.com/\">", false);
-
-        for (String element : new String[]{"DeliverableUnit", "Collection", "Manifestation"}) {
-            assertEquals("<xip:" + element + " status=\"foo\" xmlns:xip=\"http://example.com/\">",
-                    replacer.apply("<xip:" + element + " status=\"foo\">", null),
-                    "Namespace injection should work for element '" + element + "'");
-        }
-        assertNotEquals("<xip:Selfmade status=\"foo\" xmlns:xip=\"http://example.com/\">",
-                replacer.apply("<xip:Selfmade status=\"foo\">", null),
-                "Namespace injection should NOT work for element 'Selfmade'");
-    }
-
-    @Test
-    void testXSI() {
-        DSTransformer replacer = new ReplaceTransformer(
-                "(xsi:schemaLocation=\"http://www.pbcore.org/PBCore/PBCoreNamespace.html\")>",
-                "$1 xmlns:xsi=\"http://example.com/\">", false);
-
-        assertEquals("xsi:schemaLocation=\"http://www.pbcore.org/PBCore/PBCoreNamespace.html\" xmlns:xsi=\"http://example.com/\">",
-                replacer.apply("xsi:schemaLocation=\"http://www.pbcore.org/PBCore/PBCoreNamespace.html\">", null),
-                "Namespace injection should work for XSI'");
-
-    }
     
     /**
      * Use the {@link ReplaceFactory} to create a {@link ReplaceTransformer} with config taken from {@code yamlString}.

--- a/src/test/java/dk/kb/present/transform/XSLTTransformerTestBase.java
+++ b/src/test/java/dk/kb/present/transform/XSLTTransformerTestBase.java
@@ -123,6 +123,7 @@ public abstract class XSLTTransformerTestBase {
                             "  - origin: 'ds.test'\n";
             YAML yaml = YAML.parse(new ByteArrayInputStream(yamlStr.getBytes(StandardCharsets.UTF_8)));
             solrString = TestUtil.getTransformedFromConfigWithAccessFields(yaml, record);
+            //TestUtil.prettyPrintJson(solrString);
         } catch (Exception e) {
             throw new RuntimeException(
                     "Unable to fetch and transform '" + record + "' using XSLT '" + getXSLT() + "'", e);

--- a/src/test/resources/solr/dssolr/conf/schema.xml
+++ b/src/test/resources/solr/dssolr/conf/schema.xml
@@ -21,8 +21,6 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
    <!-- Default solr field -->
   <field name="_version_" type="plong" indexed="false" stored="false"/>
 
-  <field name="relation_test" type="text_general"/>
-
   <field name="id" type="string" multiValued="false" required="true">
     <?description The ID derived from UUID in database.?>
     <?example     770379f0-8a0d-11e1-805f-0016357f605f?>
@@ -445,6 +443,11 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <field name="aspect_ratio" type="string">
     <?description The aspect ratio of the video?>
     <?example     16:9?>
+  </field>
+
+  <field name="manifestation_type" type="string">
+    <?description the type of manifestation?>
+    <?example     Video?>
   </field>
 
 

--- a/src/test/resources/solr/dssolr/conf/schema.xml
+++ b/src/test/resources/solr/dssolr/conf/schema.xml
@@ -446,7 +446,8 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   </field>
 
   <field name="manifestation_type" type="string">
-    <?description the type of manifestation?>
+    <?description A manifestation describes the technical metadata related to a document.
+                  The manifestation type describes what type of content the related file contains.?>
     <?example     Video?>
   </field>
 

--- a/src/test/resources/solr/dssolr/conf/schema.xml
+++ b/src/test/resources/solr/dssolr/conf/schema.xml
@@ -21,6 +21,8 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
    <!-- Default solr field -->
   <field name="_version_" type="plong" indexed="false" stored="false"/>
 
+  <field name="relation_test" type="text_general"/>
+
   <field name="id" type="string" multiValued="false" required="true">
     <?description The ID derived from UUID in database.?>
     <?example     770379f0-8a0d-11e1-805f-0016357f605f?>

--- a/src/test/resources/test_setup.yaml
+++ b/src/test/resources/test_setup.yaml
@@ -57,16 +57,7 @@ config:
         origin: 'ds.test'
         description: 'Local records, mostly biographical'
         getrecordendpoint: 'http://example.com/ds-present/v1/record/'
-        # Temporary hack to make the Preservica XML block well-formed (it is missing a namespace declaration)
-        testdatahack: &TEST_DATA_HACK_XIP
-          regexp: '<xip:(DeliverableUnit|Collection|Manifestation) +status="([^"]+)" *>'
-          replacement: '<xip:$1 status="$2" xmlns:xip="http://www.w3.org/2001/XMLSchema-instance">'
-          replaceall: false
 
-        testdatahack2: &TEST_DATA_HACK_XSI
-          regexp: '(xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html")>'
-          replacement: '$1 xmlns:xsi="http://www.tessella.com/XIP/v4">'
-          replaceall: false
         # Different views on the material. Note that all collections has at least mods, jsonld and solrjson as views
         views:
           - mods:
@@ -76,8 +67,6 @@ config:
           - json-ld:
               mime: 'application/json'
               transformers:
-                - replace: *TEST_DATA_HACK_XIP
-                - replace: *TEST_DATA_HACK_XSI
                 - xslt:
                     stylesheet: 'xslt/mods2schemaorg.xsl'
                     injections:
@@ -86,8 +75,6 @@ config:
           - solrjson:
               mime: 'application/json'
               transformers:
-                - replace: *TEST_DATA_HACK_XIP
-                - replace: *TEST_DATA_HACK_XSI
                 - xslt:
                     stylesheet: 'xslt/mods2solr.xsl'
                     injections:

--- a/src/test/resources/test_setup.yaml
+++ b/src/test/resources/test_setup.yaml
@@ -56,6 +56,7 @@ config:
         prefix: 'local' # The prefix to match on incoming IDs
         origin: 'ds.test'
         description: 'Local records, mostly biographical'
+        getchildendpoint: 'http://example.com/ds-present/v1/record/'
         # Temporary hack to make the Preservica XML block well-formed (it is missing a namespace declaration)
         testdatahack: &TEST_DATA_HACK_XIP
           regexp: '<xip:(DeliverableUnit|Collection|Manifestation) +status="([^"]+)" *>'

--- a/src/test/resources/test_setup.yaml
+++ b/src/test/resources/test_setup.yaml
@@ -56,7 +56,7 @@ config:
         prefix: 'local' # The prefix to match on incoming IDs
         origin: 'ds.test'
         description: 'Local records, mostly biographical'
-        getchildendpoint: 'http://example.com/ds-present/v1/record/'
+        getrecordendpoint: 'http://example.com/ds-present/v1/record/'
         # Temporary hack to make the Preservica XML block well-formed (it is missing a namespace declaration)
         testdatahack: &TEST_DATA_HACK_XIP
           regexp: '<xip:(DeliverableUnit|Collection|Manifestation) +status="([^"]+)" *>'


### PR DESCRIPTION
Add resource_id to deliverable units, which has been extraced by parsing a child manifestation to extract the fileref from here. 

Includes changes in config files. remember to update aegis if deploying to devel environment. This PR applies this functionality to  the preservica2solr transformation, where we are including the child for a parent record. Internal KB issues are created for applying this logic in preservica2schemaorg transformation as well and for implementing the reverse child --> parent logic, which is needed for other types of material.