### PR TITLE
Enable More Like This support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
         <plugins>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.1.0</version>
                 <executions>
@@ -620,6 +621,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
                 <configuration>
                     <webXml>src/main/webapp/WEB-INF/web.xml</webXml>
                     <archive>

--- a/src/test/resources/solr/dssolr/conf/schema.xml
+++ b/src/test/resources/solr/dssolr/conf/schema.xml
@@ -540,9 +540,16 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     ?>
   </field>
 
+  <field name="text" type="text_general" multiValued="true" stored="true" >
+    <?description Content text field for newspaper article main text, book full text, television subtitles, radio transcriptions etc.?>
+    <?example     If a television recording with subtitles is indexed, this field will hold the subtitles and only the subtitles.?>
+  </field>
+
   <!-- Most fields are copied to this field for matching. -->
   <field name="freetext" type="freetext" multiValued="true" stored="false">
-    <?description Freetext field, which contains text from multiple other fields.?>
+    <?description Freetext field, which contains text from multiple other fields.
+                  Note: If the indexed material has 'body text', such as the main content of a book, a newspaper
+                  article or subtitles for a TV-recording, it will be indexed in the 'text' field.?>
     <?example     If a play with the titel 'Romeo and Juliet' written by the author 'William Shakespeare' is indexed,
                   then the freetext field for this play will contain content from multiple other fields, so that the
                   value of the freetext field could be something like this: "William Shakespeare Romeo and Juliet".?>
@@ -587,7 +594,8 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     </analyzer>
   </fieldType>
 
-  <fieldType name="text_general" class="solr.TextField" multiValued="false" indexed="true" required="false" stored="true">
+    <!-- termVectors=true & storeTermVectors=true to get better MoreLikeThis and support the Unified Highlighter -->
+  <fieldType name="text_general" class="solr.TextField" multiValued="false" indexed="true" required="false" stored="true"  termVectors="true" storeOffsetsWithPositions="true">
     <analyzer type="index">
        <tokenizer class="solr.StandardTokenizerFactory"/>
        <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt"/>

--- a/src/test/resources/solr/dssolr/conf/solrconfig.xml
+++ b/src/test/resources/solr/dssolr/conf/solrconfig.xml
@@ -755,7 +755,7 @@
        <str name="df">freetext</str>
        <str name="q.op">AND</str>
        <str name="defType">edismax</str>
-        
+        <!-- Update qf for /mlt above when changing this -->
         <str name="qf">
         filename_local^5.0
         title_strict^5.0
@@ -766,7 +766,8 @@
         collection
         catalog
         resource_description
-        freetext^0.5       
+        text^0.75
+        freetext^0.5
        </str>
        
         <str name="pf">
@@ -890,6 +891,51 @@
     <arr name="last-components">
       <str>tvComponent</str>
     </arr>
+  </requestHandler>
+
+  <!-- https://solr.apache.org/guide/solr/latest/query-guide/morelikethis.html#request-handler-configuration -->
+  <!-- Must be a handler (as opposed to search component) for distribution support -->
+  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
+    <!-- mlt-parameteres probably needs to be tweaked. This is just a semi-loose first attempt -->
+    <lst name="defaults">
+      <str name="mlt.fl">title,subtitle,alternative_title,creator_full_name,area,topic,notes,catalog,production_place,subject_full_name,audience,text</str>
+      <str name="mlt.mintf">2</str>
+      <str name="mlt.mindf">2</str>
+      <str name="mlt.boost">true</str>
+      <str name="mlt.maxntp">5000</str>
+      <!-- mlt.qf synchronized with edismax qf -->
+      <str name="mlt.qf">
+        filename_local^5.0
+        title_strict^5.0
+        creator_full_name_strict^5.0
+        topic^2.0
+        location
+        notes
+        collection
+        catalog
+        resource_description
+        text^0.75
+        freetext^0.5
+      </str>
+      <str name="mlt.maxqt">25</str>
+      <str name="mlt.maxdfpct">75</str>
+
+      <!-- Poorly understood hacking to get edismax-support for MLT -->
+      <str name="defType">edismax</str>
+      <str name="qf">
+          filename_local^5.0
+          title_strict^5.0
+          creator_full_name_strict^5.0
+          topic^2.0
+          location
+          notes
+          collection
+          catalog
+          resource_description
+          text^0.75
+          freetext^0.5
+        </str>
+    </lst>
   </requestHandler>
 
   <!-- Search results clustering component

--- a/src/test/resources/solr/dssolr/conf/solrconfig.xml
+++ b/src/test/resources/solr/dssolr/conf/solrconfig.xml
@@ -898,7 +898,7 @@
   <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
     <!-- mlt-parameteres probably needs to be tweaked. This is just a semi-loose first attempt -->
     <lst name="defaults">
-      <str name="mlt.fl">title,subtitle,alternative_title,creator_full_name,area,topic,notes,catalog,production_place,subject_full_name,audience,text</str>
+      <str name="mlt.fl">abstract,description,genre_sub,title,subtitle,alternative_title,creator_full_name,area,topic,notes,catalog,production_place,subject_full_name,audience,text</str>
       <str name="mlt.mintf">2</str>
       <str name="mlt.mindf">2</str>
       <str name="mlt.boost">true</str>

--- a/src/test/resources/solr/dssolr/conf/solrconfig.xml
+++ b/src/test/resources/solr/dssolr/conf/solrconfig.xml
@@ -755,7 +755,7 @@
        <str name="df">freetext</str>
        <str name="q.op">AND</str>
        <str name="defType">edismax</str>
-        <!-- Update qf for /mlt above when changing this -->
+        <!-- Update qf for /mlt handler further down in the solrconfig.xml when changing this -->
         <str name="qf">
         filename_local^5.0
         title_strict^5.0


### PR DESCRIPTION
This pull request tweaks the `text_general` specification to support efficient highlighting and More Like This. It also add a `MoreLikeThisHandler` so `solrconfig.xml` for proper support with distributed search.

The functionality can be tested by updating the configuration for an existing Solr setup with DS-content, then calling

```
curl -s 'http://localhost:10007/solr/ds/mlt' -d 'mlt.interestingTerms=list' -d 'mlt.fl=text' -d "q=*:*" -d 'fl=id,title' -d 'mlt.match.include=true' -d 'mlt.mintf=2' -d 'mlt.mindf=2' -d 'mlt.boost=true' -d 'mlt.maxntp=100000' -d 'mlt.qf=text' -d 'mlt.maxqt=10' -d 'mlt.maxdfpct=50' 
```

This should show
* The origo document under `match`
* 10 related documents under `response`
* The terms used for searching the related documents under `interestingTerms`