### PR TITLE
Add continuation support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.18-SNAPSHOT</version>
+            <version>1.4.18</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
       <dependency>
         <groupId>dk.kb.storage</groupId>
         <artifactId>ds-storage</artifactId>
-          <version>1.11-SNAPSHOT</version>
+          <version>1.11</version>
           <type>jar</type>
           <classifier>classes</classifier>
           <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.15</version>
+            <version>1.4.18-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->
@@ -348,7 +348,7 @@
       <dependency>
         <groupId>dk.kb.storage</groupId>
         <artifactId>ds-storage</artifactId>
-          <version>1.7</version>
+          <version>1.11-SNAPSHOT</version>
           <type>jar</type>
           <classifier>classes</classifier>
           <exclusions>

--- a/src/main/java/dk/kb/present/storage/DSStorage.java
+++ b/src/main/java/dk/kb/present/storage/DSStorage.java
@@ -14,25 +14,18 @@
  */
 package dk.kb.present.storage;
 
-
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.NoSuchElementException;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import dk.kb.storage.model.v1.RecordTypeDto;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import dk.kb.storage.client.v1.DsStorageApi;
 import dk.kb.storage.invoker.v1.ApiException;
 import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.RecordTypeDto;
 import dk.kb.storage.util.DsStorageClient;
 import dk.kb.util.webservice.exception.InternalServiceException;
 import dk.kb.util.webservice.exception.NotFoundServiceException;
+import dk.kb.util.webservice.stream.ContinuationStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
 
 /**
  * Proxy for a ds-storage https://github.com/kb-dk/ds-storage instance.
@@ -51,7 +44,7 @@ public class DSStorage implements Storage {
 
     private final boolean isDefault;
     
-    private static DsStorageApi storageClient;  
+    private static DsStorageClient storageClient;
 
     /**
      * Create a Storage connection to a ds-storage server.
@@ -62,6 +55,7 @@ public class DSStorage implements Storage {
      *                   {@link DsStorageApi#getRecordsModifiedAfter(String, Long, Long)}.
      * @param isDefault if true, this is the default storage for origins.
      */
+    @SuppressWarnings("JavadocLinkAsPlainText")
     public DSStorage(String id, String origin,
                      String storageUrl,
                      int batchCount, boolean isDefault) {
@@ -75,9 +69,6 @@ public class DSStorage implements Storage {
        
 
         storageClient = getDsStorageApiClient(storageUrl);
-//        if (isEmpty(id) || isEmpty(scheme) || isEmpty(host) || isEmpty(basepath) || isEmpty(origin)) {
-//            throw new IllegalArgumentException("All parameters must be specified for " + this);
-//        }
         log.info("Created " + this);
     }
 
@@ -120,14 +111,14 @@ public class DSStorage implements Storage {
 
 
     @Override
-    public Stream<DsRecordDto> getDSRecords(final String origin, long mTime, long maxRecords) {
+    public ContinuationStream<DsRecordDto, Long> getDSRecords(final String origin, long mTime, long maxRecords) {
         log.debug("getDSRecords(origin='{}', mTime={}, maxRecords={}) called", origin, mTime, maxRecords);
 
         return getDsRecordDtoStream(mTime, maxRecords, origin, null);
     }
 
     @Override
-    public Stream<DsRecordDto> getDSRecordsByRecordTypeLocalTree(String origin, RecordTypeDto recordType,
+    public ContinuationStream<DsRecordDto, Long> getDSRecordsByRecordTypeLocalTree(String origin, RecordTypeDto recordType,
                                                                  long mTime, long maxRecords) {
         log.debug("getDSRecordsByRecordTypeLocalTree(origin='{}', recordType={}, mTime={}, maxRecords={}) called",
                 origin, recordType, mTime, maxRecords);
@@ -136,79 +127,30 @@ public class DSStorage implements Storage {
         return getDsRecordDtoStream(mTime, maxRecords, origin, recordType);
     }
 
-    private Stream<DsRecordDto> getDsRecordDtoStream(long mTime, long maxRecords, String origin, RecordTypeDto recordType) {
+    private ContinuationStream<DsRecordDto, Long> getDsRecordDtoStream(
+            long mTime, long maxRecords, String origin, RecordTypeDto recordType) {
         String finalOrigin = origin == null ? this.origin : origin;
-        if (finalOrigin == null || finalOrigin.isEmpty()) {
+        if (isEmpty(finalOrigin)) {
             throw new InternalServiceException(
                     "origin not defined for DSStorage '" + getID() + "'. Only single record lookups are possible");
         }
 
-        // Unfortunately the OpenAPI generator creates a client which requests all records as a list in a single call
-        // instead of doing streaming, so we need to page.
-
-        Iterator<DsRecordDto> iterator = new Iterator<DsRecordDto>() {
-            long pending = maxRecords == -1 ? Long.MAX_VALUE : maxRecords; // -1 = all records
-            final AtomicLong lastMTime = new AtomicLong(mTime);
-            List<DsRecordDto> records = null;
-            boolean finished = pending == 0;
-
-            void ensureFilled() {
-                if (finished || (records != null && !records.isEmpty())) {
-                    return;
-                }
-                if (pending <= 0) {
-                    finished = true;
-                    return;
-                }
-
-                long request = pending < batchCount ? (int) pending : batchCount;
-                try {
-                    if (recordType == null) {
-                        log.debug("Calling the raw endpoint.");
-                        records = storageClient.getRecordsModifiedAfter(finalOrigin, lastMTime.get(), request);
-                    } else {
-                        records = storageClient.getRecordsByRecordTypeModifiedAfterLocalTree(finalOrigin, recordType, lastMTime.get(), request);
-                    }
-                } catch (ApiException e) {
-                    String message = String.format(
-                            Locale.ROOT,
-                            "Exception making remote call to ds-storage client " +
-                            "getRecordsModifiedAfter(origin='%s', mTime=%d, maxRecords=%d)",
-                            finalOrigin, mTime, maxRecords);
-                    log.warn(message, e);
-                    throw new InternalServiceException(message, e);
-                }
-                pending -= records.size();
-                finished = records.isEmpty();
-                if (!finished) {
-                    Long lastRecordMTime = records.get(records.size()-1).getmTime();
-                    if (lastRecordMTime == null) {
-                        throw new InternalServiceException(
-                                "Got null as mTime for record '" + records.get(records.size()-1).getId());
-                    }
-                    lastMTime.set(lastRecordMTime);
-                }
-            }
-            @Override
-            public boolean hasNext() {
-                ensureFilled();
-                return !finished;
-            }
-
-            @Override
-            public DsRecordDto next() {
-                ensureFilled();
-                if (finished) {
-                    throw new NoSuchElementException("No more records");
-                }
-                return records.remove(0);
-            }
-        };
-
-        return StreamSupport.stream(((Iterable<DsRecordDto>) () -> iterator).spliterator(), false);
+        try {
+            return recordType == null ?
+                    storageClient.getRecordsModifiedAfterStream(finalOrigin, mTime, maxRecords) :
+                    storageClient.getRecordsByRecordTypeModifiedAfterLocalTreeStream(finalOrigin, recordType, mTime, maxRecords);
+        } catch (Exception e) {
+            String message = String.format(
+                    Locale.ROOT,
+                    "Exception requesting records from remote storage for " +
+                            "origin='%s', mTime=%d, maxRecords=%d, recordType='%s')",
+                    finalOrigin, mTime, maxRecords, recordType);
+            log.warn(message, e);
+            throw new InternalServiceException(message, e);
+        }
     }
 
-    private static DsStorageApi getDsStorageApiClient(String storageUrl) {       
+    private static DsStorageClient getDsStorageApiClient(String storageUrl) {
         if (storageClient!= null) {            
         	return storageClient;
         }

--- a/src/main/java/dk/kb/present/storage/FailStorage.java
+++ b/src/main/java/dk/kb/present/storage/FailStorage.java
@@ -18,6 +18,7 @@ package dk.kb.present.storage;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
 import dk.kb.util.webservice.exception.NotFoundServiceException;
+import dk.kb.util.webservice.stream.ContinuationStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,12 +65,12 @@ public class FailStorage implements Storage {
     }
 
     @Override
-    public Stream<DsRecordDto> getDSRecords(String origin, long mTime, long maxRecords) {
+    public ContinuationStream<DsRecordDto, Long> getDSRecords(String origin, long mTime, long maxRecords) {
         throw new NotFoundServiceException("Unable to locate any records after mTime " + mTime);
     }
 
     @Override
-    public Stream<DsRecordDto> getDSRecordsByRecordTypeLocalTree(String origin, RecordTypeDto recordType, long mTime, long maxRecords) {
+    public ContinuationStream<DsRecordDto, Long> getDSRecordsByRecordTypeLocalTree(String origin, RecordTypeDto recordType, long mTime, long maxRecords) {
         throw new NotFoundServiceException("Unable to locate any records after mTime " + mTime);
     }
 

--- a/src/main/java/dk/kb/present/storage/Storage.java
+++ b/src/main/java/dk/kb/present/storage/Storage.java
@@ -14,11 +14,9 @@
  */
 package dk.kb.present.storage;
 
-
-import java.util.stream.Stream;
-
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
+import dk.kb.util.webservice.stream.ContinuationStream;
 
 /**
  * Provides access to records.
@@ -72,8 +70,8 @@ public interface Storage {
      * @param maxRecords the maximum number of records to deliver. -1 means no limit.
      * @return a stream of records after the given mTime.
      */
-    Stream<DsRecordDto> getDSRecords(String origin, long mTime, long maxRecords);
+    ContinuationStream<DsRecordDto, Long> getDSRecords(String origin, long mTime, long maxRecords);
 
-    Stream<DsRecordDto> getDSRecordsByRecordTypeLocalTree(String origin, RecordTypeDto recordType, long mTime, long maxRecords);
+    ContinuationStream<DsRecordDto, Long> getDSRecordsByRecordTypeLocalTree(String origin, RecordTypeDto recordType, long mTime, long maxRecords);
 
 }

--- a/src/main/java/dk/kb/present/util/DsPresentClient.java
+++ b/src/main/java/dk/kb/present/util/DsPresentClient.java
@@ -14,13 +14,19 @@
  */
 package dk.kb.present.util;
 
+import dk.kb.present.client.v1.ServiceApi;
 import dk.kb.present.client.v1.DsPresentApi;
 import dk.kb.present.client.v1.IiifPresentationApi;
 import dk.kb.present.invoker.v1.ApiClient;
 import dk.kb.present.invoker.v1.Configuration;
+import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.util.webservice.stream.ContinuationInputStream;
+import dk.kb.util.webservice.stream.ContinuationStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.core.UriBuilder;
+import java.io.IOException;
 import java.net.URI;
 
 /**
@@ -36,19 +42,37 @@ import java.net.URI;
  */
 public class DsPresentClient extends DsPresentApi {
     private static final Logger log = LoggerFactory.getLogger(DsPresentClient.class);
+    private final String serviceURI;
+
+    public static final String PRESENT_SERVER_URL_KEY = ".config.present.url";
 
     /**
      * Sub-client for the IIIF endpoints.
      */
     public final IiifPresentationApi iiif;
+    /**
+     * Sub-client for the service endpoints.
+     */
+    public final ServiceApi service;
 
     /**
-     * Creates a client for the service.
+     * Creates a client for the remote ds-present service.
+     * <p>
+     * When working with YAML configs, it is suggested to define the ds-present URI as the structure
+     * <pre>
+     * config:
+     *   storage:
+     *     url: 'http://localhost:9073/ds-storage/v1'
+     * </pre>
+     * Then use the path {@link #PRESENT_SERVER_URL_KEY} to extract the URL.
      * @param serviceURI the URI for the service, e.g. {@code https://example.com/ds-present/v1}.
      */
+    @SuppressWarnings("JavadocLinkAsPlainText")
     public DsPresentClient(String serviceURI) {
         super(createClient(serviceURI));
+        this.serviceURI = serviceURI;
         iiif = new IiifPresentationApi(createClient(serviceURI));
+        service = new ServiceApi(createClient(serviceURI));
         log.info("Created OpenAPI client for '" + serviceURI + "'");
     }
 
@@ -68,4 +92,80 @@ public class DsPresentClient extends DsPresentApi {
                 setPort(serviceURI.getPort()).
                 setBasePath(serviceURI.getRawPath());
     }
+
+    /**
+     * Call the remote ds-present {@link #getRecords} and return the response unchanged as a wrapped
+     * bytestream. The concrete representation of the content is controlled by {@code format}.
+     * <p>
+     * Important: Ensure that the returned stream is closed to avoid resource leaks.
+     * @param origin     the origin for the records.
+     * @param mTime      exclusive start time for records to deliver:
+     *                   Epoch time in microseconds (milliseconds times 1000).
+     * @param maxRecords the maximum number of records to deliver. -1 means no limit.
+     * @param format     the format for the records. Valid formats are {@code }
+     * @return a raw bytestream with the response from the remote ds-present.
+     * @throws IOException if the connection to the remote ds-present failed.
+     */
+    public ContinuationInputStream<Long> getRecordsJSON(String origin, Long mTime, Long maxRecords, String format)
+            throws IOException {
+        URI uri = UriBuilder.fromUri(serviceURI)
+                .path("records")
+                .queryParam("origin", origin)
+                .queryParam("mTime", mTime == null ? 0L : mTime)
+                .queryParam("maxRecords", maxRecords == null ? 10 : maxRecords)
+                .queryParam("format", format)
+                .build();
+        log.debug("Opening streaming connection to '{}'", uri);
+        return ContinuationInputStream.from(uri, Long::valueOf);
+    }
+
+    /**
+     * Call the remote ds-present {@link #getRecordsRaw} and return the JSON serialised
+     * {@link dk.kb.storage.model.v1.DsRecordDto}s unchanged as a wrapped bytestream.
+     * The concrete JSON representation is controlled by {@code asJsonLines}.
+     * <p>
+     * Important: Ensure that the returned stream is closed to avoid resource leaks.
+     * @param origin      the origin for the records.
+     * @param mTime       exclusive start time for records to deliver:
+     *                    Epoch time in microseconds (milliseconds times 1000).
+     * @param maxRecords  the maximum number of records to deliver. -1 means no limit.
+     * @param asJsonLines if true, the {@link dk.kb.storage.model.v1.DsRecordDto} JSON entries are represented in
+     *                    JSON-Lines format (one record/line, inly linebreak as divider). If false, the entries
+     *                    are represented in a single JSON array.
+     * @return a raw bytestream with the JSON or JSON_Lines response from the remote ds-present.
+     * @throws IOException if the connection to the remote ds-present failed.
+     */
+    public ContinuationInputStream<Long> getRecordsRawJSON(
+            String origin, Long mTime, Long maxRecords, Boolean asJsonLines) throws IOException {
+        URI uri = UriBuilder.fromUri(serviceURI)
+                .path("recordsraw")
+                .queryParam("origin", origin)
+                .queryParam("mTime", mTime == null ? 0L : mTime)
+                .queryParam("maxRecords", maxRecords == null ? 10 : maxRecords)
+                .queryParam("asJsonLines", asJsonLines != null && asJsonLines)
+                .build();
+        log.debug("Opening streaming connection to '{}'", uri);
+        return ContinuationInputStream.from(uri, Long::valueOf);
+    }
+
+    /**
+     * Call the remote ds-storage {@link #getRecordsRaw} and return the response in the form of a Stream of records.
+     * <p>
+     * The stream is unbounded by memory and gives access to the highest modification time (microseconds since
+     * Epoch 1970) for any record that will be delivered by the stream {@link ContinuationStream#getContinuationToken}.
+     * <p>
+     * Important: Ensure that the returned stream is closed to avoid resource leaks.
+     * @param origin      the origin for the records.
+     * @param mTime       exclusive start time for records to deliver:
+     *                    Epoch time in microseconds (milliseconds times 1000).
+     * @param maxRecords  the maximum number of records to deliver. -1 means no limit.
+     * @return a stream of records from the remote ds-storage.
+     * @throws IOException if the connection to the remote ds-storage failed.
+     */
+    public ContinuationStream<DsRecordDto, Long> getRecordsRawStream(
+            String origin, Long mTime, Long maxRecords) throws IOException {
+        return getRecordsRawJSON(origin, mTime, maxRecords, false)
+                .stream(DsRecordDto.class);
+    }
+
 }

--- a/src/test/java/dk/kb/present/util/DsPresentClientTest.java
+++ b/src/test/java/dk/kb/present/util/DsPresentClientTest.java
@@ -14,15 +14,39 @@
  */
 package dk.kb.present.util;
 
+import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.util.webservice.stream.ContinuationInputStream;
+import dk.kb.util.webservice.stream.ContinuationStream;
+import dk.kb.util.webservice.stream.ContinuationUtil;
+import dk.kb.util.yaml.YAML;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Simple verification of client code generation.
  */
 public class DsPresentClientTest {
     private static final Logger log = LoggerFactory.getLogger(DsPresentClientTest.class);
+
+    public static final String TEST_CONF = "internal-test-setup.yaml";
+
+    private static DsPresentClient remote = null;
+
+    @BeforeAll
+    public static void beforeClass() {
+        remote = getRemote();
+    }
 
     // We cannot test usage as that would require a running instance of ds-present to connect to
     @Test
@@ -31,4 +55,70 @@ public class DsPresentClientTest {
         log.debug("Creating inactive client for ds-present with URI '{}'", backendURIString);
         new DsPresentClient(backendURIString);
     }
+
+    @Test
+    public void testRemoteRecordsRaw() throws IOException {
+        if (remote == null) {
+            return;
+        }
+        try (ContinuationInputStream<Long> recordsIS = remote.getRecordsJSON(
+                "ds.radiotv", 0L, 3L, "JSON-LD")) {
+            String recordsStr = IOUtils.toString(recordsIS, StandardCharsets.UTF_8);
+            assertTrue(recordsStr.contains("\"id\":\"ds.radiotv:oai"),
+                    "At least 1 JSON block for a record should be returned");
+            assertNotNull(recordsIS.getContinuationToken(),
+                    "The continuation header '" + ContinuationUtil.HEADER_PAGING_CONTINUATION_TOKEN +
+                            "' should be present");
+            assertTrue(ContinuationUtil.getHasMore(recordsIS).isPresent(),
+                       "The continuation header '" + ContinuationUtil.HEADER_PAGING_HAS_MORE + "' should be present");
+        }
+    }
+
+    @Test
+    public void testRemoteRecordsStream() throws IOException {
+       if (remote == null) {
+            return;
+        }
+        try (ContinuationStream<DsRecordDto, Long> records = remote.getRecordsRawStream("ds.radiotv", 0L, 3L)) {
+            List<DsRecordDto> recordList = records.collect(Collectors.toList());
+
+            assertEquals(3L, recordList.size(), "The requested number of records should be received");
+            assertNotNull(records.getContinuationToken(),
+                    "The highest modification time should be present");
+            log.debug("Stated highest modification time was " + records.getContinuationToken());
+            assertEquals(recordList.get(recordList.size()-1).getmTime(),
+                         records.getContinuationToken(),
+                    "Received highest mTime should match stated highest mTime");
+        }
+    }
+
+    /**
+     * @return a {@link DsPresentClient} if a KB-internal remote storage is specified and is available.
+     */
+    private static DsPresentClient getRemote() {
+        YAML config;
+        try {
+            config = YAML.resolveLayeredConfigs(TEST_CONF);
+        } catch (Exception e) {
+            log.info("Unable to resolve '{}' (try running 'kb init'). Skipping test", TEST_CONF);
+            return null;
+        }
+        String presentURL = config.getString(DsPresentClient.PRESENT_SERVER_URL_KEY, null);
+        if (presentURL == null) {
+            log.info("Resolved internal config '{}' but could not retrieve a value for key '{}'. Skipping test",
+                    TEST_CONF, DsPresentClient.PRESENT_SERVER_URL_KEY);
+            return null;
+        }
+        DsPresentClient client = new DsPresentClient(presentURL);
+        try {
+            client.service.status(); // We cannot use ping as it does not return JSON. This is a problem!
+        } catch (Exception e) {
+            log.debug("Exc", e);
+            log.info("Found ds-storage address '{}' but could not establish contact. Skipping test", presentURL);
+            return null;
+        }
+        log.debug("Established connection to remote ds-present at '{}'", presentURL);
+        return client;
+    }
+
 }


### PR DESCRIPTION
Adding continuation stream support to `ds-present` was not trivial as `ds-present` has its own storage abstraction (primarily to support testing) which had do be adjusted to deliver continuation data. This was not possible for `MultiStorage`, which we do not currently use.
As with`ds-storage`, integration tests has been added (see `DsPresentClientTest`). These rely on a matching `ds-present` being deployed on the devel server (this has been done) and on on a `kb init`.