### PR TITLE
Prepare for OAuth2 flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.1](https://github.com/kb-dk/ds-present/releases/tag/v1.2.1) - 2023-12-11
 ### changed
  - Enum types define for presentations-formats (FormatDTO)
->>>>>>> master
 
 ## [1.2.0](https://github.com/kb-dk/ds-present/releases/tag/v1.2.0) - 2023-12-05
 ### Changed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-
+- Preliminary support for token based user group resolving, preparing for OAuth2
 
 ## [1.2.0](https://github.com/kb-dk/ds-present/releases/tag/v1.2.0) - 2023-12-05
 ### Changed 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.19-SNAPSHOT</version>
+            <version>1.4.19</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.18</version>
+            <version>1.4.19-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->

--- a/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
@@ -17,12 +17,10 @@ import java.util.List;
 
 /**
  * ds-present
- *
- * <p>Metadata delivery for the Royal Danish Library 
- *
+ * <p>
+ * Metadata delivery for the Royal Danish Library
  */
 public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
-    public static final String HEADER_SIMULATED_GROUP = "Simulated-OAuth2-Group";
     private static final Logger log = LoggerFactory.getLogger(DsPresentApiServiceImpl.class);
 
     // "Search" is best guess for the access type for now
@@ -112,8 +110,8 @@ public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
     @Override
     public String getRecord(String id, String format) throws ServiceException {
         try {
-            log.debug("getRecord(id='{}', format='{}') called with call details: {}", id, format, getCallDetails());
-            ACCESS access = AccessUtil.createAccessChecker(RECORD_ACCESS_TYPE).apply(id);
+            log.debug("getRecord(id='{}', format='{}') called with group call details: {}", id, format, getCallDetails());
+            ACCESS access = AccessUtil.createAccessChecker(AccessUtil.getGroups(httpHeaders), RECORD_ACCESS_TYPE).apply(id);
             switch (access) {
                 case ok:
                     return PresentFacade.getRecord(id, format);
@@ -144,7 +142,7 @@ public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
             long finalMaxRecords = maxRecords == null ? 1000L : maxRecords;
             return PresentFacade.getRecords(
                     httpServletResponse, origin, finalMTime, finalMaxRecords, format,
-                    AccessUtil.createAccessFilter(RECORD_ACCESS_TYPE));
+                    AccessUtil.createAccessFilter(AccessUtil.getGroups(httpHeaders), RECORD_ACCESS_TYPE));
         } catch (Exception e){
             throw handleException(e);
         }
@@ -161,14 +159,13 @@ public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
             asJsonLines = false;
         }
 
-        // Returning all IDs.
-        // When using AccessUtil.createAccessFilter(RECORD_ACCESS_TYPE) online deliverable units are returned
         try {
             long finalMTime = mTime == null ? 0L : mTime;
             long finalMaxRecords = maxRecords == null ? 1000L : maxRecords;
             return PresentFacade.getRecordsRaw(
                     httpServletResponse, origin, finalMTime, finalMaxRecords,
-                    ids -> ids, asJsonLines);
+                    AccessUtil.createAccessFilter(AccessUtil.getGroups(httpHeaders), RECORD_ACCESS_TYPE),
+                    asJsonLines);
         } catch (Exception e){
             throw handleException(e);
         }

--- a/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
@@ -89,7 +89,6 @@ public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
         } catch (Exception e){
             throw handleException(e);
         }
-    
     }
 
     /**
@@ -110,8 +109,10 @@ public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
     @Override
     public String getRecord(String id, String format) throws ServiceException {
         try {
-            log.debug("getRecord(id='{}', format='{}') called with group call details: {}", id, format, getCallDetails());
-            ACCESS access = AccessUtil.createAccessChecker(AccessUtil.getGroups(httpHeaders), RECORD_ACCESS_TYPE).apply(id);
+            log.debug("getRecord(id='{}', format='{}') called with groups {} call details: {}",
+                    id, format, AccessUtil.getGroups(httpHeaders), getCallDetails());
+            ACCESS access =
+                    AccessUtil.createAccessChecker(AccessUtil.getGroups(httpHeaders), RECORD_ACCESS_TYPE).apply(id);
             switch (access) {
                 case ok:
                     return PresentFacade.getRecord(id, format);
@@ -132,8 +133,9 @@ public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
 
     @Override
     public StreamingOutput getRecords(String origin, Long mTime, Long maxRecords, String format) {
-        log.debug("getRecords(origin='{}', mTime={}, maxRecords={}, format='{}') called with call details: {}",
-                  origin, mTime, maxRecords, format, getCallDetails());
+        log.debug("getRecords(origin='{}', mTime={}, maxRecords={}, format='{}') called with groups {} " +
+                        "and call details: {}",
+                  origin, mTime, maxRecords, format, AccessUtil.getGroups(httpHeaders), getCallDetails());
         if (origin == null) {
             throw new InternalServiceException("origin must be specified but was not");
         }
@@ -150,8 +152,9 @@ public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
 
     @Override
     public StreamingOutput getRecordsRaw(String origin, Long mTime, Long maxRecords, Boolean asJsonLines) {
-        log.debug("getRawRecords(origin='{}', mTime={}, maxRecords={}, asJsonLines={}) called with call details: {}",
-                origin, mTime, maxRecords, asJsonLines, getCallDetails());
+        log.debug("getRawRecords(origin='{}', mTime={}, maxRecords={}, asJsonLines={}) called with groups {} " +
+                        "and call details: {}",
+                origin, mTime, maxRecords, asJsonLines, AccessUtil.getGroups(httpHeaders), getCallDetails());
         if (origin == null) {
             throw new InternalServiceException("origin must be specified but was not");
         }

--- a/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
  *
  */
 public class DsPresentApiServiceImpl extends ImplBase implements DsPresentApi {
+    public static final String HEADER_SIMULATED_GROUP = "Simulated-OAuth2-Group";
     private static final Logger log = LoggerFactory.getLogger(DsPresentApiServiceImpl.class);
 
     // "Search" is best guess for the access type for now

--- a/src/main/java/dk/kb/present/api/v1/impl/ServiceApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/ServiceApiServiceImpl.java
@@ -2,6 +2,8 @@ package dk.kb.present.api.v1.impl;
 
 import dk.kb.present.api.v1.ServiceApi;
 import dk.kb.present.model.v1.StatusDto;
+import dk.kb.present.model.v1.WhoamiDto;
+import dk.kb.present.webservice.AccessUtil;
 import dk.kb.util.BuildInfoManager;
 import dk.kb.util.webservice.ImplBase;
 import dk.kb.util.webservice.exception.ServiceException;
@@ -10,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 
 /**
  * ds-present
@@ -72,5 +75,11 @@ public class ServiceApiServiceImpl extends ImplBase implements ServiceApi {
                 .health("ok");
     }
 
-
+    // Test with curl -X GET "http://localhost:9073/ds-present/v1/probe/whoami" -H  "Simulated-OAuth2-Group: foo"
+    @Override
+    public WhoamiDto whoami() {
+        return new WhoamiDto()
+                .hasAuthenticationToken(AccessUtil.hasAuthorization(httpHeaders))
+                .groups(new ArrayList<>(AccessUtil.getGroups(httpHeaders)));
+    }
 }

--- a/src/main/java/dk/kb/present/util/DsPresentClient.java
+++ b/src/main/java/dk/kb/present/util/DsPresentClient.java
@@ -261,7 +261,9 @@ public class DsPresentClient extends DsPresentApi {
         if (headers == null || headers.length == 0) {
             return Collections.emptyMap();
         }
+
         return Arrays.stream(headers)
+                .filter(Objects::nonNull)
                 .flatMap(hs -> hs.entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }

--- a/src/main/java/dk/kb/present/util/DsPresentClient.java
+++ b/src/main/java/dk/kb/present/util/DsPresentClient.java
@@ -72,13 +72,12 @@ public class DsPresentClient extends DsPresentApi {
      * <p>
      * This constructor expects the structure
      * <pre>
-     * config:
-     *   present:
-     *     url: 'http://localhost:9073/ds-present/v1'
-     *     headers:
-     *       # Placeholder for authentication until OAuth2 integration is in place
-     *       # Set this to 'internal_service` on local and devel to bypass license check in ds-present
-     *       - Simulated-OAuth2-Group: anonymous
+     * present:
+     *   url: 'http://localhost:9073/ds-present/v1'
+     *   headers:
+     *     # Placeholder for authentication until OAuth2 integration is in place
+     *     # Set this to 'internal_service` on local and devel to bypass license check in ds-present
+     *     - Simulated-OAuth2-Group: anonymous
      * </pre>
      * @param config following the outlined structure.
      * @param headers zero or more maps of headers, which will be set for all calls by this client.
@@ -107,13 +106,12 @@ public class DsPresentClient extends DsPresentApi {
      * <p>
      * When working with YAML configs, it is suggested to use the structure
      * <pre>
-     * config:
-     *   present:
-     *     url: 'http://localhost:9073/ds-present/v1'
-     *     headers:
-     *       # Placeholder for authentication until OAuth2 integration is in place
-     *       # Set this to 'internal_service` on local and devel to bypass license check in ds-present
-     *       - Simulated-OAuth2-Group: anonymous
+     * present:
+     *   url: 'http://localhost:9073/ds-present/v1'
+     *   headers:
+     *     # Placeholder for authentication until OAuth2 integration is in place
+     *     # Set this to 'internal_service` on local and devel to bypass license check in ds-present
+     *     - Simulated-OAuth2-Group: anonymous
      * </pre>
      * Then use the path {@link #PRESENT_SERVER_URL_KEY} to extract the URL.
      * <p>

--- a/src/main/java/dk/kb/present/util/DsPresentClient.java
+++ b/src/main/java/dk/kb/present/util/DsPresentClient.java
@@ -155,7 +155,7 @@ public class DsPresentClient extends DsPresentApi {
                 .queryParam("format", format)
                 .build();
         log.debug("Opening streaming connection to '{}'", uri);
-        return ContinuationInputStream.from(uri, Long::valueOf);
+        return ContinuationInputStream.from(uri, Long::valueOf, headers);
     }
 
     /**
@@ -184,7 +184,7 @@ public class DsPresentClient extends DsPresentApi {
                 .queryParam("asJsonLines", asJsonLines != null && asJsonLines)
                 .build();
         log.debug("Opening streaming connection to '{}'", uri);
-        return ContinuationInputStream.from(uri, Long::valueOf);
+        return ContinuationInputStream.from(uri, Long::valueOf, headers);
     }
 
     /**

--- a/src/main/java/dk/kb/present/util/DsPresentClient.java
+++ b/src/main/java/dk/kb/present/util/DsPresentClient.java
@@ -14,20 +14,23 @@
  */
 package dk.kb.present.util;
 
-import dk.kb.present.client.v1.ServiceApi;
 import dk.kb.present.client.v1.DsPresentApi;
 import dk.kb.present.client.v1.IiifPresentationApi;
+import dk.kb.present.client.v1.ServiceApi;
 import dk.kb.present.invoker.v1.ApiClient;
 import dk.kb.present.invoker.v1.Configuration;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.util.webservice.stream.ContinuationInputStream;
 import dk.kb.util.webservice.stream.ContinuationStream;
+import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URI;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Client for the service. Intended for use by other projects that calls this service.
@@ -40,11 +43,13 @@ import java.net.URI;
  * <p/>
  * In order to call the IIIF endpoints, use {@link DsPresentClient#iiif}.
  */
+@SuppressWarnings("unchecked")
 public class DsPresentClient extends DsPresentApi {
     private static final Logger log = LoggerFactory.getLogger(DsPresentClient.class);
     private final String serviceURI;
 
     public static final String PRESENT_SERVER_URL_KEY = ".config.present.url";
+    public static final String PRESENT_SERVER_HEADERS_KEY = ".config.present.headers";
 
     /**
      * Sub-client for the IIIF endpoints.
@@ -56,41 +61,75 @@ public class DsPresentClient extends DsPresentApi {
     public final ServiceApi service;
 
     /**
-     * Creates a client for the remote ds-present service.
+     * Headers used for all calls to ds-license.
+     */
+    public Map<String, String> headers;
+
+    /**
+     * Create a client for the remote ds-present service.
      * <p>
-     * When working with YAML configs, it is suggested to define the ds-present URI as the structure
+     * This constructor expects the structure
      * <pre>
      * config:
-     *   storage:
-     *     url: 'http://localhost:9073/ds-storage/v1'
+     *   present:
+     *     url: 'http://localhost:9073/ds-present/v1'
+     *     headers:
+     *       # Placeholder for authentication until OAuth2 integration is in place
+     *       # Set this to 'internal_service` on local and devel to bypass license check in ds-present
+     *       - Simulated-OAuth2-Group: anonymous
      * </pre>
-     * Then use the path {@link #PRESENT_SERVER_URL_KEY} to extract the URL.
-     * @param serviceURI the URI for the service, e.g. {@code https://example.com/ds-present/v1}.
+     * @param config following the outlined structure.
+     * @param headers zero or more maps of headers, which will be set for all calls by this client.
+     *                Note that this compounds with headers specified in {@code config}, with the {@code clientHeaders}
+     *                overriding the headers in the {@code config} in case of collisions.
      */
     @SuppressWarnings("JavadocLinkAsPlainText")
-    public DsPresentClient(String serviceURI) {
-        super(createClient(serviceURI));
-        this.serviceURI = serviceURI;
-        iiif = new IiifPresentationApi(createClient(serviceURI));
-        service = new ServiceApi(createClient(serviceURI));
-        log.info("Created OpenAPI client for '" + serviceURI + "'");
+    public DsPresentClient(YAML config, Map<String, String>... headers) {
+        this(config.getString(PRESENT_SERVER_URL_KEY), getAllHeaders(config, headers));
     }
 
     /**
-     * Deconstruct the given URI and use the components to create an ApiClient.
-     * @param serviceURIString an URI to a service.
-     * @return an ApiClient constructed from the serviceURIString.
+     * Create a client for the remote ds-present service, without special headers.
+     * <p>
+     * Note: Clients created using this constructor has no special header supports. The alternative constructor
+     * {@link DsPresentClient(YAML, Map)} handles both URL and fixed header setup.
+     * @param serviceURI the URI for the service, e.g. {@code https://example.com/ds-present/v1}.
+     * @see DsPresentClient(YAML)
      */
-    private static ApiClient createClient(String serviceURIString) {
-        log.debug("Creating OpenAPI client with URI '{}'", serviceURIString);
+    public DsPresentClient(String serviceURI) {
+        this(serviceURI, (Map<String, String>) null);
+    }
 
-        URI serviceURI = URI.create(serviceURIString);
-        // No mechanism for just providing the full URI. We have to deconstruct it
-        return Configuration.getDefaultApiClient().
-                setScheme(serviceURI.getScheme()).
-                setHost(serviceURI.getHost()).
-                setPort(serviceURI.getPort()).
-                setBasePath(serviceURI.getRawPath());
+    /**
+     * Create a client for the remote ds-present service.
+     * <p>
+     * When working with YAML configs, it is suggested to use the structure
+     * <pre>
+     * config:
+     *   present:
+     *     url: 'http://localhost:9073/ds-present/v1'
+     *     headers:
+     *       # Placeholder for authentication until OAuth2 integration is in place
+     *       # Set this to 'internal_service` on local and devel to bypass license check in ds-present
+     *       - Simulated-OAuth2-Group: anonymous
+     * </pre>
+     * Then use the path {@link #PRESENT_SERVER_URL_KEY} to extract the URL.
+     * <p>
+     * Note: The alternative constructor {@link DsPresentClient(YAML, Map)} handles both URL and fixed header setup.
+     * @param serviceURI the URI for the service, e.g. {@code https://example.com/ds-present/v1}.
+     * @param headers zero or more maps of headers, which will be set for all calls by this client.
+     * @see DsPresentClient(YAML, Map)
+     */
+    @SuppressWarnings("JavadocLinkAsPlainText")
+    public DsPresentClient(String serviceURI, Map<String, String>... headers) {
+        super(createApiClient(serviceURI, headers));
+        // Unfortunately we need to recreate the ApiClient as it is not retrievable from the super class
+        ApiClient apiClient = createApiClient(serviceURI, headers);
+        this.serviceURI = serviceURI;
+        this.headers = collapse(headers);
+        iiif = new IiifPresentationApi(apiClient);
+        service = new ServiceApi(apiClient);
+        log.info("Created OpenAPI client for '{}' with headers {}", serviceURI, headers);
     }
 
     /**
@@ -166,6 +205,65 @@ public class DsPresentClient extends DsPresentApi {
             String origin, Long mTime, Long maxRecords) throws IOException {
         return getRecordsRawJSON(origin, mTime, maxRecords, false)
                 .stream(DsRecordDto.class);
+    }
+
+    /**
+     * @return the headers used by this client.
+     */
+    public Map<String, String> getHeaders() {
+        return Collections.unmodifiableMap(headers);
+    }
+
+    /**
+     * Deconstruct the given URI and use the components to create an ApiClient.
+     * @param serviceURIString an URI to a ds-service.
+     * @param headers zero or more maps of headers, which will be set for all calls by this client.
+     * @return an ApiClient constructed from the serviceURIString.
+     */
+    static ApiClient createApiClient(String serviceURIString, Map<String, String>... headers) {
+        log.debug("Creating OpenAPI client with URI '{}', headers {}", serviceURIString, headers);
+
+        URI serviceURI = URI.create(serviceURIString);
+        // No mechanism for just providing the full URI. We have to deconstruct it
+        return Configuration.getDefaultApiClient()
+                .setScheme(serviceURI.getScheme())
+                .setHost(serviceURI.getHost())
+                .setPort(serviceURI.getPort())
+                .setBasePath(serviceURI.getRawPath())
+                .setRequestInterceptor(builder -> collapse(headers).forEach(builder::header));
+    }
+
+    /**
+     * Extract fixed headers for remote calls from {@link #PRESENT_SERVER_HEADERS_KEY} in {@code config} and
+     * combine them with the given {@code extraHeaders}.
+     * @param config  a configuration possibly containing fixed headers.
+     * @param extraHeaders will override any headers given in the {@code config}.
+     * @return a map of fixed headers. Note that duplicate entries are eliminated.
+     */
+    static Map<String, String> getAllHeaders(YAML config, Map<String, String>... extraHeaders) {
+        if (!config.containsKey(PRESENT_SERVER_HEADERS_KEY)) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> combined = new HashMap<>();
+        config.getYAMLList(PRESENT_SERVER_HEADERS_KEY).stream()
+                .flatMap(entry -> entry.entrySet().stream())
+                .forEach(entry -> combined.put(entry.getKey(), Objects.toString(entry.getValue())));
+        combined.putAll(collapse(extraHeaders));
+        return combined;
+    }
+
+    /**
+     * Take zero or more maps and collapses them into a single map, letting later entries override earlier ones.
+     * @param headers zero or more maps.
+     * @return a single map with all key/values.
+     */
+    static Map<String, String> collapse(Map<String, String>... headers) {
+        if (headers == null || headers.length == 0) {
+            return Collections.emptyMap();
+        }
+        return Arrays.stream(headers)
+                .flatMap(hs -> hs.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
 }

--- a/src/main/java/dk/kb/present/webservice/AccessUtil.java
+++ b/src/main/java/dk/kb/present/webservice/AccessUtil.java
@@ -37,6 +37,7 @@ public class AccessUtil {
     private static final Logger log = LoggerFactory.getLogger(AccessUtil.class);
 
     public static final String HEADER_SIMULATED_GROUP = "Simulated-OAuth2-Group";
+    // TODO: The two roles below are preliminary. When the OAuth2 project is underway, they should be changed or removed
     public static final String GROUP_INTERNAL_SERVICE = "internal_service";
     public static final String GROUP_ADMIN = "admin";
 

--- a/src/main/java/dk/kb/present/webservice/AccessUtil.java
+++ b/src/main/java/dk/kb/present/webservice/AccessUtil.java
@@ -37,6 +37,7 @@ public class AccessUtil {
     private static final Logger log = LoggerFactory.getLogger(AccessUtil.class);
 
     public static final String HEADER_SIMULATED_GROUP = "Simulated-OAuth2-Group";
+    public static final String GROUP_INTERNAL_SERVICE = "internal_service";
     public static final String GROUP_ADMIN = "admin";
 
     private static final String LICENSE_URL_KEY = "config.licensemodule.url"; // Used for creating licenseClient
@@ -57,7 +58,8 @@ public class AccessUtil {
     public static Function<String, DsPresentApiServiceImpl.ACCESS> createAccessChecker(
             Set<String> groups, String presentationType) {
         return id -> {
-            if (licenseAllowAll || groups.contains(GROUP_ADMIN)) {
+            if (licenseAllowAll ||
+                    groups.contains(GROUP_ADMIN) || groups.contains(GROUP_INTERNAL_SERVICE)) {
                 return DsPresentApiServiceImpl.ACCESS.ok;
             }
 
@@ -105,7 +107,8 @@ public class AccessUtil {
     public static Function<List<String>, List<String>> createAccessFilter(
             Set<String> groups, String presentationType) {
         return ids -> {
-            if (licenseAllowAll || ids.isEmpty() || groups.contains(GROUP_ADMIN)) {
+            if (licenseAllowAll || ids.isEmpty() ||
+                    groups.contains(GROUP_ADMIN) || groups.contains(GROUP_INTERNAL_SERVICE)) {
                 return new ArrayList<>(ids);
             }
 

--- a/src/main/openapi/ds-present-openapi_v1.yaml
+++ b/src/main/openapi/ds-present-openapi_v1.yaml
@@ -14,6 +14,12 @@ info:
     
     Furthermore metadata can be delivered as IIIF Presentation manifests through the `/IIIF/{identifier}/manifest`-endpoint. 
     For information on the IIIF Presentation API see the following [link](https://iiif.io/api/presentation/3.0/). This API supports version 3.0 and should be backwards compatible with version 2.1.1
+    
+    This service is under development and is **not** suitable for production!
+    In order to perform calls at an elevanted level, i.e. bypass the license module, add the header
+    `Simulated-OAuth2-Group: admin` to relevant service calls.
+    
+    TODO: Update this description when enabling OAuth2 security
   contact:
     email: '${user.name}@kb.dk'
   license:
@@ -382,6 +388,20 @@ paths:
               schema:
                 type: string
 
+  # Debugging of OAuth2 roles
+  /probe/whoami:
+    get:
+      tags:
+        - Service
+      summary: 'Pseudo-OAuth2 check: The groups that the caller belongs'
+      operationId: whoami
+      responses:
+        '200':
+          description: 'OK'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Whoami'
 
 components:
   schemas:
@@ -1070,3 +1090,19 @@ components:
           type: string
           description: 'Self diagnosed health'
           example: 'ok'
+
+    Whoami:
+      type: object
+      required:
+        - hasAuthenticationToken
+      properties:
+        hasAuthenticationToken:
+          description: 'True if an authentication token was provided with the call, else false'
+          type: boolean
+          example: true
+        groups:
+          description: 'The groups that the user belongs to within this service'
+          type: array
+          items:
+            type: string
+            example: 'read'

--- a/src/test/java/dk/kb/present/util/DsPresentClientTest.java
+++ b/src/test/java/dk/kb/present/util/DsPresentClientTest.java
@@ -14,7 +14,7 @@
  */
 package dk.kb.present.util;
 
-import dk.kb.present.api.v1.impl.DsPresentApiServiceImpl;
+import dk.kb.present.webservice.AccessUtil;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.util.webservice.stream.ContinuationInputStream;
 import dk.kb.util.webservice.stream.ContinuationStream;
@@ -98,12 +98,12 @@ public class DsPresentClientTest {
     @Test
     void getFixedHeaders() {
         YAML config = new YAML(Map.of("config", Map.of("present", Map.of("headers", List.of(
-                Map.of(DsPresentApiServiceImpl.HEADER_SIMULATED_GROUP, "anonymous"),
+                Map.of(AccessUtil.HEADER_SIMULATED_GROUP, "anonymous"),
                 Map.of("Some-Other-Header", "foo"))))));
         Map<String, String> headers = DsPresentClient.getAllHeaders(config);
         assertEquals(2, headers.size(),
                 "The right number of headers should be extracted");
-        assertEquals("anonymous", headers.get(DsPresentApiServiceImpl.HEADER_SIMULATED_GROUP),
+        assertEquals("anonymous", headers.get(AccessUtil.HEADER_SIMULATED_GROUP),
                 "The group header should be correct");
     }
 

--- a/src/test/java/dk/kb/present/util/DsPresentClientTest.java
+++ b/src/test/java/dk/kb/present/util/DsPresentClientTest.java
@@ -125,7 +125,8 @@ public class DsPresentClientTest {
                     TEST_CONF, DsPresentClient.PRESENT_SERVER_URL_KEY);
             return null;
         }
-        DsPresentClient client = new DsPresentClient(presentURL);
+
+        DsPresentClient client = new DsPresentClient(config);
         try {
             client.service.status(); // We cannot use ping as it does not return JSON. This is a problem!
         } catch (Exception e) {

--- a/src/test/java/dk/kb/present/util/DsPresentClientTest.java
+++ b/src/test/java/dk/kb/present/util/DsPresentClientTest.java
@@ -97,9 +97,9 @@ public class DsPresentClientTest {
     @SuppressWarnings("unchecked")
     @Test
     void getFixedHeaders() {
-        YAML config = new YAML(Map.of("config", Map.of("present", Map.of("headers", List.of(
+        YAML config = new YAML(Map.of("present", Map.of("headers", List.of(
                 Map.of(AccessUtil.HEADER_SIMULATED_GROUP, "anonymous"),
-                Map.of("Some-Other-Header", "foo"))))));
+                Map.of("Some-Other-Header", "foo")))));
         Map<String, String> headers = DsPresentClient.getAllHeaders(config);
         assertEquals(2, headers.size(),
                 "The right number of headers should be extracted");

--- a/src/test/java/dk/kb/present/util/DsPresentClientTest.java
+++ b/src/test/java/dk/kb/present/util/DsPresentClientTest.java
@@ -14,6 +14,7 @@
  */
 package dk.kb.present.util;
 
+import dk.kb.present.api.v1.impl.DsPresentApiServiceImpl;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.util.webservice.stream.ContinuationInputStream;
 import dk.kb.util.webservice.stream.ContinuationStream;
@@ -28,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -90,6 +92,19 @@ public class DsPresentClientTest {
                          records.getContinuationToken(),
                     "Received highest mTime should match stated highest mTime");
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void getFixedHeaders() {
+        YAML config = new YAML(Map.of("config", Map.of("present", Map.of("headers", List.of(
+                Map.of(DsPresentApiServiceImpl.HEADER_SIMULATED_GROUP, "anonymous"),
+                Map.of("Some-Other-Header", "foo"))))));
+        Map<String, String> headers = DsPresentClient.getAllHeaders(config);
+        assertEquals(2, headers.size(),
+                "The right number of headers should be extracted");
+        assertEquals("anonymous", headers.get(DsPresentApiServiceImpl.HEADER_SIMULATED_GROUP),
+                "The group header should be correct");
     }
 
     /**


### PR DESCRIPTION
The Ds-services are expected to be OAuth2 enabled in the future. This is needed for some endpoints, where special privileges should disable licence checks for exports; needed for the initial update of the Solr index as the Solr index is used by the license module - chicken & egg.

This pull request adds support for the HTTP header
```
Simulated-OAuth2-Group: internal_service
```
when calling web service endpoints. If the header is set, the license check is bypassed. This is **absolutely not** an attempt at providing access checks, but serves to test the flow of headers between our services as well as having different groups of callers.

For debugging, the endpoint `/monitor/whoami` has been added. It can be tested with 
```
curl -X GET "http://localhost:9073/ds-present/v1/probe/whoami" -H  "Simulated-OAuth2-Group: foo"
```
