### PR TITLE
Disc 540 remove empty map

### DIFF
--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -172,13 +172,22 @@
       <!-- Extract manifestation -->
       <xsl:call-template name="extract-manifestation"/>
 
-      <f:map key="kb:internal">
-      <!-- Transforms values that does not fit directly into Schema.org into an internal map. -->
-        <xsl:call-template name="kb-internal">
-          <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-          <xsl:with-param name="type" select="$type"/>
-        </xsl:call-template>
-      </f:map>
+      <!-- Checking for PBCore Extensions as most values in the internal map are defined as extensions. -->
+      <!--<xsl:if test="$pbcExtensions != ''">-->
+        <f:string key="exists">
+          <xsl:value-of select="my:doesInternalMapExist($pbcExtensions, '/')"/>
+        </f:string>
+
+        <f:map key="kb:internal">
+        <!-- Transforms values that does not fit directly into Schema.org into an internal map. -->
+          <xsl:call-template name="kb-internal">
+            <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+            <xsl:with-param name="type" select="$type"/>
+          </xsl:call-template>
+        </f:map>
+<!--
+      </xsl:if>
+-->
 
     </f:map>
   </xsl:template>
@@ -876,5 +885,19 @@
 
 
   </xsl:template>
+
+  <xsl:function name="my:doesInternalMapExist" as="xs:boolean">
+    <xsl:param name="rootElement"/>
+    <xsl:param name="pbcExtensions"/>
+    <xsl:value-of select="$rootElement/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreGenre/genre != '' or
+                          $rootElement/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatChannelConfiguration != '' or
+                          $pbcExtensions != '' or
+                          $rootElement/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreFormatID != '' or
+                          $rootElement/xip:DeliverableUnit/Metadata/padding:padding/paddingSeconds != '' or
+                          $rootElement/xip:DeliverableUnit/Metadata/access:access != '' or
+                          $rootElement/xip:DeliverableUnit/Metadata/program_structure:program_structure != ''
+                          "/>
+
+  </xsl:function>
 
 </xsl:transform>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -881,6 +881,7 @@
 
   </xsl:template>
 
+  <!-- Specific function which checks for existence of any internal field in the incoming XML document. -->
   <xsl:function name="my:doesInternalMapExist" as="xs:boolean">
     <xsl:param name="rootElement"/>
     <xsl:param name="pbcExtensions"/>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -172,12 +172,8 @@
       <!-- Extract manifestation -->
       <xsl:call-template name="extract-manifestation"/>
 
-      <!-- Checking for PBCore Extensions as most values in the internal map are defined as extensions. -->
-      <!--<xsl:if test="$pbcExtensions != ''">-->
-        <f:string key="exists">
-          <xsl:value-of select="my:doesInternalMapExist($pbcExtensions, '/')"/>
-        </f:string>
-
+      <!-- If type is MediaObject we don't create the internal map. -->
+      <xsl:if test="$type != 'MediaObject'">
         <f:map key="kb:internal">
         <!-- Transforms values that does not fit directly into Schema.org into an internal map. -->
           <xsl:call-template name="kb-internal">
@@ -185,9 +181,8 @@
             <xsl:with-param name="type" select="$type"/>
           </xsl:call-template>
         </f:map>
-<!--
       </xsl:if>
--->
+
 
     </f:map>
   </xsl:template>
@@ -889,14 +884,21 @@
   <xsl:function name="my:doesInternalMapExist" as="xs:boolean">
     <xsl:param name="rootElement"/>
     <xsl:param name="pbcExtensions"/>
-    <xsl:value-of select="$rootElement/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreGenre/genre != '' or
-                          $rootElement/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatChannelConfiguration != '' or
-                          $pbcExtensions != '' or
-                          $rootElement/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreFormatID != '' or
-                          $rootElement/xip:DeliverableUnit/Metadata/padding:padding/paddingSeconds != '' or
-                          $rootElement/xip:DeliverableUnit/Metadata/access:access != '' or
-                          $rootElement/xip:DeliverableUnit/Metadata/program_structure:program_structure != ''
-                          "/>
+    <xsl:value-of select="f:contains($rootElement/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreGenre/genre, 'undergenre:' ) or
+                          f:contains($rootElement/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatChannelConfiguration, 'surround') or
+                          $rootElement/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreFormatID/formatIdentifierSource = 'ritzau' or
+                          $rootElement/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreFormatID/formatIdentifierSource = 'nielsen' or
+                          $rootElement/xip:DeliverableUnit/Metadata/padding:padding/paddingSeconds or
+                          $rootElement/xip:DeliverableUnit/Metadata/access:access/individuelt_forbud or
+                          $rootElement/xip:DeliverableUnit/Metadata/access:access/klausuleret or
+                          $rootElement/xip:DeliverableUnit/Metadata/access:access/defekt or
+                          $rootElement/xip:DeliverableUnit/Metadata/access:access/kommentarer != '' or
+                          $rootElement/xip:DeliverableUnit/Metadata/program_structure:program_structure != '' or
+                          $pbcExtensions[f:contains(., 'premiere')] or
+                          $pbcExtensions[f:contains(., 'genudsendelse')] or
+                          $pbcExtensions[f:contains(., 'id')] or
+                          $pbcExtensions[f:contains(., 'program')]
+                      "/>
 
   </xsl:function>
 

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -489,26 +489,13 @@
 
 
     <xsl:variable name="array1" select="my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap')" as="item()*"/>
-
-    <xsl:choose>
-      <xsl:when test="f:exists($array1[1])">
-        <f:string key="testArrayBool"><xsl:value-of select="map:get($array1[1], 'file1UUID')"/></f:string>
-      </xsl:when>
-      <xsl:when test="not(f:exists($array1['test']))">
-        <f:string key="testArrayBool"><xsl:value-of select="false()"/></f:string>
-      </xsl:when>
-      <xsl:otherwise>
-        <f:string key="testArrayBool"><xsl:value-of select="'nopenopenope'"/></f:string>
-      </xsl:otherwise>
-    </xsl:choose>
-
     <!-- Overlaps are hard to extract to solr as they are tricky to represent in a flat JSON structure where each key
          has a unique name. -->
     <xsl:if test="f:exists($array1[1])">
       <f:array key="internal_overlapping_files">
         <xsl:for-each select="$array1">
           <f:string>
-            <xsl:value-of select="concat(map:get(., 'file1UUID'), ', ', map:get(., 'file2UUID'))"/>
+            <xsl:value-of select="concat(map:get(., 'file1UUID'), ',', map:get(., 'file2UUID'))"/>
           </f:string>
         </xsl:for-each>
       </f:array>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -488,12 +488,12 @@
     </xsl:if>
 
 
-    <xsl:variable name="array1" select="my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap')" as="item()*"/>
+    <xsl:variable name="overlapsArray" select="my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap')" as="item()*"/>
     <!-- Overlaps are hard to extract to solr as they are tricky to represent in a flat JSON structure where each key
          has a unique name. -->
-    <xsl:if test="f:exists($array1[1])">
+    <xsl:if test="f:exists($overlapsArray[1]) and $overlapsArray[1] != ''">
       <f:array key="internal_overlapping_files">
-        <xsl:for-each select="$array1">
+        <xsl:for-each select="$overlapsArray">
           <f:string>
             <xsl:value-of select="concat(map:get(., 'file1UUID'), ',', map:get(., 'file2UUID'))"/>
           </f:string>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -207,9 +207,9 @@
           </xsl:if>
 
           <!-- Extract color boolean-->
-          <xsl:if test="f:exists(map:get($schemaorg-xml('kb:internal'),'kb:color'))">
+          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:color') != ''">
             <f:string key="color">
-              <xsl:value-of select="map:get($schemaorg-xml('kb:internal'),'kb:color')"/>
+              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:color') "/>
             </f:string>
           </xsl:if>
 
@@ -221,23 +221,23 @@
           </xsl:if>
 
           <!-- Extract surround sound-->
-          <xsl:if test="f:exists(map:get($schemaorg-xml('kb:internal'),'kb:surround_sound'))">
+        <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:surround_sound') != ''">
             <f:string key="surround_sound">
-              <xsl:value-of select="map:get($schemaorg-xml('kb:internal'),'kb:surround_sound')"/>
+              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:surround_sound')"/>
             </f:string>
           </xsl:if>
 
           <!-- Extract premiere-->
-          <xsl:if test="f:exists(map:get($schemaorg-xml('kb:internal'), 'kb:premiere'))">
+        <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:premiere') != ''">
             <f:string key="premiere">
-              <xsl:value-of select="$schemaorg-xml('kb:internal')('kb:premiere')"/>
+              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:premiere')"/>
             </f:string>
           </xsl:if>
 
           <!-- Extract aspect ratio-->
-          <xsl:if test="f:exists(map:get($schemaorg-xml('kb:internal'), 'kb:aspect_ratio'))">
+        <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio') != ''">
             <f:string key="aspect_ratio">
-              <xsl:value-of select="$schemaorg-xml('kb:internal')('kb:aspect_ratio')"/>
+              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio')"/>
             </f:string>
           </xsl:if>
 
@@ -251,9 +251,9 @@
           </xsl:if>
 
           <!-- Extract boolean for retransmission -->
-          <xsl:if test="f:exists($schemaorg-xml('kb:internal')('kb:retransmission'))">
+          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:retransmission')">
             <f:string key="retransmission">
-              <xsl:value-of select="($schemaorg-xml('kb:internal')('kb:retransmission'))"/>
+              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:retransmission')"/>
             </f:string>
           </xsl:if>
 
@@ -272,23 +272,25 @@
           </xsl:if>
 
           <!-- Extract sub genre -->
-          <xsl:if test="f:exists($schemaorg-xml('kb:internal')('kb:genre_sub'))">
+          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:genre_sub')">
             <f:string key="genre_sub">
-              <xsl:value-of select="$schemaorg-xml('kb:internal')('kb:genre_sub')"/>
+              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:genre_sub')"/>
             </f:string>
           </xsl:if>
 
           <!-- Extract boolean for subtitles -->
-          <xsl:if test="f:exists($schemaorg-xml('kb:internal')('kb:has_subtitles'))">
+          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:has_subtitles')">
             <f:string key="has_subtitles">
-              <xsl:value-of select="$schemaorg-xml('kb:internal')('kb:has_subtitles')"/>
+              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:has_subtitles')"/>
             </f:string>
           </xsl:if>
 
           <!-- Extract boolean for subtitles for hearing impaired  -->
-          <xsl:if test="f:exists($schemaorg-xml('kb:internal')('kb:has_subtitles_for_hearing_impaired'))">
+          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal',
+                                                    'kb:has_subtitles_for_hearing_impaired')">
             <f:string key="has_subtitles_for_hearing_impaired">
-              <xsl:value-of select="$schemaorg-xml('kb:internal')('kb:has_subtitles_for_hearing_impaired')"/>
+              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal',
+                                                                'kb:has_subtitles_for_hearing_impaired')"/>
             </f:string>
           </xsl:if>
 
@@ -352,149 +354,147 @@
   <xsl:template name="kbInternal">
     <xsl:param name="internalMap"/>
 
-    <xsl:if test="f:exists($internalMap('kb:format_identifier_ritzau'))">
+
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:format_identifier_ritzau') != ''">
       <f:string key="internal_format_identifier_ritzau">
-        <xsl:value-of select="$internalMap('kb:format_identifier_ritzau')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:format_identifier_ritzau')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:format_identifier_nielsen'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:format_identifier_nielsen') != ''">
       <f:string key="internal_format_identifier_nielsen">
-        <xsl:value-of select="$internalMap('kb:format_identifier_nielsen')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:format_identifier_nielsen')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:maingenre_id'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:maingenre_id') != ''">
       <f:string key="internal_maingenre_id">
-        <xsl:value-of select="$internalMap('kb:maingenre_id')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:maingenre_id')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:channel_id'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:channel_id') != ''">
       <f:string key="internal_channel_id">
-        <xsl:value-of select="$internalMap('kb:channel_id')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:channel_id')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:country_of_origin_id'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:country_of_origin_id') != ''">
       <f:string key="internal_country_of_origin_id">
-        <xsl:value-of select="$internalMap('kb:country_of_origin_id')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:country_of_origin_id')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:ritzau_program_id'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:ritzau_program_id') != ''">
       <f:string key="internal_ritzau_program_id">
-        <xsl:value-of select="$internalMap('kb:ritzau_program_id')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:ritzau_program_id')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:subgenre_id'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:subgenre_id') != ''">
       <f:string key="internal_subgenre_id">
-        <xsl:value-of select="$internalMap('kb:subgenre_id')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:subgenre_id')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:episode_id'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:episode_id') != ''">
       <f:string key="internal_episode_id">
-        <xsl:value-of select="$internalMap('kb:episode_id')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:episode_id')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:season_id'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:season_id') != ''">
       <f:string key="internal_season_id">
-        <xsl:value-of select="$internalMap('kb:season_id')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:season_id')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:series_id'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:series_id') != ''">
       <f:string key="internal_series_id">
-        <xsl:value-of select="$internalMap('kb:series_id')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:series_id')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:program_ophold'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:program_ophold') != ''">
       <f:string key="internal_program_ophold">
-        <xsl:value-of select="$internalMap('kb:program_ophold')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:program_ophold')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:is_teletext'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:is_teletext') != ''">
       <f:string key="internal_is_teletext">
-        <xsl:value-of select="$internalMap('kb:is_teletext')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:is_teletext')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:showviewcode'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:showviewcode') != ''">
       <f:string key="internal_showviewcode">
-        <xsl:value-of select="$internalMap('kb:showviewcode')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:showviewcode')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:padding_seconds'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:padding_seconds') != ''">
       <f:string key="internal_padding_seconds">
-        <xsl:value-of select="$internalMap('kb:padding_seconds')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:padding_seconds')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:access_individual_prohibition'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:access_individual_prohibition') != ''">
       <f:string key="internal_access_individual_prohibition">
-        <xsl:value-of select="$internalMap('kb:access_individual_prohibition')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:access_individual_prohibition')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:access_claused'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:access_claused') != ''">
       <f:string key="internal_access_claused">
-        <xsl:value-of select="$internalMap('kb:access_claused')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:access_claused')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:access_malfunction'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:access_malfunction') != ''">
       <f:string key="internal_access_malfunction">
-        <xsl:value-of select="$internalMap('kb:access_malfunction')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:access_malfunction')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:access_comments'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:access_comments') != ''">
       <f:string key="internal_access_comments">
-        <xsl:value-of select="$internalMap('kb:access_comments')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:access_comments')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:program_structure_missing_seconds_start'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:program_structure_missing_seconds_start') != ''">
       <f:string key="internal_program_structure_missing_seconds_start">
-        <xsl:value-of select="$internalMap('kb:program_structure_missing_seconds_start')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:program_structure_missing_seconds_start')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:program_structure_missing_seconds_end'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:program_structure_missing_seconds_end') != ''">
       <f:string key="internal_program_structure_missing_seconds_end">
-        <xsl:value-of select="$internalMap('kb:program_structure_missing_seconds_end')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:program_structure_missing_seconds_end')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:program_structure_holes'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:program_structure_holes') != ''">
       <f:string key="internal_program_structure_holes">
-        <xsl:value-of select="$internalMap('kb:program_structure_holes')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:program_structure_holes')"/>
       </f:string>
     </xsl:if>
 
-    <xsl:if test="f:exists($internalMap('kb:program_structure_overlaps'))">
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlaps') != ''">
       <f:string key="internal_program_structure_overlaps">
-        <xsl:value-of select="$internalMap('kb:program_structure_overlaps')"/>
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlaps')"/>
       </f:string>
     </xsl:if>
 
     <!-- Overlaps are hard to extract to solr as they are tricky to represent in a flat JSON structure where each key
          has a unique name. -->
-    <xsl:if test="f:exists($internalMap('kb:program_structure_overlap'))">
-      <xsl:variable name="overlapsArray" as="item()*">
-        <xsl:copy-of select="array:flatten($internalMap('kb:program_structure_overlap'))"/>
-      </xsl:variable>
-
+    <xsl:if test="not(f:empty(my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap'))) and
+                  my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap') != '' ">
       <f:array key="internal_overlapping_files">
-        <xsl:for-each select="$overlapsArray">
+        <xsl:for-each select="my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap')">
           <f:string>
-            <xsl:value-of select="concat(map:get(., 'file1UUID'), ',', map:get(., 'file2UUID'))"/>
+            <xsl:value-of select="concat(map:get(., 'file1UUID'), ', ', map:get(., 'file2UUID'))"/>
           </f:string>
         </xsl:for-each>
       </f:array>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -489,8 +489,7 @@
 
     <!-- Overlaps are hard to extract to solr as they are tricky to represent in a flat JSON structure where each key
          has a unique name. -->
-    <xsl:if test="not(f:empty(my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap'))) and
-                  my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap') != '' ">
+    <xsl:if test="not(f:empty(my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap'))) ">
       <f:array key="internal_overlapping_files">
         <xsl:for-each select="my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap')">
           <f:string>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -487,11 +487,26 @@
       </f:string>
     </xsl:if>
 
+
+    <xsl:variable name="array1" select="my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap')" as="item()*"/>
+
+    <xsl:choose>
+      <xsl:when test="f:exists($array1[1])">
+        <f:string key="testArrayBool"><xsl:value-of select="map:get($array1[1], 'file1UUID')"/></f:string>
+      </xsl:when>
+      <xsl:when test="not(f:exists($array1['test']))">
+        <f:string key="testArrayBool"><xsl:value-of select="false()"/></f:string>
+      </xsl:when>
+      <xsl:otherwise>
+        <f:string key="testArrayBool"><xsl:value-of select="'nopenopenope'"/></f:string>
+      </xsl:otherwise>
+    </xsl:choose>
+
     <!-- Overlaps are hard to extract to solr as they are tricky to represent in a flat JSON structure where each key
          has a unique name. -->
-    <xsl:if test="not(f:empty(my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap'))) ">
+    <xsl:if test="f:exists($array1[1])">
       <f:array key="internal_overlapping_files">
-        <xsl:for-each select="my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap')">
+        <xsl:for-each select="$array1">
           <f:string>
             <xsl:value-of select="concat(map:get(., 'file1UUID'), ', ', map:get(., 'file2UUID'))"/>
           </f:string>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -491,7 +491,7 @@
     <xsl:variable name="overlapsArray" select="my:getArrayFromNestedMap($schemaorg-xml, 'kb:internal', 'kb:program_structure_overlap')" as="item()*"/>
     <!-- Overlaps are hard to extract to solr as they are tricky to represent in a flat JSON structure where each key
          has a unique name. -->
-    <xsl:if test="f:exists($overlapsArray[1]) and $overlapsArray[1] != ''">
+    <xsl:if test="f:exists($overlapsArray[1]) and not(map:contains($overlapsArray[1], 'empty')) ">
       <f:array key="internal_overlapping_files">
         <xsl:for-each select="$overlapsArray">
           <f:string>

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -16,15 +16,15 @@
     <xsl:value-of select="($endDate - $startDate) div xs:dayTimeDuration('PT0.001S')"/>
   </xsl:function>
 
-  <xsl:function name="my:getArrayFromNestedMap">
+  <xsl:function name="my:getArrayFromNestedMap" as="item()*">
     <xsl:param name="object"/>
     <xsl:param name="map1"/>
     <xsl:param name="array"/>
     <xsl:choose>
-      <xsl:when test="f:empty($object)"><xsl:value-of select="''"/></xsl:when>
-      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:value-of select="''"/></xsl:when>
-      <xsl:when test="f:empty(map:get(map:get($object, $map1), $array))"><xsl:value-of select="''"/></xsl:when>
-      <xsl:otherwise> <xsl:copy-of select="array:flatten(map:get(map:get($object, $map1), $array))"/></xsl:otherwise>
+      <xsl:when test="f:empty($object)"><xsl:sequence select="map:entry('empty', 'empty')"/></xsl:when>
+      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:sequence select="map:entry('empty', 'empty')"/></xsl:when>
+      <xsl:when test="f:empty(map:get(map:get($object, $map1), $array))"><xsl:sequence select="map:entry('empty', 'empty')"/></xsl:when>
+      <xsl:otherwise><xsl:copy-of select="array:flatten(map:get(map:get($object, $map1), $array))"/></xsl:otherwise>
     </xsl:choose>
   </xsl:function>
 
@@ -35,9 +35,9 @@
     <xsl:param name="map1"/>
     <xsl:param name="map2"/>
     <xsl:choose>
-      <xsl:when test="f:empty($object)"><xsl:value-of select="('empty', 'empty')"/></xsl:when>
-      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:value-of select="('empty', 'empty')"/></xsl:when>
-      <xsl:when test="f:empty(map:get(map:get($object, $map1), $map2))"><xsl:value-of select="('empty', 'empty')"/></xsl:when>
+      <xsl:when test="f:empty($object)"><xsl:value-of select="''"/></xsl:when>
+      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:value-of select="''"/></xsl:when>
+      <xsl:when test="f:empty(map:get(map:get($object, $map1), $map2))"><xsl:value-of select="''"/></xsl:when>
       <xsl:otherwise> <xsl:value-of select="map:get(map:get($object, $map1),$map2)"/></xsl:otherwise>
     </xsl:choose>
   </xsl:function>

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -8,6 +8,13 @@
                 xmlns:my="urn:my"
                 version="3.0">
 
+  <!-- Empty map used as return variable for functions-->
+  <xsl:param name="emptyMap" as="map(*)">
+    <xsl:map>
+      <xsl:map-entry key="'empty'" select="''"/>
+    </xsl:map>
+  </xsl:param>
+
   <!-- FUNCTIONS -->
   <!-- Get milliseconds between two datetimes. -->
   <xsl:function name="my:toMilliseconds" as="xs:integer">
@@ -22,9 +29,9 @@
     <xsl:param name="map1"/>
     <xsl:param name="array"/>
     <xsl:choose>
-      <xsl:when test="f:empty($object)"><xsl:sequence select="''"/></xsl:when>
-      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:sequence select="''"/></xsl:when>
-      <xsl:when test="f:empty(map:get(map:get($object, $map1), $array))"><xsl:sequence select="''"/></xsl:when>
+      <xsl:when test="f:empty($object)"><xsl:sequence select="$emptyMap"/></xsl:when>
+      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:sequence select="$emptyMap"/></xsl:when>
+      <xsl:when test="f:empty(map:get(map:get($object, $map1), $array))"><xsl:sequence select="$emptyMap"/></xsl:when>
       <xsl:otherwise><xsl:copy-of select="array:flatten(map:get(map:get($object, $map1), $array))"/></xsl:otherwise>
     </xsl:choose>
   </xsl:function>

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -35,9 +35,9 @@
     <xsl:param name="map1"/>
     <xsl:param name="map2"/>
     <xsl:choose>
-      <xsl:when test="f:empty($object)"><xsl:value-of select="''"/></xsl:when>
-      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:value-of select="''"/></xsl:when>
-      <xsl:when test="f:empty(map:get(map:get($object, $map1), $map2))"><xsl:value-of select="''"/></xsl:when>
+      <xsl:when test="f:empty($object)"><xsl:value-of select="('empty', 'empty')"/></xsl:when>
+      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:value-of select="('empty', 'empty')"/></xsl:when>
+      <xsl:when test="f:empty(map:get(map:get($object, $map1), $map2))"><xsl:value-of select="('empty', 'empty')"/></xsl:when>
       <xsl:otherwise> <xsl:value-of select="map:get(map:get($object, $map1),$map2)"/></xsl:otherwise>
     </xsl:choose>
   </xsl:function>

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -16,6 +16,18 @@
     <xsl:value-of select="($endDate - $startDate) div xs:dayTimeDuration('PT0.001S')"/>
   </xsl:function>
 
+  <xsl:function name="my:getArrayFromNestedMap">
+    <xsl:param name="object"/>
+    <xsl:param name="map1"/>
+    <xsl:param name="array"/>
+    <xsl:choose>
+      <xsl:when test="f:empty($object)"><xsl:value-of select="''"/></xsl:when>
+      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:value-of select="''"/></xsl:when>
+      <xsl:when test="f:empty(map:get(map:get($object, $map1), $array))"><xsl:value-of select="''"/></xsl:when>
+      <xsl:otherwise> <xsl:copy-of select="array:flatten(map:get(map:get($object, $map1), $array))"/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+
   <!-- Get a value from a nested JSON map. The function checks that each level of the map isn't empty.
        If the map is empty, an empty string will be returned.-->
   <xsl:function name="my:getNestedMapValue2Levels">

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -16,14 +16,15 @@
     <xsl:value-of select="($endDate - $startDate) div xs:dayTimeDuration('PT0.001S')"/>
   </xsl:function>
 
+  <!-- Get the objects from inside a nested array flattened. If the array doesn't exist an empty string will be returned. -->
   <xsl:function name="my:getArrayFromNestedMap" as="item()*">
     <xsl:param name="object"/>
     <xsl:param name="map1"/>
     <xsl:param name="array"/>
     <xsl:choose>
-      <xsl:when test="f:empty($object)"><xsl:sequence select="map:entry('empty', 'empty')"/></xsl:when>
-      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:sequence select="map:entry('empty', 'empty')"/></xsl:when>
-      <xsl:when test="f:empty(map:get(map:get($object, $map1), $array))"><xsl:sequence select="map:entry('empty', 'empty')"/></xsl:when>
+      <xsl:when test="f:empty($object)"><xsl:sequence select="''"/></xsl:when>
+      <xsl:when test="f:empty(map:get($object, $map1))"><xsl:sequence select="''"/></xsl:when>
+      <xsl:when test="f:empty(map:get(map:get($object, $map1), $array))"><xsl:sequence select="''"/></xsl:when>
       <xsl:otherwise><xsl:copy-of select="array:flatten(map:get(map:get($object, $map1), $array))"/></xsl:otherwise>
     </xsl:choose>
   </xsl:function>

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -113,7 +113,7 @@ public class TestUtil {
 		Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/",
 				"streamingserver" ,"https://www.example.com/streamingserver/");
 		String schemaOrgJson = TestUtil.getTransformedWithAccessFieldsAdded(schemaOrgTransformer, record, injections);
-		//prettyPrintJson(schemaOrgJson);
+		prettyPrintJson(schemaOrgJson);
 
 		String placeholderXml = "placeholder.xml";
 		Map<String, String> mapOfJson = Map.of("schemaorgjson", schemaOrgJson);

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -113,7 +113,7 @@ public class TestUtil {
 		Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/",
 				"streamingserver" ,"https://www.example.com/streamingserver/");
 		String schemaOrgJson = TestUtil.getTransformedWithAccessFieldsAdded(schemaOrgTransformer, record, injections);
-		prettyPrintJson(schemaOrgJson);
+		//prettyPrintJson(schemaOrgJson);
 
 		String placeholderXml = "placeholder.xml";
 		Map<String, String> mapOfJson = Map.of("schemaorgjson", schemaOrgJson);

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -37,7 +37,7 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     public void testSetup() throws IOException {
         //printSchemaOrgJson(PVICA_RECORD_74e22fd8);
-        printSchemaOrgJson(TestFiles.PVICA_RECORD_accf8d1c);
+        printSchemaOrgJson(TestFiles.PVICA_RECORD_4f706cda);
         //printSchemaOrgJson(PVICA_RECORD_1F3A6A66);
         //printSchemaOrgJson(PVICA_RECORD_44979f67);
     }
@@ -335,6 +335,14 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
 
         Assertions.assertTrue(transformedJSON.contains("\"kb:format_identifier_ritzau\":\"81213310\"," +
                 "\"kb:format_identifier_nielsen\":\"101|20220526|140000|180958|0|9629d8b8-b751-450f-bfd7-d2510910bb34|69\"," ));
+    }
+
+    @Test
+    void testNoEmptyInternalMap() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_4f706cda);
+        TestUtil.prettyPrintJson(transformedJSON);
+        Assertions.assertFalse(transformedJSON.contains("\"kb:internal\":{}"));
+
     }
 
 

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -340,7 +340,6 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     void testNoEmptyInternalMap() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_4f706cda);
-        TestUtil.prettyPrintJson(transformedJSON);
         Assertions.assertFalse(transformedJSON.contains("\"kb:internal\":{}"));
 
     }

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -394,13 +394,12 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
         String solrString;
         try {
             solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJson(PRESERVICA2SCHEMAORG, record);
-            //TestUtil.prettyPrintJson(solrString);
         } catch (Exception e) {
             throw new RuntimeException(
                     "Unable to fetch and transform '" + record + "' using XSLT '" + getXSLT() + "'", e);
         }
 
-        //TestUtil.prettyPrintJson(solrString);
+        TestUtil.prettyPrintJson(solrString);
 
         Arrays.stream(tests).forEach(test -> test.accept(solrString));
     }

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -399,8 +399,6 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
                     "Unable to fetch and transform '" + record + "' using XSLT '" + getXSLT() + "'", e);
         }
 
-        TestUtil.prettyPrintJson(solrString);
-
         Arrays.stream(tests).forEach(test -> test.accept(solrString));
     }
 


### PR DESCRIPTION
This PR makes sure, that the map KB:internal isn't created when there are no values to put into it by checking for existence of such values. 

Furthermore the PR updates the XSLTs to make better use of the newly introduced functions for checking nested maps. In this regard a new function has been introduced which makes it possible to check for values of type map in an array by 