### PR TITLE
Use Solr aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Developed and maintained by the Royal Danish Library.
 ## Test run
 
 Build and start the service using jetty with
-```
+```shell
 mvn package jetty:run
 ```
 After this, the Swagger UI should be available at <http://localhost:9073/ds-present/api/>. 
@@ -40,40 +40,150 @@ After this, a record for ID `doms.radio:albert-einstein.xml` should be delivered
 
 ## Test with Solr
 
-### Setup Solr
+### Solr fundamentals
+
+In DS, Solr operates with versioned collections. Upon first start or if a full reindex is needed, a timestamped collection is created. Access to the collection is done through two aliases:
+
+* **ds** is used for searching
+* **ds-write** is used for updating
+
+Normally the two aliases will point to the same timestamped collection, but if a full index rebuild is underway, **ds** will point to the complete old collection while **ds-write** will point to the new collection being created. When the full index rebuild has finished, **ds** will be switched to the new collection.
+
+This method ensures that there are no disruptions to Solr search. It is used in production at the Royal Danish Library and also on devel + stage for consistency.
+
+The how-to below expects the version of the Solr configuration to be specified in `schema.xml` as a special field looking like this:
+```xml
+ <field name="_ds_1.0.0_" type="string" indexed="false" stored="false"/>
+```
+If the schema is changed, the version must be updated.
+
+### Initial setup of Solr Cloud
 
 ds-present comes with convenience scripts for downloading, installing and starting Solr 9 in Cloud mode.
 
 ```shell
   bin/cloud_install.sh
   bin/cloud_start.sh
-  bin/cloud_sync.sh src/main/solr/dssolr/conf/ ds-conf ds
+
+  COLLECTION="ds-$(date +%Y%m%d-%H%M)" ; echo "Collection: $COLLECTION"
+  CONF_VERSION=$(grep 'name="_ds_.*_"' src/main/solr/dssolr/conf/schema.xml  | sed 's/.*name="_ds_\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)_.*/\1.\2.\3/') ; echo "ds-conf version: $CONF_VERSION"
+  bin/cloud_sync.sh src/main/solr/dssolr/conf/ ds-conf-${CONF_VERSION} $COLLECTION
+  bin/cloud_alias.sh ds-write $COLLECTION
+  bin/cloud_alias.sh ds $COLLECTION
 ```
 
 Check that the collection was created by visiting
 [http://localhost:10007/solr/#/~cloud?view=graph](http://localhost:10007/solr/#/~cloud?view=graph)
 
-After this Solr is available at http://localhost:10007/solr/ and can be stopped and started with
-```
+After this Solr is available at http://localhost:10007/solr/ 
+
+### Operating Solr
+
+The cloud can be stopped and started with
+```shell
 bin/cloud_stop.sh
 bin/cloud_start.sh
 ```
 
-If the Solr configuration is changed, force an update of `ds` with
+Aliases and collections can be seen from the admin gui or by calling
+```shell
+bin/cloud_alias.sh
 ```
-FORCE_CONFIG=true bin/cloud_sync.sh src/main/solr/dssolr/conf/ ds-conf ds
-```
-
-Clear all records in the `ds` collection, but keep the collection with
-```
-bin/cloud_clear.sh ds
-```
-
-Fully delete the `ds` collection with
-```
-bin/cloud_delete.sh ds
+and
+```shell
+bin/cloud_status.sh
 ```
 
+Clear all records in the `ds-20231114-1446` collection, but keep the collection:
+```shell
+bin/cloud_clear.sh ds-20231114-1446
+```
+
+Fully delete a concrete collection, e.g. `ds-20231114-1446`:
+```shell
+bin/cloud_delete.sh ds-20231114-1446
+```
+
+### Configuration update without reindex
+
+
+If the Solr configuration is changed in a way that does not require a full reindex, the
+configuration can be assigned to an existing collection.
+
+Start by determining what the current collection is by calling
+```shell
+bin/cloud_alias.sh
+```
+This should give an output such as 
+```
+Aliases:
+{
+  "ds-write": "ds-20231116-1045",
+  "ds": "ds-20231116-1045"
+}
+
+Collections:
+ds-20231114-1312
+ds-20231116-1045
+```
+
+Extract the current version and update the configuration for the collection with the following (note that the collection name must be entered explicitly. In this case it's `ds-20231116-1045`):
+
+```shell
+CONF_VERSION=$(grep 'name="_ds_.*_"' src/main/solr/dssolr/conf/schema.xml  | sed 's/.*name="_ds_\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)_.*/\1.\2.\3/') ; echo "ds-conf version: $CONF_VERSION"
+bin/cloud_sync.sh src/main/solr/dssolr/conf/ ds-conf-${CONF_VERSION} ds-20231116-1045
+```
+
+If this is during development and the Solr config version has not been bumped, the update can be forced:
+```shell
+CONF_VERSION=$(grep 'name="_ds_.*_"' src/main/solr/dssolr/conf/schema.xml  | sed 's/.*name="_ds_\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)_.*/\1.\2.\3/') ; echo "ds-conf version: $CONF_VERSION"
+FORCE_CONFIG=true bin/cloud_sync.sh src/main/solr/dssolr/conf/ ds-conf-${CONF_VERSION} ds-20231116-1045
+```
+
+
+### Full reindex
+
+If a fresh index is needed, the alias mehanism ensures that this is done without disrupting
+the existing collection.
+
+Create a new empty index with
+```shell
+  COLLECTION="ds-$(date +%Y%m%d-%H%M)" ; echo "Collection: $COLLECTION"
+  CONF_VERSION=$(grep 'name="_ds_.*_"' src/main/solr/dssolr/conf/schema.xml  | sed 's/.*name="_ds_\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)_.*/\1.\2.\3/') ; echo "ds-conf version: $CONF_VERSION"
+  bin/cloud_sync.sh src/main/solr/dssolr/conf/ ds-conf-${CONF_VERSION} $COLLECTION
+  bin/cloud_alias.sh ds-write $COLLECTION
+```
+This will create a new index and set the `ds-write` alias to point to it. It can be inspected with
+```shell
+bin/cloud_alias.sh
+```
+which should give something like
+
+```
+Aliases:
+{
+  "ds-write": "ds-20231116-1240",
+  "ds": "ds-20231116-1045"
+}
+
+Collections:
+ds-20231116-1045
+ds-20231116-1051
+ds-20231116-1240
+```
+Note hos `ds-write` and `ds` points to different collections.
+
+
+Perform the full reindex (`http://<develserver>/ds-datahandler/api/#/ds-datahandler/solrIndex`).
+Users of the index (`ds-license` and `ds-discover`) will continue to query the old index
+while this takes place.
+
+When the index has finished, adjust the **ds** alias to point to the new full collection
+```shell
+  bin/cloud_alias.sh ds $COLLECTION
+```
+
+Users of the index (`ds-license` and `ds-discover`) will now use the new index.
 
 ### Extract SolrJSONDocuments and index in Solr
 
@@ -100,12 +210,12 @@ copy `conf/ds-present-behaviour.yaml` to `conf/ds-present-environment.yaml` and 
 ## Build & run
 
 Build with
-``` 
+```shell 
 mvn package
 ```
 
 Test the webservice with
-```
+```shell
 mvn jetty:run
 ```
 

--- a/bin/cloud.conf
+++ b/bin/cloud.conf
@@ -4,7 +4,7 @@
 
 : ${SOLR_BASE_PORT:=10007}
 : ${SOLR_MEM:=1g}
-: ${VERSION:="9.1.1"}
+: ${VERSION:="9.4.0"}
 : ${ZOO_BASE_PORT:=10017}
 
 : ${ZOO_VERSION:="3.8.1"} # Latest stable as of 2023-02-06

--- a/bin/general.conf
+++ b/bin/general.conf
@@ -5,7 +5,7 @@ if [[ -s custom.conf ]]; then
 fi
 
 # Don't change the VERSIONS without also updating the scripts themselves
-VERSIONS="4.10.4 4.10.4-sparse 5.5.5 6.6.2 7.1.0 7.2.1 7.3.0 7.6.0 8.0.0 8.2.0 8.4.0 8.7.0 8.11.1 9.1.1"
+VERSIONS="4.10.4 4.10.4-sparse 5.5.5 6.6.2 7.1.0 7.2.1 7.3.0 7.6.0 8.0.0 8.2.0 8.4.0 8.7.0 8.11.1 9.1.1 9.4.0"
 # TODO: Enable these when it make sense: trunk trunk-7521
 LAYOUT2_VERSIONS="5.5.5 6.6.2 7.2.1 7.3.0 7.6.0 8.0.0 8.2.0 8.4.0 8.7.0 8.11.1 trunk trunk-7521"
 

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -15,6 +15,15 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
           examples for a field, please encapsulate each example in their own ?Example tag.?>
 
 <schema name="example" version="1.6">
+
+  <!-- Digitale Samlinger specific version field.
+
+       Update this according to Semantic Versioning rules: https://semver.org/
+
+       Used by scripts for keeping track of versioning of Solr setup across time and Solr instances.
+  -->
+  <field name="_ds_1.0.0_" type="string" indexed="false" stored="false"/>
+
   <uniqueKey>id</uniqueKey>
 
    <!-- START FIELDS  -->

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -36,7 +36,6 @@
        affect both how text is indexed and queried.
   -->
   <luceneMatchVersion>9.3</luceneMatchVersion>
-
   <!-- <lib/> directives can be used to instruct Solr to load any Jars
        identified and use them to resolve any "plugins" specified in
        your solrconfig.xml or schema.xml (ie: Analyzers, Request
@@ -591,7 +590,7 @@
      Circuit Breaker Section - This section consists of configurations for
      circuit breakers
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
-  <circuitBreaker>
+  <circuitBreaker class="solr.CircuitBreakerManager" enabled="true">
     <!-- Enable Circuit Breakers
 
      Circuit breakers are designed to allow stability and predictable query


### PR DESCRIPTION
This is primarily a large `README.md`-update. This switches from a hackish "There is only one config and one collection" to "Both configs and collections are versioned and full reindex can be performed without disruptions to the service".

For testing I recommend following the Solr instructions locally and inspecting the Solr Cloud state underway, either through commands listed in the `README.md` or through the Solr Admin GUI.

When this pull request has been accepted, the setup `ds-datahandler/devel/conf/ds-datahandler-devel.yaml` must be updated, changing
```yaml
  # solr. Used by workflow that extracts from storage, xslt and index into solr.  
  solr:
    url:  http://devel11:10007/solr/ds/update
```
to
```yaml
  # solr. Used by workflow that extracts from storage, xslt and index into solr.  
  solr:
    url:  http://devel11:10007/solr/ds-write/update
```
