### PR TITLE
Add license support to ds-present

### DIFF
--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -39,6 +39,12 @@ config:
   streamingserver:
     url: "http://example.com/streaming/"
 
+  # Used for verifying access to metadata https://github.com/kb-dk/ds-license
+  # If allowall is set to true (default is false), all access is granted. Use only for devel + stage
+  licensemodule:
+    url: http://localhost:9076/ds-license/v1
+    allowall: false
+
   endpoints:
     - example:
         getrecord: 'http://example.com/ds-present/v1/record/'

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,22 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Client for ds-license. This will also require the org.openapitools dependency-->
+      <dependency>
+        <groupId>dk.kb.license</groupId>
+        <artifactId>ds-license</artifactId>
+          <version>1.2-SNAPSHOT</version>
+          <type>jar</type>
+          <classifier>classes</classifier>
+          <exclusions>
+            <exclusion>
+              <groupId>*</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+        </exclusions>
+      </dependency>
+
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>

--- a/src/main/java/dk/kb/present/DSCollection.java
+++ b/src/main/java/dk/kb/present/DSCollection.java
@@ -20,6 +20,7 @@ import dk.kb.present.transform.RuntimeTransformerException;
 import dk.kb.storage.model.v1.DsRecordDto;
 
 import dk.kb.storage.model.v1.RecordTypeDto;
+import dk.kb.util.other.ExtractionUtils;
 import dk.kb.util.webservice.exception.InternalServiceException;
 import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 import dk.kb.util.webservice.exception.ServiceException;
@@ -29,11 +30,10 @@ import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -77,7 +77,7 @@ public class DSCollection {
 
     /**
      * Optional origin, with fallback to the default origin for {@link Storage}.
-     * Used when {@link #getDSRecords(Long, Long, String)} is called.
+     * Used when {@link #getDSRecords(Long, Long, String, Function)} is called.
      */
     private final String origin;
 
@@ -151,19 +151,29 @@ public class DSCollection {
     /**
      * Returns a stream of records where the data are transformed to the given format.
      * Only records of type DELIVERABLEUNIT are returned as these are the main metadata format.
-     * @param mTime point in time (epoch * 1000) for the records to deliver, exclusive.
-     * @param maxRecords the maximum number of records to deliver. -1 means no limit.
-     * @param format the format of the record. See {@link #getViews()} for available formats.
+     * <p>
+     * The logic is complicated by the need to check for access to the IDs:
+     * The raw stream of records is split into batches in order to lower the amount of external calls to ds-license.
+     * The {@code flatMap(accessFilter)} processes such a batch (a list of {@code DsRecordDto}s) and flattens the
+     * result to a regular stream of {@code DsRecordDto}s.
+     * @param mTime        point in time (epoch * 1000) for the records to deliver, exclusive.
+     * @param maxRecords   the maximum number of records to deliver. -1 means no limit.
+     * @param format       the format of the record. See {@link #getViews()} for available formats.
+     * @param accessFilter filters which records should be delivered.
      * @return a stream of records in the requested format.
      * @throws ServiceException if anything went wrong during construction of the stream.
      */
-    public Stream<DsRecordDto> getDSRecords(Long mTime, Long maxRecords, String format) {
+    public Stream<DsRecordDto> getDSRecords(
+            Long mTime, Long maxRecords, String format, Function<List<DsRecordDto>, Stream<DsRecordDto>> accessFilter) {
         View view = getView(format);
         RecordTypeDto deliverableUnit = RecordTypeDto.DELIVERABLEUNIT;
         log.debug("Calling storage.getDSRecords(origin='{}', mTime={}, maxRecords={})",
                 origin, mTime, maxRecords);
         try {
-            return storage.getDSRecordsByRecordTypeLocalTree(origin, deliverableUnit, mTime, maxRecords)
+            // 500 is a magic number, which is poor code style. Currently, it controls batch size against ds-license
+            return ExtractionUtils.splitToLists(
+                            storage.getDSRecordsByRecordTypeLocalTree(origin, deliverableUnit, mTime, maxRecords), 500)
+                    .flatMap(accessFilter)
                     .peek(record -> {
                         try {
                             record.data(view.apply(record));

--- a/src/main/java/dk/kb/present/PresentFacade.java
+++ b/src/main/java/dk/kb/present/PresentFacade.java
@@ -14,6 +14,7 @@
  */
 package dk.kb.present;
 
+import dk.kb.present.api.v1.impl.DsPresentApiServiceImpl;
 import dk.kb.present.config.ServiceConfig;
 import dk.kb.present.model.v1.CollectionDto;
 import dk.kb.present.model.v1.ViewDto;
@@ -33,10 +34,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.StreamingOutput;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**
@@ -116,8 +117,20 @@ public class PresentFacade {
                 .mime(view.getMime().toString());
     }
 
+    /**
+     * Deliver streaming output for serialized records from a given collection.
+     * @param httpServletResponse used for setting MIME type.
+     * @param collectionID the collection to retrieve records for.
+     * @param mTime        only records after this time (Epoch milliseconds) will be delivered.
+     * @param maxRecords   the maximum number of records to deliver.
+     * @param format       the serialized format of the records. Valid values are {@code JSON-LD},
+     * {@code JSON-LD-LINES}, {@code MODS}, {@code STORAGERECORD} , {@code STORAGERECORD-LINES} and {@code SOLRJSON}.
+     * @param accessChecker only IDs evaluating to {@link DsPresentApiServiceImpl.ACCESS#ok} are delivered.
+     * @return a stream of serialized records.
+     */
     public static StreamingOutput getRecords(
-            HttpServletResponse httpServletResponse, String collectionID, Long mTime, Long maxRecords, String format) {
+            HttpServletResponse httpServletResponse, String collectionID, Long mTime, Long maxRecords, String format,
+            Function<List<String>, List<String>> accessChecker) {
         DSCollection collection = collectionHandler.getCollection(collectionID);
         if (collection == null) {
             throw new InvalidArgumentServiceException(String.format(
@@ -126,24 +139,34 @@ public class PresentFacade {
                     collectionHandler.getCollections().stream().map(DSCollection::getId).collect(Collectors.toList())));
         }
 
+        // Batch-oriented filter that only passed records that are allowed
+        Function<List<DsRecordDto>, Stream<DsRecordDto>> accessFilter = records -> {
+            List<String> allIDs = records.stream().map(DsRecordDto::getId).collect(Collectors.toList());
+            Set<String> allowedIDs = new HashSet<>(accessChecker.apply(allIDs));
+            return records.size() == allowedIDs.size() ?
+                    records.stream() : // No need for checking as all IDs passed
+                    records.stream().filter(record -> allowedIDs.contains(record.getId()));
+        };
+
         // enum:  ['JSON-LD', 'JSON-LD-Lines', 'MODS', 'SolrJSON', "StorageRecord"]
         switch (format.toUpperCase(Locale.ROOT)) {
             case "JSON-LD": return getRecordsData(
                     collection, mTime, maxRecords,
-                    httpServletResponse, "JSON-LD", ExportWriterFactory.FORMAT.json);
+                    httpServletResponse, "JSON-LD", ExportWriterFactory.FORMAT.json,
+                    accessFilter);
             case "JSON-LD-LINES": return getRecordsData(
                     collection, mTime, maxRecords,
-                    httpServletResponse, "JSON-LD", ExportWriterFactory.FORMAT.jsonl);
+                    httpServletResponse, "JSON-LD", ExportWriterFactory.FORMAT.jsonl, accessFilter);
             case "MODS": return getRecordsData(
                     collection, mTime, maxRecords,
-                    httpServletResponse, "MODS", ExportWriterFactory.FORMAT.xml);
+                    httpServletResponse, "MODS", ExportWriterFactory.FORMAT.xml, accessFilter);
             case "STORAGERECORD": return getRecordsFull(
                     collection, mTime, maxRecords,
-                    httpServletResponse, ExportWriterFactory.FORMAT.json);
+                    httpServletResponse, ExportWriterFactory.FORMAT.json, accessFilter);
             case "STORAGERECORD-LINES": return getRecordsFull(
                     collection, mTime, maxRecords,
-                    httpServletResponse, ExportWriterFactory.FORMAT.jsonl);
-            case "SOLRJSON": return getRecordsSolr(collection, mTime, maxRecords, httpServletResponse);
+                    httpServletResponse, ExportWriterFactory.FORMAT.jsonl, accessFilter);
+            case "SOLRJSON": return getRecordsSolr(collection, mTime, maxRecords, httpServletResponse, accessFilter);
             default: throw new InvalidArgumentServiceException("The format '" + format + "' is not supported");
         }
     }
@@ -151,12 +174,13 @@ public class PresentFacade {
     // Only deliver the data-part of the Records
     private static StreamingOutput getRecordsData(
             DSCollection collection, Long mTime, Long maxRecords,
-            HttpServletResponse httpServletResponse, String recordFormat, ExportWriterFactory.FORMAT deliveryFormat) {
+            HttpServletResponse httpServletResponse, String recordFormat, ExportWriterFactory.FORMAT deliveryFormat,
+            Function<List<DsRecordDto>, Stream<DsRecordDto>> accessFilter) {
         setFilename(httpServletResponse, mTime, maxRecords, deliveryFormat);
         return output -> {
             try (ExportWriter writer = ExportWriterFactory.wrap(
                     output, httpServletResponse, deliveryFormat, false, "records")) {
-                collection.getDSRecords(mTime, maxRecords, recordFormat)
+                collection.getDSRecords(mTime, maxRecords, recordFormat, accessFilter)
                         .map(DsRecordDto::getData)
                         .map(DataCleanup::removeXMLDeclaration)
                         .forEach(writer::write);
@@ -167,12 +191,13 @@ public class PresentFacade {
     // Retrieve full records to support deletions
     private static StreamingOutput getRecordsFull(
             DSCollection collection, Long mTime, Long maxRecords,
-            HttpServletResponse httpServletResponse, ExportWriterFactory.FORMAT deliveryFormat) {
+            HttpServletResponse httpServletResponse, ExportWriterFactory.FORMAT deliveryFormat,
+            Function<List<DsRecordDto>, Stream<DsRecordDto>> accessFilter) {
         setFilename(httpServletResponse, mTime, maxRecords, deliveryFormat);
         return output -> {
             try (ExportWriter writer = ExportWriterFactory.wrap(
                     output, httpServletResponse, deliveryFormat, false, "records")) {
-                collection.getDSRecords(mTime, maxRecords, recordView) // Does not contain deleted records
+                collection.getDSRecords(mTime, maxRecords, recordView, accessFilter) // Does not contain deleted records
                         .peek(record -> record.setData(DataCleanup.removeXMLDeclaration(record.getData())))
                         .forEach(writer::write);
             }
@@ -181,7 +206,8 @@ public class PresentFacade {
 
     // Direct ds-storage record JSON
     private static StreamingOutput getRecordsSolr(DSCollection collection, Long mTime, Long maxRecords,
-                                                  HttpServletResponse httpServletResponse) {
+                                                  HttpServletResponse httpServletResponse,
+                                                  Function<List<DsRecordDto>, Stream<DsRecordDto>> accessPredicate) {
         setFilename(httpServletResponse, mTime, maxRecords, ExportWriterFactory.FORMAT.json);
         return output -> {
             ExportWriter writer = ExportWriterFactory.wrap(
@@ -191,7 +217,7 @@ public class PresentFacade {
             ((JSONStreamWriter) writer).setPostOutput("\n}\n");
 
             try {
-                collection.getDSRecords(mTime, maxRecords, "SolrJSON")
+                collection.getDSRecords(mTime, maxRecords, "SolrJSON", accessPredicate)
                         .map(PresentFacade::wrapSolrJSON)
                         .forEach(writer::write);
             } catch (Exception e) {
@@ -232,7 +258,7 @@ public class PresentFacade {
     
     }
 
-    /**
+    /*
      * If the source data contains multiple DOMS, there will also be multiple SolrJSONDocuments.
      * This method splits those from one JSON structure to one structure/document.
      * @param solrJSONs one or more JSON documents in a JSON array.

--- a/src/main/java/dk/kb/present/PresentFacade.java
+++ b/src/main/java/dk/kb/present/PresentFacade.java
@@ -207,7 +207,7 @@ public class PresentFacade {
     // Direct ds-storage record JSON
     private static StreamingOutput getRecordsSolr(DSCollection collection, Long mTime, Long maxRecords,
                                                   HttpServletResponse httpServletResponse,
-                                                  Function<List<DsRecordDto>, Stream<DsRecordDto>> accessPredicate) {
+                                                  Function<List<DsRecordDto>, Stream<DsRecordDto>> accessFilter) {
         setFilename(httpServletResponse, mTime, maxRecords, ExportWriterFactory.FORMAT.json);
         return output -> {
             ExportWriter writer = ExportWriterFactory.wrap(
@@ -217,7 +217,7 @@ public class PresentFacade {
             ((JSONStreamWriter) writer).setPostOutput("\n}\n");
 
             try {
-                collection.getDSRecords(mTime, maxRecords, "SolrJSON", accessPredicate)
+                collection.getDSRecords(mTime, maxRecords, "SolrJSON", accessFilter)
                         .map(PresentFacade::wrapSolrJSON)
                         .forEach(writer::write);
             } catch (Exception e) {

--- a/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
@@ -221,8 +221,8 @@ public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
     }
 
     /**
-     * Based on user credentials (not used yet) and ds-license this function extracts allowed IDs from the given
-     * list and returns them as a new list. Order is preserved.
+     * Based on user credentials (not used yet) and ds-license this function extract allowed IDs from the given
+     * list and return them as a new list. Order is preserved.
      * @return function converting a list of IDs to allowed IDs.
      */
     private static Function<List<String>, List<String>> createAccessFilter() {

--- a/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
@@ -36,8 +36,8 @@ public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
     // License handling in DsPresentApiServiceImpl as tokens from the request will be needed later on
     private static final String LICENSE_URL_KEY = "config.licensemodule.url";
     private static final String LICENSE_ALLOWALL_KEY = "config.licensemodule.allowall";
-    private static DsLicenseApi licenseClient;
-    private static boolean licenseAllowAll = false;
+    static DsLicenseApi licenseClient;     // Shared between instances
+    static boolean licenseAllowAll = false;
     public static final String RECORD_ACCESS_TYPE = "Search"; // TODO: Evaluate if a specific type is needed
 
     /**
@@ -137,7 +137,8 @@ public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
                     throw new UnsupportedOperationException("The access condition '" + access + "' is unsupported");
             }
         } catch (Exception e){
-            throw handleException(e);
+            throw e;
+            //throw handleException(e);
         }
     }
 

--- a/src/main/java/dk/kb/present/webservice/AccessUtil.java
+++ b/src/main/java/dk/kb/present/webservice/AccessUtil.java
@@ -1,0 +1,153 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.present.webservice;
+
+import dk.kb.license.client.v1.DsLicenseApi;
+import dk.kb.license.model.v1.CheckAccessForIdsInputDto;
+import dk.kb.license.model.v1.CheckAccessForIdsOutputDto;
+import dk.kb.license.model.v1.UserObjAttributeDto;
+import dk.kb.license.util.DsLicenseClient;
+import dk.kb.present.api.v1.impl.DsPresentApiServiceImpl;
+import dk.kb.present.config.ServiceConfig;
+import dk.kb.util.webservice.exception.InternalServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Helpers for determining access conditions for material, based on caller credentials and ds-license setup.
+ */
+public class AccessUtil {
+    private static final Logger log = LoggerFactory.getLogger(AccessUtil.class);
+
+    private static final String LICENSE_URL_KEY = "config.licensemodule.url"; // Used for creating licenseClient
+    private static final String LICENSE_ALLOWALL_KEY = "config.licensemodule.allowall";
+
+    public static DsLicenseApi licenseClient;     // Shared between instances
+    public static boolean licenseAllowAll = ServiceConfig.getConfig().getBoolean(LICENSE_ALLOWALL_KEY, false);
+
+    /**
+     * Based on user credentials (not used yet as it requires pending OAuth2-integration) and ds-license setup,
+     * the produced function return an {@link DsPresentApiServiceImpl.ACCESS} state for metadata for a given id.
+     * @param presentationType as defined in ds-license, e.g. {@code Search}, {@code Stream}, {@code Thumbnails}...
+     * @return function for evaluating access to metadata for the current caller.
+     */
+    // Note: When OAuth2 support is added, this method should probably be extended with a HttpServletRequest parameter
+    public static Function<String, DsPresentApiServiceImpl.ACCESS> createAccessChecker(String presentationType) {
+        return id -> {
+            if (licenseAllowAll) {
+                return DsPresentApiServiceImpl.ACCESS.ok;
+            }
+
+            // Temporary singular role while we wait for OAuth2
+            UserObjAttributeDto everybody = new UserObjAttributeDto()
+                    .attribute("everybody")
+                    .values(List.of("yes"));
+
+            CheckAccessForIdsInputDto input = new CheckAccessForIdsInputDto()
+                    .accessIds(List.of(id))
+                    .presentationType(presentationType)
+                    .attributes(List.of(everybody));
+            CheckAccessForIdsOutputDto response;
+            try {
+                response = getLicenseClient().checkAccessForIds(input);
+            } catch (Exception e) {
+                String message = String.format(Locale.ROOT,
+                        "Exception calling license server for ID '%s' with attributes %s",
+                        id, everybody);
+                log.warn(message, e);
+                throw new InternalServiceException(message + ". This error has been logged");
+            }
+            if (response.getAccessIds() != null && response.getAccessIds().contains(id)) {
+                return DsPresentApiServiceImpl.ACCESS.ok;
+            }
+            if (response.getNonAccessIds() != null && response.getNonAccessIds().contains(id)) {
+                return DsPresentApiServiceImpl.ACCESS.not_allowed;
+            }
+            if (response.getNonExistingIds() != null && response.getNonExistingIds().contains(id)) {
+                return DsPresentApiServiceImpl.ACCESS.not_exists;
+            }
+            throw new InternalServiceException("Unable to determine access for '" + id + "'");
+        };
+    }
+
+    /**
+     * Based on user credentials (not used yet as it requires pending OAuth2-integration) and ds-license setup,
+     * the produced function isolate the IDs that the caller is allowed to see metadata for.
+     * Order is preserved, input is never changed, output is always a new list.
+     * @param presentationType as defined in ds-license, e.g. {@code Search}, {@code Stream}, {@code Thumbnails}...
+     * @return function converting a list of IDs to allowed IDs.
+     */
+    // Note: When OAuth2 support is added, this method should probably be extended with a HttpServletRequest parameter
+    public static Function<List<String>, List<String>> createAccessFilter(String presentationType) {
+        return ids -> {
+            if (licenseAllowAll || ids.isEmpty()) {
+                return new ArrayList<>(ids);
+            }
+
+            // Temporary singular role while we wait for OAuth2
+            UserObjAttributeDto everybody = new UserObjAttributeDto()
+                    .attribute("everybody")
+                    .values(List.of("yes"));
+
+            CheckAccessForIdsInputDto input = new CheckAccessForIdsInputDto()
+                    .accessIds(ids)
+                    .presentationType(presentationType)
+                    .attributes(List.of(everybody));
+            CheckAccessForIdsOutputDto response;
+            try {
+                response = getLicenseClient().checkAccessForIds(input);
+            } catch (Exception e) {
+                String message = String.format(Locale.ROOT,
+                        "Exception calling license server for %d IDs with attributes %s. First ID='%s'",
+                        ids.size(), everybody, ids.get(0));
+                log.warn(message, e);
+                throw new InternalServiceException(message + ". This error has been logged");
+            }
+            if (response.getAccessIds() != null) {
+                if (response.getAccessIds().size() == ids.size()) {
+                    // New array creation to ensure decoupling of input & output
+                    return new ArrayList<>(ids);
+                }
+                Set<String> allowed = new HashSet<>(response.getAccessIds());
+                return ids.stream().filter(allowed::contains).collect(Collectors.toList());
+            }
+            // TODO: Should a warning be logged here? Will getAccessIds return null if no IDs are allowed?
+            return Collections.emptyList();
+        };
+    }
+
+    /**
+     * The ds-license client is used to verify access to individual records.
+     * @return a ds-license client, ready for use.
+     */
+    static DsLicenseApi getLicenseClient() {
+        if (licenseClient != null) {
+          return licenseClient;
+        }
+
+        String dsLicenseUrl = ServiceConfig.getConfig().getString(LICENSE_URL_KEY, null);
+        if (dsLicenseUrl == null) {
+            throw new IllegalStateException("No ds-license URL specified at " + LICENSE_URL_KEY);
+        }
+        licenseClient = new DsLicenseClient(dsLicenseUrl);
+        log.info("Created client for ds-license at URL '{}' with allowall={}", dsLicenseUrl, licenseAllowAll);
+        return licenseClient;
+    }
+
+}

--- a/src/test/java/dk/kb/present/PresentFacadeTest.java
+++ b/src/test/java/dk/kb/present/PresentFacadeTest.java
@@ -29,7 +29,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class PresentFacadeTest {
+public class PresentFacadeTest {
 
 
     @BeforeAll
@@ -79,7 +79,7 @@ class PresentFacadeTest {
      * @param out stream of records in METS/MODS-format.
      * @return the number of records in the stream.
      */
-    private long countMETS(StreamingOutput out) throws IOException {
+    public static long countMETS(StreamingOutput out) throws IOException {
         Matcher m = METS_PATTERN.matcher(toString(out));
         long count = 0;
         while (m.find()) {
@@ -87,7 +87,7 @@ class PresentFacadeTest {
         }
         return count;
     }
-    private final Pattern METS_PATTERN = Pattern.compile("<mets:mets ");
+    private static final Pattern METS_PATTERN = Pattern.compile("<mets:mets ");
 
     @Test
     void getRecordsMODSDeclaration() throws IOException {
@@ -163,7 +163,7 @@ class PresentFacadeTest {
         String result = toString(out);
     }
 
-    private String toString(StreamingOutput out) throws IOException {
+    private static String toString(StreamingOutput out) throws IOException {
         try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             out.write(os);
             return os.toString(StandardCharsets.UTF_8);

--- a/src/test/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImplTest.java
+++ b/src/test/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImplTest.java
@@ -21,6 +21,7 @@ import dk.kb.license.model.v1.CheckAccessForIdsOutputDto;
 import dk.kb.present.PresentFacade;
 import dk.kb.present.PresentFacadeTest;
 import dk.kb.present.config.ServiceConfig;
+import dk.kb.present.webservice.AccessUtil;
 import dk.kb.present.webservice.exception.ForbiddenServiceException;
 import dk.kb.util.webservice.exception.NotFoundServiceException;
 import org.junit.jupiter.api.BeforeAll;
@@ -59,7 +60,7 @@ class DsPresentApiServiceImplTest {
         DsLicenseApi mockedLicenseClient = mock(DsLicenseApi.class);
         CheckAccessForIdsOutputDto accessResponse = new CheckAccessForIdsOutputDto().accessIds(List.of(RECORD_ID));
         doReturn(accessResponse).when(mockedLicenseClient).checkAccessForIds(any(CheckAccessForIdsInputDto.class));
-        DsPresentApiServiceImpl.licenseClient = mockedLicenseClient;
+        AccessUtil.licenseClient = mockedLicenseClient;
         String record = presentAPI.getRecord(RECORD_ID, "mods");
         assertTrue(record.contains("<mets:mets "), "Extraction with accepting license client should work");
 
@@ -109,7 +110,7 @@ class DsPresentApiServiceImplTest {
         CheckAccessForIdsOutputDto accessResponse = new CheckAccessForIdsOutputDto().accessIds(List.of(
                 RECORD_ID1, RECORD_ID2, RECORD_ID3));
         doReturn(accessResponse).when(mockedLicenseClient).checkAccessForIds(any(CheckAccessForIdsInputDto.class));
-        DsPresentApiServiceImpl.licenseClient = mockedLicenseClient;
+        AccessUtil.licenseClient = mockedLicenseClient;
         StreamingOutput records = presentAPI.getRecords("dsfl", 0L, 1000L, "mods");
         assertEquals(3, PresentFacadeTest.countMETS(records),
                 "3-specific-records-accepting license should return exactly 3 records");
@@ -131,20 +132,20 @@ class DsPresentApiServiceImplTest {
         DsLicenseApi mockedLicenseClient = mock(DsLicenseApi.class);
         CheckAccessForIdsOutputDto noAccessResponse = new CheckAccessForIdsOutputDto().nonAccessIds(List.of(RECORD_ID));
         doReturn(noAccessResponse).when(mockedLicenseClient).checkAccessForIds(any(CheckAccessForIdsInputDto.class));
-        DsPresentApiServiceImpl.licenseClient = mockedLicenseClient;
+        AccessUtil.licenseClient = mockedLicenseClient;
 
         assertThrowsInner(ForbiddenServiceException.class, () -> presentAPI.getRecord(RECORD_ID, "mods"),
                 "Calling getRecord should not be allowed");
 
         // Set allowall=true and try again
-        boolean oldAllowall = DsPresentApiServiceImpl.licenseAllowAll;
-        DsPresentApiServiceImpl.licenseAllowAll = true;
+        boolean oldAllowall = AccessUtil.licenseAllowAll;
+        AccessUtil.licenseAllowAll = true;
         try {
             assertTrue(presentAPI.getRecord(RECORD_ID, "mods").contains("<mets:mets "),
                     "Extraction with allowall=true should work");
         } finally {
             // Clean up for next test
-            DsPresentApiServiceImpl.licenseAllowAll = oldAllowall;
+            AccessUtil.licenseAllowAll = oldAllowall;
         }
     }
 
@@ -158,21 +159,21 @@ class DsPresentApiServiceImplTest {
         DsLicenseApi mockedLicenseClient = mock(DsLicenseApi.class);
         CheckAccessForIdsOutputDto accessResponse = new CheckAccessForIdsOutputDto().accessIds(List.of(RECORD_ID1));
         doReturn(accessResponse).when(mockedLicenseClient).checkAccessForIds(any(CheckAccessForIdsInputDto.class));
-        DsPresentApiServiceImpl.licenseClient = mockedLicenseClient;
+        AccessUtil.licenseClient = mockedLicenseClient;
         StreamingOutput records = presentAPI.getRecords("dsfl", 0L, 1000L, "mods");
         assertEquals(1, PresentFacadeTest.countMETS(records),
                 "1-specific-record-accepting license should return exactly 1 records");
 
         // Set allowall=true and try again
-        boolean oldAllowall = DsPresentApiServiceImpl.licenseAllowAll;
-        DsPresentApiServiceImpl.licenseAllowAll = true;
+        boolean oldAllowall = AccessUtil.licenseAllowAll;
+        AccessUtil.licenseAllowAll = true;
         try {
             records = presentAPI.getRecords("dsfl", 0L, 1000L, "mods");
             assertTrue(PresentFacadeTest.countMETS(records) > 1,
                     "allowall should return more than 1 records");
         } finally {
             // Clean up for next test
-            DsPresentApiServiceImpl.licenseAllowAll = oldAllowall;
+            AccessUtil.licenseAllowAll = oldAllowall;
         }
     }
 

--- a/src/test/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImplTest.java
+++ b/src/test/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImplTest.java
@@ -1,0 +1,97 @@
+package dk.kb.present.api.v1.impl;
+
+import dk.kb.license.client.v1.DsLicenseApi;
+import dk.kb.license.invoker.v1.ApiException;
+import dk.kb.license.model.v1.CheckAccessForIdsInputDto;
+import dk.kb.license.model.v1.CheckAccessForIdsOutputDto;
+import dk.kb.present.PresentFacade;
+import dk.kb.present.config.ServiceConfig;
+import dk.kb.present.webservice.exception.ForbiddenServiceException;
+import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.util.webservice.exception.NotFoundServiceException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.FieldSetter;
+
+import javax.servlet.http.HttpServletMapping;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.ForbiddenException;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.internal.util.reflection.FieldSetter.setField;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+class DsPresentApiServiceImplTest {
+
+    @BeforeAll
+    static void setup() {
+        try {
+            ServiceConfig.initialize("test_setup.yaml");
+            PresentFacade.warmUp();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    @Test
+    public void testSingleRecordLicense() throws NoSuchFieldException, ApiException {
+        final String RECORD_ID = "local.mods:40221e30-1414-11e9-8fb8-00505688346e.xml";
+
+        // Setup mock license that allows RECORD_ID
+        DsPresentApiServiceImpl presentAPI = getMockedPresentAPI();
+        DsLicenseApi mockedLicenseClient = mock(DsLicenseApi.class);
+        CheckAccessForIdsOutputDto accessResponse = new CheckAccessForIdsOutputDto().accessIds(List.of(RECORD_ID));
+        doReturn(accessResponse).when(mockedLicenseClient).checkAccessForIds(any(CheckAccessForIdsInputDto.class));
+        DsPresentApiServiceImpl.licenseClient = mockedLicenseClient;
+        String record = presentAPI.getRecord(RECORD_ID, "mods");
+        assertTrue(record.contains("<mets:mets "), "Extraction with accepting license client should work");
+
+        // Change the mock to not allow the record
+        CheckAccessForIdsOutputDto noAccessResponse = new CheckAccessForIdsOutputDto().nonAccessIds(List.of(RECORD_ID));
+        doReturn(noAccessResponse).when(mockedLicenseClient).checkAccessForIds(any(CheckAccessForIdsInputDto.class));
+        assertThrows(ForbiddenServiceException.class, () -> presentAPI.getRecord(RECORD_ID, "mods"),
+                "Calling getRecord should not be allowed");
+
+        // Change the mock to not have the record
+        CheckAccessForIdsOutputDto noRecordResponse = new CheckAccessForIdsOutputDto().nonExistingIds(List.of(RECORD_ID));
+        doReturn(noRecordResponse).when(mockedLicenseClient).checkAccessForIds(any(CheckAccessForIdsInputDto.class));
+        assertThrows(NotFoundServiceException.class, () -> presentAPI.getRecord(RECORD_ID, "mods"),
+                "Calling getRecord should raise a not found exception");
+    }
+
+    /**
+     * Basic mocking of the {@link DsPresentApiServiceImpl}. Callers should add further mocking.
+     * @return a Mochito mock of {@code } DsPresentApiServiceImpl with {@code httpServletRequest}.
+     * @throws NoSuchFieldException
+     */
+    private static DsPresentApiServiceImpl getMockedPresentAPI() throws NoSuchFieldException {
+        HttpServletMapping mockedMapping = mock(HttpServletMapping.class);
+        doReturn("foo").when(mockedMapping).getMatchValue();
+
+        HttpServletRequest mockedRequest = mock(HttpServletRequest.class);
+        doReturn("GET").when(mockedRequest).getMethod();
+        doReturn(mockedMapping).when(mockedRequest).getHttpServletMapping();
+        doReturn(Collections.enumeration(List.of("foo/bar"))).when(mockedRequest).getHeaders("Accept");
+
+        DsPresentApiServiceImpl presentAPI = spy(new DsPresentApiServiceImpl());
+        setField(presentAPI, dk.kb.util.webservice.ImplBase.class.getDeclaredField("httpServletRequest"), mockedRequest);
+        return presentAPI;
+    }
+}

--- a/src/test/resources/test_setup.yaml
+++ b/src/test/resources/test_setup.yaml
@@ -3,6 +3,11 @@
 #
 config:
 
+  # The client for ds-license will be mocked in the relevant unit tests.
+  licensemodule:
+    url: http://example.com
+    allowall: false
+
   # Only some of the sample files can be properly transformed to SolrJSONDocuments
   filewhitelist: &whitelist
      - '.*albert-einstein.xml'


### PR DESCRIPTION
This pull request adds support for ds-license integration (enabled as default). The 2 endpoints `/record({id}` and `/records` has different behaviour

* `/record/{id}` throws an exception (not found if the record is not in the Sol index, forbidden if access is not allowed) if the record cannot/must not be delivered
* `/records` passes existing allowed records and silently ignores non-indexed/non-access records

When testing it is possible to turn off access checking in the configuration.

* Note 1: The `DISC-367_license`-branch is deployed on the devel server
* Note 2: `aegis` has been updated