### PR TITLE
Improve stopOnError

### DIFF
--- a/src/main/java/dk/kb/present/DSOrigin.java
+++ b/src/main/java/dk/kb/present/DSOrigin.java
@@ -262,7 +262,8 @@ public class DSOrigin {
                     throw new RuntimeTransformerException(
                             "Exception transforming record '" + record.getId() + "' to format '" + format + "'");
                 } else {
-                    log.warn("Exception transforming record '" + record.getId() + "' to format '" + format + "'", e);
+                    log.warn("Non-critical Exception transforming record '{}' to format '{}'. " +
+                            "Overall processing will continue as stopOnError=", record.getId(), format, e);
                     return null;
                 }
             }

--- a/src/test/java/dk/kb/present/PresentFacadeTest.java
+++ b/src/test/java/dk/kb/present/PresentFacadeTest.java
@@ -167,28 +167,6 @@ public class PresentFacadeTest {
         assertFalse(result.endsWith("]\n"), "Result should not end with ']' as it should be in JSON-Lin es");
     }
 
-    /* TODO: FIX!
-    //   Can only be fixed, when the updated XSLT to JSON-LD has been reviewed and merged to master
-    @Test
-    void getRecordsJSONLD() throws IOException {
-        StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "json-ld");
-        String result = toString(out);
-        System.out.println(result);
-        //assertTrue(result.contains("\"@value\":\"Letters to\\/from David Simonsen\"}"), "Result should contain the name David Simonsen in the expected wrapping");
-        assertTrue(result.contains(",\n"), "Result should contain a comma followed by newline as it should be a multi-entry JSON array"); // Plain JSON array
-        assertTrue(result.endsWith("]\n"), "Result should end with ']' as it should be a JSON array"); // JSON array
-    }
-     */
-
-    @Test
-    void getRecordsJSONLDLines() throws IOException {
-        StreamingOutput out = PresentFacade.getRecords(null, "dsfl", 0L, -1L, "json-ld-lines", ids -> ids);
-        String result = toString(out);
-        assertTrue(result.contains("\"@value\":\"Letters to\\/from David Simonsen\"}"), "Result should contain the name David Simonsen in the expected wrapping");
-        assertFalse(result.contains(",\n"), "Result should not contain a comma followed by newline as it should be a multi-entry JSON-Lines");
-        assertFalse(result.endsWith("]\n"), "Result should not end with ']' as it should be in JSON-Lin es");
-    }
-
     @Test
     void getRecordsSolr() throws IOException {
         if (Resolver.getPathFromClasspath("internal_test_files") == null){

--- a/src/test/resources/test_setup.yaml
+++ b/src/test/resources/test_setup.yaml
@@ -8,6 +8,11 @@ config:
     url: http://example.com
     allowall: false
 
+
+  records:
+    # Default is true, so set to false here to check via debugging
+    stoponerrors: false
+
   # Only some of the sample files can be properly transformed to SolrJSONDocuments
   filewhitelist: &whitelist
      - '.*albert-einstein.xml'


### PR DESCRIPTION
The old handling of single record transformation errors was poorly implemented, both regarding code logic and log message. This pull request cleans up the code and makes it explicit in the log that the error is not fatal.