### PR TITLE
Add sortable title field to Solr

### DIFF
--- a/bin/cloud.conf
+++ b/bin/cloud.conf
@@ -7,8 +7,8 @@
 : ${VERSION:="9.4.0"}
 : ${ZOO_BASE_PORT:=10017}
 
-: ${ZOO_VERSION:="3.8.1"} # Latest stable as of 2023-02-06
-: ${ZOO_VERSION_TAR:="${ZOO_VERSION}-bin"} # No bin for ~3.4.14
+: ${ZOO_VERSION:="3.9.1"} # Latest stable as of 2023-11-23
+: ${ZOO_VERSION_TAR:="${ZOO_VERSION}-bin"}
 
 # Digitale Samlinger Solr config
 : ${CONFIG_FOLDER:="$(pwd)/../src/main/solr/dssolr/conf/"}

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -76,6 +76,10 @@
             <f:string key="title">
               <xsl:value-of select="$schemaorg-xml('name')"/>
             </f:string>
+
+            <f:string key="title_sort_da">
+              <xsl:value-of select="$schemaorg-xml('name')"/>
+            </f:string>
           </xsl:if>
 
           <!-- extract alternate title-->

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -84,6 +84,13 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     Den grimme ælling.?>
   </field>
 
+  <!-- Note: The title_sort_da field IS NOT automatically copied from title as title_sort_da is single valued -->
+  <field name="title_sort_da" type="sort_da">
+    <?description The object title, usable for sorting according to Danish locale.
+                  Not readable for human eyes.?>
+    <?example     #432#2asFSSAFs?>
+  </field>
+
   <field name="creator_affiliation" type="text_general" multiValued="true">
     <?description The name of an organization, institution, etc. with which
             the entity was associated at the time that the resource was created.?>
@@ -846,6 +853,11 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
       <filter class="solr.LowerCaseFilterFactory"/>
     </analyzer>
   </fieldType>
+
+  <!-- https://solr.apache.org/guide/solr/9_3/indexing-guide/language-analysis.html#unicode-collation -->
+  <fieldType name="sort_da" class="solr.ICUCollationField" locale="da" strength="secondary"
+             indexed="true" stored="false" docValues="true" multiValued="false"/>
+
   <!-- END FIELDTYPE DEFINITIONS-->
 
   <!-- START COPYFIELDS  -->


### PR DESCRIPTION
Standard Solr operation calls for multiple fields for the same data, depending on need for search, faceting/grouping and sorting. This pull request takes a first (small) stab at this, adding the `title_sort_da`-field.