### PR TITLE
Introduce shingles

### DIFF
--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -867,6 +867,8 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     </analyzer>
   </fieldType>
 
+  <!-- TODO: Consider setting multi value distance fairly short for phrase search across
+       timestamped Whisper output -->
   <!-- https://solr.apache.org/guide/solr/latest/indexing-guide/filters.html#shingle-filter -->
   <fieldType name="text_shingles" class="solr.TextField" multiValued="true" indexed="true" required="false" stored="false"  termVectors="true" storeOffsetsWithPositions="true">
     <analyzer>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -21,8 +21,10 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
        Update this according to Semantic Versioning rules: https://semver.org/
 
        Used by scripts for keeping track of versioning of Solr setup across time and Solr instances.
+
+       1.0.1: Added text_shingles
   -->
-  <field name="_ds_1.0.0_" type="string" indexed="false" stored="false"/>
+  <field name="_ds_1.0.1_" type="string" indexed="false" stored="false"/>
 
   <uniqueKey>id</uniqueKey>
 
@@ -796,6 +798,11 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     If a television recording with subtitles is indexed, this field will hold the subtitles and only the subtitles.?>
   </field>
 
+  <field name="text_shingles" type="text_shingles">
+    <?description Content text field for newspaper article main text, book full text, television subtitles, radio transcriptions etc. This differs from "text" by being shingled up to 4 tokens, which should make it more useful for automatic keyword extraction.?>
+    <?example     If a television recording with subtitles is indexed, this field will hold the subtitles and only the subtitles.?>
+  </field>
+
   <!-- Most fields are copied to this field for matching. -->
   <field name="freetext" type="freetext" multiValued="true" stored="false">
     <?description Freetext field, which contains text from multiple other fields.
@@ -856,6 +863,19 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
         <tokenizer class="solr.StandardTokenizerFactory"/>
       <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt"/>
       <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- https://solr.apache.org/guide/solr/latest/indexing-guide/filters.html#shingle-filter -->
+  <fieldType name="text_shingles" class="solr.TextField" multiValued="true" indexed="true" required="false" stored="false"  termVectors="true" storeOffsetsWithPositions="true">
+    <analyzer>
+      <tokenizer name="standard"/>
+       <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt"/>
+       <filter class="solr.LowerCaseFilterFactory"/>
+       <!-- Max shingles size 4 is just a "best guess right now".
+            It should be tweaked when a corpus of tens of thousands of documents has been indexed.
+            Unigrams are kept for use with keyword extraction using MoreLikeThis -->
+      <filter name="shingle" maxShingleSize="4" outputUnigrams="true"/>
     </analyzer>
   </fieldType>
 
@@ -928,6 +948,10 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <copyField source="subtitle" dest="freetext"/>
   <copyField source="alternative_title" dest="freetext"/>
   <copyField source="original_title" dest="freetext"/>
+
+  <copyField source="text" dest="text_shingles">
+    <?description Copies the content of the basic text field to the shingles enabled text field, for better phrase search ranking and keyword extraction.?>
+  </copyField>
 
   <!-- END COPYFIELDS  -->
  </schema>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -878,7 +878,9 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
             Unigrams are kept for use with keyword extraction using MoreLikeThis -->
        <!-- https://stackoverflow.com/questions/18885764/lucene-analyzer-chain-shinglefilter-without-filler-tokens -->
        <filter name="shingle" maxShingleSize="4" outputUnigrams="true" fillerToken="___" />
-       <filter class="solr.PatternReplaceFilterFactory" pattern=".*___.*" replacement=""/>        
+       <filter class="solr.PatternReplaceFilterFactory" pattern=".*___.*" replacement=""/>
+       <!-- Remove embedded timestamp tokens (only used in the 'text' field for temporal search via highlights) -->
+       <filter class="solr.PatternReplaceFilterFactory" pattern="ɣ[0-9]+ɣ" replacement=""/>        
     </analyzer>
   </fieldType>
 

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -22,9 +22,10 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 
        Used by scripts for keeping track of versioning of Solr setup across time and Solr instances.
 
-       1.0.1: Added text_shingles
+1.0.1: Added text_shingles
+1.0.2: Defined 'snowball' for all stopword filters
   -->
-  <field name="_ds_1.0.1_" type="string" indexed="false" stored="false"/>
+  <field name="_ds_1.0.2_" type="string" indexed="false" stored="false"/>
 
   <uniqueKey>id</uniqueKey>
 
@@ -856,12 +857,12 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <fieldType name="text_general" class="solr.TextField" multiValued="false" indexed="true" required="false" stored="true"  termVectors="true" storeOffsetsWithPositions="true">
     <analyzer type="index">
        <tokenizer class="solr.StandardTokenizerFactory"/>
-       <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt"/>
+       <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt" format="snowball"/>
        <filter class="solr.LowerCaseFilterFactory"/>
     </analyzer>
     <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-      <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt"/>
+      <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt" format="snowball"/>
       <filter class="solr.LowerCaseFilterFactory"/>
     </analyzer>
   </fieldType>
@@ -870,12 +871,14 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <fieldType name="text_shingles" class="solr.TextField" multiValued="true" indexed="true" required="false" stored="false"  termVectors="true" storeOffsetsWithPositions="true">
     <analyzer>
       <tokenizer name="standard"/>
-       <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt"/>
        <filter class="solr.LowerCaseFilterFactory"/>
+       <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt" format="snowball" />
        <!-- Max shingles size 4 is just a "best guess right now".
             It should be tweaked when a corpus of tens of thousands of documents has been indexed.
             Unigrams are kept for use with keyword extraction using MoreLikeThis -->
-      <filter name="shingle" maxShingleSize="4" outputUnigrams="true"/>
+       <!-- https://stackoverflow.com/questions/18885764/lucene-analyzer-chain-shinglefilter-without-filler-tokens -->
+       <filter name="shingle" maxShingleSize="4" outputUnigrams="true" fillerToken="___" />
+       <filter class="solr.PatternReplaceFilterFactory" pattern=".*___.*" replacement=""/>        
     </analyzer>
   </fieldType>
 
@@ -894,13 +897,13 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <analyzer type="index">
       <tokenizer class="solr.StandardTokenizerFactory"/>
       <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
-      <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt"/>
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt" format="snowball"/>
       <filter class="solr.LowerCaseFilterFactory"/>
     </analyzer>
     <analyzer type="query">
       <tokenizer class="solr.StandardTokenizerFactory"/>
       <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
-      <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt"/>
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt" format="snowball"/>
       <filter class="solr.LowerCaseFilterFactory"/>
     </analyzer>
   </fieldType>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -775,6 +775,7 @@
         description
         internal_showviewcode
         text^0.75
+        text_shingles^0.75
         freetext^0.5
        </str>
        
@@ -953,6 +954,7 @@
         description
         internal_showviewcode
         text^0.75
+        text_shingles^0.75
         freetext^0.5
       </str>
       <str name="mlt.maxqt">25</str>
@@ -971,6 +973,7 @@
           catalog
           resource_description
           text^0.75
+          text_shingles^0.75
           freetext^0.5
         </str>
     </lst>


### PR DESCRIPTION
[Solr shingle filters](https://solr.apache.org/guide/solr/latest/indexing-guide/filters.html#shingle-filter) (also known as token n.grams) improves the relevance of phrase searches and allows for statistics-based extraction of multi-work keywords.

In this pull request the shingles field (`text_shingles`) is coupled to `text` using `copyField`. Officialle we do not have any content in the `text` field yet, but I have experimented with Whisper and populated both fields, so that a test is possible: The script below performa a search (in this case for `*:*`) and used the Solkr MoreLikeThis to extract "significant terms".

```shell
Q='*:*' ; for O in $(seq 0 9); do curl -s 'http://<ds-devel-machine>:10007/solr/ds/mlt' -d 'mlt.interestingTerms=list' -d 'mlt.fl=text_shingles' -d "q=$Q" -d 'fl=id' -d 'mlt.match.include=true' -d 'mlt.mintf=2' -d 'mlt.mindf=2' -d 'mlt.boost=true' -d 'mlt.maxntp=100000' -d 'mlt.qf=text_shingles' -d 'mlt.maxqt=10' -d 'mlt.maxdfpct=50' -d "mlt.match.offset=$O" | jq  -c ' .interestingTerms ' ; done
```

```
["kharkiv","sanktioner","kan","kiev","gas","så","russiske","rusland","ukraine",""]
["landet","solen","sæk","grader","vejr","så","altså","millimeter","februar",""]
[]
["nødhjælp","altså","rusland","russiske","kiev","lviv","så","ukrainske","ukraine",""]
["godt","ej","kan"," så","bum"," ej"," ja","ja","så",""]
["bolig","sønderborg","kan"," ja","ja","så","ej","ej ej","ej ej ej",""]
[" ja","pleje","kan","kontanter","kunderne","ja","selskaber","så","kolding",""]
["jørgen"," så","lidt","lige","godt","kan"," ja","ja","så",""]
["the","pounds","så","betty","vildt","stephen","profit","angus","pounder",""]
[" vær så","vær så","james"," vær så god","vær så god","kvinde","god","nødt","fit",""]
```
The quality is not high, but should improve somewhat by tweaking parameters and a lot more by having a larger corpus (current one is 250 documents).