### PR TITLE
Disc 460 pvica to schema

### DIFF
--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -23,6 +23,8 @@
   <xsl:param name="recordID"/>
   <xsl:param name="manifestation"/>
 
+  <!-- MAIN TEMPLATE. This template delegates, which fields are to be created for each schema.org object.
+       Currently, the template handles transformations from Preservica records to SCHEMA.ORG VideoObjects and AudioObjects. -->
   <xsl:template match="/">
     <!-- Saves all extensions in a variable used to check if one or more conditions are met in any of them.
          This is done to create one nested object in the JSON with values from multiple PBC extensions. -->
@@ -40,12 +42,16 @@
         </xsl:choose>
       </xsl:variable>
 
+      <!-- First three fields for schema.org are these no matter which object the transformer transforms to. -->
       <f:map>
         <f:string key="@context">http://schema.org/</f:string>
         <f:string key="@type"><xsl:value-of select="$type"/></f:string>
         <f:string key="id">
             <xsl:value-of select="$recordID"/>
         </f:string>
+
+        <!-- TODO: Here should be a choose statement, which handles the overall transformation for either VideoObject or
+             AudioObject -->
 
         <!-- Extract PBCore metadata -->
         <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument">
@@ -55,7 +61,7 @@
           </xsl:call-template>
         </xsl:for-each>
 
-        <!-- Manifestations are extracted here. I would like to create a template for this.
+        <!-- TODO: Manifestations are extracted here. I would like to create a template for this.
             However, this is quite tricky when using the document() function -->
         <xsl:if test="$manifestation != ''">
           <xsl:variable name="manifestationRef">

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -378,7 +378,7 @@
     </xsl:if>
 
     <!-- Is the resource hd? or do we know anything about the video quality=? -->
-    <xsl:if test="pbcoreInstantiation/formatStandard != ''">
+    <xsl:if test="$type = 'Moving Image' and pbcoreInstantiation/formatStandard != ''">
       <f:string key="videoQuality"><xsl:value-of select="pbcoreInstantiation/formatStandard"/></f:string>
     </xsl:if>
   </xsl:template>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -336,6 +336,15 @@
             </xsl:when>
             <xsl:when test="identifier = ''">
             </xsl:when>
+            <xsl:when test="identifierSource = 'Det Kongelige Bibliotek; Radio/TV-samlingen; De hvide programmer'">
+              <f:map>
+                <f:string key="@type">PropertyValue</f:string>
+                <f:string key="PropertyID">WhiteProgramID</f:string>
+                <f:string key="value">
+                  <xsl:value-of select="normalize-space(substring-after(identifier, 'ID:'))"/>
+                </f:string>
+              </f:map>
+            </xsl:when>
             <xsl:otherwise>
               <f:map>
                 <f:string key="@type">PropertyValue</f:string>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -551,7 +551,7 @@
         </f:string>
       </xsl:when>
       <!--Extract internal showviewcode -->
-      <xsl:when test="f:starts-with(. , 'showviewcode:')">
+      <xsl:when test="$type = 'VideoObject' and f:starts-with(. , 'showviewcode:')">
         <f:string key="kb:showviewcode">
           <xsl:value-of select="f:substring-after(. , 'showviewcode:')"/>
         </f:string>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -127,32 +127,11 @@
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
 
-    <f:map>
-      <!-- Creates the first three fields for docs. -->
-      <xsl:call-template name="schema-context-and-type">
-        <xsl:with-param name="type" select="$type"/>
-      </xsl:call-template>
-
-      <!-- Extract PBCore metadata -->
-      <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument">
-        <xsl:call-template name="pbc-metadata">
-          <xsl:with-param name="type" select="$type"/>
-          <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-        </xsl:call-template>
-      </xsl:for-each>
-
-      <!-- Extract manifestation -->
-      <xsl:call-template name="extract-manifestation"/>
-
-      <f:map key="kb:internal">
-      <!-- Transforms values that does not fit directly into Schema.org into an internal map. -->
-        <xsl:call-template name="kb-internal">
-          <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-          <xsl:with-param name="type" select="$type"/>
-        </xsl:call-template>
-      </f:map>
-
-    </f:map>
+    <!-- As the generic template currently is the same as the AudioObject, then this template is called here-->
+    <xsl:call-template name="generic-transformation">
+      <xsl:with-param name="type" select="$type"/>
+      <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+    </xsl:call-template>
   </xsl:template>
 
   <!-- TEMPLATE FOR TRANSFORMING OBJECTS, WHICH ARE WRONGLY DEFINED.-->

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -25,6 +25,7 @@ public class TestFiles {
     public static final String PVICA_RECORD_4b18d02d = "internal_test_files/tvMetadata/4b18d02d-a421-4026-b522-66436a56bc0a.xml";
     public static final String PVICA_RECORD_33e30aa9 = "internal_test_files/tvMetadata/33e30aa9-d216-4216-aabf-b28d2b465215.xml";
     public static final String PVICA_RECORD_b346acc8 = "internal_test_files/tvMetadata//b346acc8-bcb2-41cd-bab1-be58bb0665e0.xml";
+    public static final String PVICA_RECORD_e683b0b8 = "internal_test_files/tvMetadata/e683b0b8-425b-45aa-be86-78ac2b4ef0ca.xml";
     public static final String CUMULUS_RECORD_05fea810 = "xml/copyright_extraction/05fea810-7181-11e0-82d7-002185371280.xml";
     public static final String CUMULUS_RECORD_3956d820 = "xml/copyright_extraction/3956d820-7b7d-11e6-b2b3-0016357f605f.xml";
     public static final String CUMULUS_RECORD_096c9090 = "xml/copyright_extraction/096c9090-717f-11e0-82d7-002185371280.xml";
@@ -50,4 +51,5 @@ public class TestFiles {
     public static final String CUMULUS_RECORD_8e608940 = "xml/copyright_extraction/8e608940-d6db-11e3-8d2e-0016357f605f.xml";
     public static final String CUMULUS_RECORD_0c02aa10 = "xml/copyright_extraction/0c02aa10-b657-11e6-aedf-00505688346e.xml";
     public static final String CUMULUS_RECORD_226d41a0 = "xml/copyright_extraction/226d41a0-5a83-11e6-8b8d-0016357f605f.xml";
+
 }

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -26,6 +26,7 @@ public class TestFiles {
     public static final String PVICA_RECORD_33e30aa9 = "internal_test_files/tvMetadata/33e30aa9-d216-4216-aabf-b28d2b465215.xml";
     public static final String PVICA_RECORD_b346acc8 = "internal_test_files/tvMetadata//b346acc8-bcb2-41cd-bab1-be58bb0665e0.xml";
     public static final String PVICA_RECORD_e683b0b8 = "internal_test_files/tvMetadata/e683b0b8-425b-45aa-be86-78ac2b4ef0ca.xml";
+    // White program radio metadata from 1966
     public static final String PVICA_RECORD_c295ae6c = "internal_test_files/tvMetadata/c295ae6c-fd34-4694-a9cc-4204b4a9f3a0.xml";
     public static final String CUMULUS_RECORD_05fea810 = "xml/copyright_extraction/05fea810-7181-11e0-82d7-002185371280.xml";
     public static final String CUMULUS_RECORD_3956d820 = "xml/copyright_extraction/3956d820-7b7d-11e6-b2b3-0016357f605f.xml";

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -26,6 +26,7 @@ public class TestFiles {
     public static final String PVICA_RECORD_33e30aa9 = "internal_test_files/tvMetadata/33e30aa9-d216-4216-aabf-b28d2b465215.xml";
     public static final String PVICA_RECORD_b346acc8 = "internal_test_files/tvMetadata//b346acc8-bcb2-41cd-bab1-be58bb0665e0.xml";
     public static final String PVICA_RECORD_e683b0b8 = "internal_test_files/tvMetadata/e683b0b8-425b-45aa-be86-78ac2b4ef0ca.xml";
+    public static final String PVICA_RECORD_c295ae6c = "internal_test_files/tvMetadata/c295ae6c-fd34-4694-a9cc-4204b4a9f3a0.xml";
     public static final String CUMULUS_RECORD_05fea810 = "xml/copyright_extraction/05fea810-7181-11e0-82d7-002185371280.xml";
     public static final String CUMULUS_RECORD_3956d820 = "xml/copyright_extraction/3956d820-7b7d-11e6-b2b3-0016357f605f.xml";
     public static final String CUMULUS_RECORD_096c9090 = "xml/copyright_extraction/096c9090-717f-11e0-82d7-002185371280.xml";

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -274,34 +274,57 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     void testKBInternalMap() throws IOException {
         // TODO: Add individual tests for all params
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_74e22fd8);
-        Assertions.assertTrue(transformedJSON.contains("\"kb:internal\":{" +
-                                                "\"kb:genre_sub\":\"Alle\"," +
-                                                "\"kb:aspect_ratio\":\"16:9\"," +
-                                                "\"kb:surround_sound\":false," +
-                                                "\"kb:color\":true," +
-                                                "\"kb:premiere\":false," +
-                                                "\"kb:format_identifier_ritzau\":\"81213310\"," +
-                                                "\"kb:format_identifier_nielsen\":\"101|20220526|140000|180958|0|9629d8b8-b751-450f-bfd7-d2510910bb34|69\"," +
-                                                "\"kb:retransmission\":false," +
-                                                "\"kb:maingenre_id\":\"1\"," +
-                                                "\"kb:channel_id\":3," +
-                                                "\"kb:country_of_origin_id\":\"0\"," +
-                                                "\"kb:ritzau_program_id\":\"25101114\"," +
-                                                "\"kb:program_ophold\":false," +
-                                                "\"kb:subgenre_id\":\"708\"," +
-                                                "\"kb:episode_id\":\"0\"," +
-                                                "\"kb:season_id\":\"0\"," +
-                                                "\"kb:series_id\":\"0\"," +
-                                                "\"kb:has_subtitles\":false," +
-                                                "\"kb:has_subtitles_for_hearing_impaired\":false," +
-                                                "\"kb:is_teletext\":false," +
-                                                "\"kb:showviewcode\":\"0\"," +
-                                                "\"kb:padding_seconds\":15," +
-                                                "\"kb:access_individual_prohibition\":\"Nej\"," +
-                                                "\"kb:access_claused\":\"Nej\"," +
-                                                "\"kb:access_malfunction\":\"Nej\"" +
-                                                "}")
-        );
+        Assertions.assertTrue(transformedJSON.contains("\"kb:surround_sound\":false"));
+        Assertions.assertTrue(transformedJSON.contains("\"kb:color\":true"));
+        Assertions.assertTrue(transformedJSON.contains("\"kb:premiere\":false"));
+        Assertions.assertTrue(transformedJSON.contains("\"kb:retransmission\":false"));
+        Assertions.assertTrue(transformedJSON.contains("\"kb:program_ophold\":false"));
+        Assertions.assertTrue(transformedJSON.contains("\"kb:showviewcode\":\"0\""));
+        Assertions.assertTrue(transformedJSON.contains("\"kb:padding_seconds\":15"));
+    }
+    @Test
+    void testInternalGenreSub() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_74e22fd8);
+        Assertions.assertTrue(transformedJSON.contains("\"kb:genre_sub\":\"Alle\""));
+    }
+    @Test
+    void testInternalAspectRatio() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_74e22fd8);
+
+        Assertions.assertTrue(transformedJSON.contains("\"kb:aspect_ratio\":\"16:9\""));
+    }
+    @Test
+    void testInternalSubtitlesAndTeletext() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_74e22fd8);
+
+        Assertions.assertTrue(transformedJSON.contains("\"kb:has_subtitles\":false," +
+                                                        "\"kb:has_subtitles_for_hearing_impaired\":false," +
+                                                        "\"kb:is_teletext\":false"));
+    }
+    @Test
+    void testInternalAcces() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_74e22fd8);
+
+        Assertions.assertTrue(transformedJSON.contains("\"kb:access_individual_prohibition\":\"Nej\"," +
+                                                        "\"kb:access_claused\":\"Nej\"," +
+                                                        "\"kb:access_malfunction\":\"Nej\""));
+    }
+    @Test
+    void testInternalIds() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_74e22fd8);
+
+        Assertions.assertTrue(transformedJSON.contains("\"kb:subgenre_id\":\"708\"," +
+                                                        "\"kb:episode_id\":\"0\"," +
+                                                        "\"kb:season_id\":\"0\"," +
+                                                        "\"kb:series_id\":\"0\""));
+
+        Assertions.assertTrue(transformedJSON.contains("\"kb:maingenre_id\":\"1\"," +
+                                                        "\"kb:channel_id\":3," +
+                                                        "\"kb:country_of_origin_id\":\"0\"," +
+                                                        "\"kb:ritzau_program_id\":\"25101114\"" ));
+
+        Assertions.assertTrue(transformedJSON.contains("\"kb:format_identifier_ritzau\":\"81213310\"," +
+                "\"kb:format_identifier_nielsen\":\"101|20220526|140000|180958|0|9629d8b8-b751-450f-bfd7-d2510910bb34|69\"," ));
     }
 
 

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -37,7 +37,7 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     public void testSetup() throws IOException {
         //printSchemaOrgJson(PVICA_RECORD_74e22fd8);
-        printSchemaOrgJson(TestFiles.PVICA_RECORD_e683b0b8);
+        printSchemaOrgJson(TestFiles.PVICA_RECORD_c295ae6c);
         //printSchemaOrgJson(PVICA_RECORD_1F3A6A66);
         //printSchemaOrgJson(PVICA_RECORD_44979f67);
     }
@@ -231,6 +231,13 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     void noVideoQualityForRadioRecords() throws IOException {
         String radio = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_e683b0b8);
         Assertions.assertFalse(radio.contains("\"videoQuality\":"));
+    }
+    @Test
+    void whiteProgramID() throws IOException {
+        String radio = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_c295ae6c);
+        Assertions.assertTrue(radio.contains("\"@type\":\"PropertyValue\"," +
+                "\"PropertyID\":\"WhiteProgramID\"," +
+                "\"value\":\"A-1966-03-20-P-0197_059\""));
     }
 
     @Test

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -239,6 +239,11 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
                 "\"PropertyID\":\"WhiteProgramID\"," +
                 "\"value\":\"A-1966-03-20-P-0197_059\""));
     }
+    @Test
+    void noShowViewcodeForRadio() throws IOException {
+        String radio = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_c295ae6c);
+        Assertions.assertFalse(radio.contains("kb:showviewcode"));
+    }
 
     @Test
     void noAspectRatioForRadio() throws IOException {

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -234,6 +234,31 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     }
 
     @Test
+    void noAspectRatioForRadio() throws IOException {
+        String radio = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_e683b0b8);
+        Assertions.assertFalse(radio.contains("\"kb:aspect_ratio\":"));
+    }
+
+    @Test
+    void noColorForRadio() throws IOException {
+        String radio = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_e683b0b8);
+        Assertions.assertFalse(radio.contains("\"kb:color\":"));
+    }
+    @Test
+    void noTeletextForRadio() throws IOException {
+        String radio = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_e683b0b8);
+        Assertions.assertFalse(radio.contains("\"kb:is_teletext\":"));
+    }
+
+    @Test
+    void noSubtitlesForRadio() throws IOException {
+        String radio = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_e683b0b8);
+        Assertions.assertFalse(radio.contains("\"kb:has_subtitles\":"));
+        Assertions.assertFalse(radio.contains("\"kb:has_subtitles_for_hearing_impaired\":"));
+    }
+
+
+    @Test
     void testKBInternalMap() throws IOException {
         // TODO: Add individual tests for all params
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_74e22fd8);

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -37,7 +37,7 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     public void testSetup() throws IOException {
         //printSchemaOrgJson(PVICA_RECORD_74e22fd8);
-        printSchemaOrgJson(TestFiles.PVICA_RECORD_df3dc9cf);
+        printSchemaOrgJson(TestFiles.PVICA_RECORD_e683b0b8);
         //printSchemaOrgJson(PVICA_RECORD_1F3A6A66);
         //printSchemaOrgJson(PVICA_RECORD_44979f67);
     }
@@ -225,6 +225,12 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
 
         String emptyGenre = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_68b233c3);
         Assertions.assertFalse(emptyGenre.contains("\"genre\":"));
+    }
+
+    @Test
+    void noVideoQualityForRadioRecords() throws IOException {
+        String radio = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_e683b0b8);
+        Assertions.assertFalse(radio.contains("\"videoQuality\":"));
     }
 
     @Test


### PR DESCRIPTION
Refactoring of preservica2schemaorg transformation. 

The transformation now takes in to account, what type of metadata record is in hand before transforming and creating fields. 
This means, that fields like aspect_ratio and color now aren't created for a radio record. 