### PR TITLE
Bugfix: Copy Solr setup files to target for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
                     </execution>
                     <execution>
                         <id>copy-resources</id>
-                        <phase>compile</phase>
+                        <phase>test</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -477,6 +477,22 @@
                                 <resource>
                                     <directory>src/test/jetty</directory>
                                     <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-solr-test-resources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>testResources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/solr</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/solr</directory>
+                                    <filtering>false</filtering>
                                 </resource>
                             </resources>
                         </configuration>

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class EmbeddedSolrFieldAnalyseTest {
 
 	private static final Logger log = LoggerFactory.getLogger(EmbeddedSolrTest.class);
-	private static String solr_home = "src/main/solr";
+	private static String solr_home = "target/solr/";
 
 	private static CoreContainer coreContainer = null;
 	private static EmbeddedSolrServer embeddedServer = null;

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class EmbeddedSolrTest {
 
     private static final Logger log = LoggerFactory.getLogger(EmbeddedSolrTest.class);
-    private static final String solr_home = "src/main/solr";
+    private static final String solr_home = "target/solr";
 
     private static CoreContainer coreContainer = null;
     private static EmbeddedSolrServer embeddedServer = null;

--- a/src/test/java/dk/kb/present/transform/XSLTDocumentationTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTDocumentationTransformerTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class XSLTDocumentationTransformerTest {
 
     public static final String SCHEMA2DOC = "xslt/schema2doc.xsl";
-    public static final String SCHEMA = "src/main/solr/dssolr/conf/schema.xml";
+    public static final String SCHEMA = "target/solr/dssolr/conf/schema.xml";
 
     @Test
     public void testExtractionOfProcessingInstruction() throws IOException {


### PR DESCRIPTION
The previous setup where `SOLR_HOME` was `src/main/solr/` caused Solr to create a sub-folder named `data` holding the index files. This commit changes `SOLR_HOME` to be `target/solr/`.