### PR TITLE
Disc 505 xslt errorhandling

### DIFF
--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -13,6 +13,7 @@
                xmlns:access="http://doms.statsbiblioteket.dk/types/access/0/1/#"
                xmlns:pidhandle="http://kuana.kb.dk/types/pidhandle/0/1/#"
                xmlns:program_structure="http://doms.statsbiblioteket.dk/types/program_structure/0/1/#"
+               xmlns:err="http://www.w3.org/2005/xqt-errors"
                version="3.0">
 
 
@@ -23,7 +24,6 @@
   <xsl:param name="recordID"/>
   <xsl:param name="manifestation"/>
   <xsl:param name="conditionsOfAccess"/>
-
   <!-- MAIN TEMPLATE. This template delegates, which fields are to be created for each schema.org object.
        Currently, the template handles transformations from Preservica records to SCHEMA.ORG VideoObjects and AudioObjects. -->
   <xsl:template match="/">
@@ -81,44 +81,62 @@
         <xsl:with-param name="type" select="$type"/>
       </xsl:call-template>
 
-      <!-- Extract PBCore metadata -->
-      <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument">
-        <xsl:call-template name="pbc-metadata">
-          <xsl:with-param name="type" select="$type"/>
+      <xsl:try>
+        <!-- Extract PBCore metadata -->
+        <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument">
+          <xsl:call-template name="pbc-metadata">
+            <xsl:with-param name="type" select="$type"/>
+            <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+          </xsl:call-template>
+
+          <!-- This is the only field directly present in pbc:PBCoreDescriptionDocument, which is only used for video
+               objects. Therefore, it is extracted here. If more fields from this part of the metadata were only
+               relevant for video objects, then a new template would be introduced. -->
+          <!-- Is the resource hd? or do we know anything about the video quality=? -->
+          <xsl:if test="pbcoreInstantiation/formatStandard != ''">
+            <f:string key="videoQuality"><xsl:value-of select="./pbcoreInstantiation/formatStandard"/></f:string>
+          </xsl:if>
+        </xsl:for-each>
+
+        <!-- Extract manifestation -->
+        <xsl:call-template name="extract-manifestation"/>
+
+        <!-- Create the kb:internal map. This map contains all metadata, that are not represented in schema.org, but were
+             available from the preservica records.-->
+        <f:map key="kb:internal">
+        <!-- Transforms values that does not fit directly into Schema.org into an internal map. -->
+        <xsl:call-template name="kb-internal">
           <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+          <xsl:with-param name="type" select="$type"/>
         </xsl:call-template>
 
-        <!-- This is the only field directly present in pbc:PBCoreDescriptionDocument, which is only used for video
-             objects. Therefore, it is extracted here. If more fields from this part of the metadata were only
-             relevant for video objects, then a new template would be introduced. -->
-        <!-- Is the resource hd? or do we know anything about the video quality=? -->
-        <xsl:if test="pbcoreInstantiation/formatStandard != ''">
-          <f:string key="videoQuality"><xsl:value-of select="./pbcoreInstantiation/formatStandard"/></f:string>
-        </xsl:if>
-      </xsl:for-each>
+        <!-- This template extracts internal fields, that are only relevant for video objects. Therefore, they have been
+             removed from the overall kb-internal template called above. The fields are: aspect_ratio and color.-->
+        <xsl:call-template name="internal-video-fields"/>
 
-      <!-- Extract manifestation -->
-      <xsl:call-template name="extract-manifestation"/>
+        <!-- This template also extracts internal fields only relevant for video. The rest of the extension extraction
+             is handled in the kb-internal template called above. -->
+        <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreExtension/extension">
+          <xsl:call-template name="video-extension-extractor"/>
+        </xsl:for-each>
+        </f:map>
 
-      <!-- Create the kb:internal map. This map contains all metadata, that are not represented in schema.org, but were
-           available from the preservica records.-->
-      <f:map key="kb:internal">
-      <!-- Transforms values that does not fit directly into Schema.org into an internal map. -->
-      <xsl:call-template name="kb-internal">
-        <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-        <xsl:with-param name="type" select="$type"/>
-      </xsl:call-template>
-
-      <!-- This template extracts internal fields, that are only relevant for video objects. Therefore, they have been
-           removed from the overall kb-internal template called above. The fields are: aspect_ratio and color.-->
-      <xsl:call-template name="internal-video-fields"/>
-
-      <!-- This template also extracts internal fields only relevant for video. The rest of the extension extraction
-           is handled in the kb-internal template called above. -->
-      <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreExtension/extension">
-        <xsl:call-template name="video-extension-extractor"/>
-      </xsl:for-each>
-      </f:map>
+        <!-- Catches all errors in sequence constructors (places where data can be used as input). If an error occurs
+             the field origin will be created and internal fields about the error will be created as well. -->
+        <xsl:catch errors="*">
+          <f:array key="identifier">
+            <f:map>
+              <f:string key="@type">PropertyValue</f:string>
+              <f:string key="PropertyID">Origin</f:string>
+              <f:string key="value"><xsl:value-of select="$origin"/></f:string>
+            </f:map>
+          </f:array>
+          <f:map key="kb:internal">
+            <f:string key="kb:transformation_error"><xsl:value-of select="true()"/></f:string>
+            <f:string key="kb:transformation_error_description"><xsl:value-of select="$err:description"/></f:string>
+          </f:map>
+        </xsl:catch>
+      </xsl:try>
 
     </f:map>
   </xsl:template>
@@ -146,19 +164,46 @@
         <xsl:with-param name="type" select="$type"/>
       </xsl:call-template>
 
-      <!-- Extract PBCore metadata -->
-      <!-- We cant assume that all records contain PBCore metadata as some OAI harvests might fail and not extract it.
-           We do need to set origin anyway, therefore this choose-statement. -->
-      <xsl:choose>
-        <xsl:when test="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument">
-          <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument">
-            <xsl:call-template name="pbc-metadata">
-              <xsl:with-param name="type" select="$type"/>
+      <xsl:try>
+        <!-- Extract PBCore metadata -->
+        <!-- We cant assume that all records contain PBCore metadata as some OAI harvests might fail and not extract it.
+             We do need to set origin anyway, therefore this choose-statement. -->
+        <xsl:choose>
+          <xsl:when test="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument">
+            <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument">
+              <xsl:call-template name="pbc-metadata">
+                <xsl:with-param name="type" select="$type"/>
+                <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+              </xsl:call-template>
+            </xsl:for-each>
+          </xsl:when>
+          <xsl:otherwise>
+            <f:array key="identifier">
+              <f:map>
+                <f:string key="@type">PropertyValue</f:string>
+                <f:string key="PropertyID">Origin</f:string>
+                <f:string key="value"><xsl:value-of select="$origin"/></f:string>
+              </f:map>
+            </f:array>
+          </xsl:otherwise>
+        </xsl:choose>
+
+        <!-- Extract manifestation -->
+        <xsl:call-template name="extract-manifestation"/>
+
+        <!-- If type is MediaObject we don't create the internal map. -->
+        <xsl:if test="$type != 'MediaObject'">
+          <f:map key="kb:internal">
+          <!-- Transforms values that does not fit directly into Schema.org into an internal map. -->
+            <xsl:call-template name="kb-internal">
               <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+              <xsl:with-param name="type" select="$type"/>
             </xsl:call-template>
-          </xsl:for-each>
-        </xsl:when>
-        <xsl:otherwise>
+          </f:map>
+        </xsl:if>
+        <!-- Catches all errors in sequence constructors (places where data can be used as input). If an error occurs
+           the field origin will be created and internal fields about the error will be created as well. -->
+        <xsl:catch errors="*">
           <f:array key="identifier">
             <f:map>
               <f:string key="@type">PropertyValue</f:string>
@@ -166,24 +211,12 @@
               <f:string key="value"><xsl:value-of select="$origin"/></f:string>
             </f:map>
           </f:array>
-        </xsl:otherwise>
-      </xsl:choose>
-
-      <!-- Extract manifestation -->
-      <xsl:call-template name="extract-manifestation"/>
-
-      <!-- If type is MediaObject we don't create the internal map. -->
-      <xsl:if test="$type != 'MediaObject'">
-        <f:map key="kb:internal">
-        <!-- Transforms values that does not fit directly into Schema.org into an internal map. -->
-          <xsl:call-template name="kb-internal">
-            <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-            <xsl:with-param name="type" select="$type"/>
-          </xsl:call-template>
-        </f:map>
-      </xsl:if>
-
-
+          <f:map key="kb:internal">
+            <f:string key="kb:transformation_error"><xsl:value-of select="true()"/></f:string>
+            <f:string key="kb:transformation_error_description"><xsl:value-of select="$err:description"/></f:string>
+          </f:map>
+        </xsl:catch>
+      </xsl:try>
     </f:map>
   </xsl:template>
 

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -133,7 +133,7 @@
           </f:array>
           <f:map key="kb:internal">
             <f:string key="kb:transformation_error"><xsl:value-of select="true()"/></f:string>
-            <f:string key="kb:transformation_error_description"><xsl:value-of select="$err:description"/></f:string>
+            <f:string key="kb:transformation_error_description"><xsl:value-of select="concat($err:code, ': ', $err:description)"/></f:string>
           </f:map>
         </xsl:catch>
       </xsl:try>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -71,7 +71,7 @@
                   <xsl:value-of select="f:true()"/>
                 </f:string>
                 <f:string key="internal_transformation_error_description">
-                  <xsl:value-of select="$err:description"/>
+                  <xsl:value-of select="concat($err:code, ': ', $err:description)"/>
                 </f:string>
               </xsl:catch>
             </xsl:try>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -8,6 +8,7 @@
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                xmlns:my="urn:my"
+               xmlns:err="http://www.w3.org/2005/xqt-errors"
                version="3.0">
   
   <xsl:output method="text" />
@@ -19,8 +20,14 @@
     <xsl:copy-of select="f:parse-json($schemaorgjson)"/>
   </xsl:variable>
 
+  <!--Extract the array of identifiers to a variable, where the individual maps can be accessed. -->
+  <xsl:variable name="identifers" as="item()*">
+    <xsl:copy-of select="array:flatten($schemaorg-xml('identifier'))"/>
+  </xsl:variable>
+
   <xsl:template name="initial-template" match="/">
     <xsl:variable name="solrjson">
+
 
       <f:map>
         <f:string key="resource_description">
@@ -35,285 +42,319 @@
           <xsl:value-of select="map:get($schemaorg-xml, 'conditionsOfAccess')"/>
         </f:string>
 
-        <!-- THIS IS THE BIGGEST AND BADDEST HACK IN TOWN! TO MAKE TEST METHODS AND XSLTS PRETTY AND MANAGEABLE,
-             WE SHOULD REALLY IMPLEMENT THIS SCHEMA2SOLR TRANSFORMATION FOR MODS RESOURCES AS WELL. CURRENTLY, THIS
-             BRANCH CAN'T GENERATE ANY SOLR-DOCUMENTS FOR MODS RECORDS, WHICH SHOULD BE DO-ABLE. -->
-        <xsl:if test="contains(map:get($schemaorg-xml,'@type'), 'VideoObject') or
-                      contains(map:get($schemaorg-xml,'@type'), 'AudioObject') or
-                      contains(map:get($schemaorg-xml,'@type'), 'MediaObject')">
-
-          <xsl:if test="f:exists($schemaorg-xml('keywords'))">
-            <!--Save categories to a variable as a sequence. -->
-            <xsl:variable name="categories" as="item()*" select="tokenize($schemaorg-xml('keywords'), ',')"/>
-            <!--Create array of categories, which fits with the multivalued solr field -->
-            <f:array key="categories">
-              <xsl:for-each select="$categories">
-                <f:string><xsl:value-of select="normalize-space(.)"/></f:string>
-              </xsl:for-each>
-            </f:array>
-          </xsl:if>
-
-          <!-- Extract collection-->
-          <xsl:if test="exists($schemaorg-xml('isPartOf'))">
-            <!-- Variable to find collections in. -->
-            <xsl:variable name="isPartOf" as="item()*">
-              <xsl:copy-of select="array:flatten($schemaorg-xml('isPartOf'))"/>
-            </xsl:variable>
-
-            <xsl:for-each select="$isPartOf">
-              <xsl:if test="map:get(., '@type') = 'Collection'">
-                <f:string key="collection">
-                  <xsl:value-of select="map:get(., 'name')"/>
-                </f:string>
-              </xsl:if>
-            </xsl:for-each>
-
-          </xsl:if>
-
-          <!-- Extract main genre -->
-          <xsl:if test="$schemaorg-xml('genre')">
-            <f:string key="genre">
-              <xsl:value-of select="$schemaorg-xml('genre')"/>
+        <xsl:choose>
+          <!--Check if an error has occurred in hte previous transformer. Otherwise, continue with this transformation -->
+          <xsl:when test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:transformation_error') = 'true'">
+            <f:string key="internal_transformation_error">
+              <xsl:value-of select="f:true()"/>
             </f:string>
-          </xsl:if>
-
-          <!-- extract title-->
-          <xsl:if test="$schemaorg-xml('name')">
-            <f:string key="title">
-              <xsl:value-of select="$schemaorg-xml('name')"/>
-            </f:string>
-
-            <f:string key="title_sort_da">
-              <xsl:value-of select="$schemaorg-xml('name')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- extract alternate title-->
-          <xsl:if test="$schemaorg-xml('alternateName')">
-            <f:string key="original_title">
-              <xsl:value-of select="$schemaorg-xml('alternateName')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract the creater affiliation. Two fields are required here as creator_affiliation can change over time.
-               Therefore, we are also extracting the creator_affiliation_generic which contains the same value for e.g.
-               DR P1 from 1960 'program 1' and 2000's 'P1'. Here the value would be drp1. -->
-          <xsl:if test="f:exists(map:get($schemaorg-xml, 'publication'))">
-            <xsl:if test="f:exists(my:getNestedMapValue2Levels($schemaorg-xml, 'publication','publishedOn'))">
-
-              <xsl:if test="not(f:empty(my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn',  'broadcastDisplayName')))">
-                  <f:string key="creator_affiliation">
-                    <xsl:value-of select="my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn',  'broadcastDisplayName')"/>
-                  </f:string>
-              </xsl:if>
-
-              <xsl:if test="not(empty(my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn', 'alternateName')))">
-                <f:string key="creator_affiliation_generic">
-                  <xsl:value-of select="my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn', 'alternateName')"/>
-                </f:string>
-              </xsl:if>
-
-              <xsl:if test="not(f:empty(my:getNestedMapValue4Levels($schemaorg-xml, 'publication',
-                                                        'publishedOn', 'broadcaster', 'legalName')))">
-                <f:string key="broadcaster">
-                  <xsl:value-of select="my:getNestedMapValue4Levels($schemaorg-xml, 'publication',
-                                                          'publishedOn', 'broadcaster', 'legalName')"/>
-                </f:string>
-              </xsl:if>
-            </xsl:if>
-          </xsl:if>
-
-
-          <!-- Creates the notes field, which originates from the mods2solr XSLT and acts as a catch all field for metadata
-               The values in this field are also present in the specific abstract and description fields.-->
-          <xsl:if test="$schemaorg-xml('abstract') or $schemaorg-xml('description')">
-            <f:array key="notes">
-              <xsl:if test="$schemaorg-xml('abstract')">
-                <f:string>
-                  <xsl:value-of select="$schemaorg-xml('abstract')"/>
-                </f:string>
-              </xsl:if>
-              <xsl:if test="$schemaorg-xml('description')">
-                <f:string>
-                  <xsl:value-of select="$schemaorg-xml('description')"/>
-                </f:string>
-              </xsl:if>
-            </f:array>
-          </xsl:if>
-
-          <!-- Extract content url-->
-          <!-- TODO: What about resourceID?-->
-          <xsl:if test="$schemaorg-xml('contentUrl')">
-            <f:string key="streaming_url">
-              <xsl:value-of select="$schemaorg-xml('contentUrl')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract data on the encoded creative work, if present-->
-          <xsl:if test="map:contains($schemaorg-xml, 'encodesCreativeWork')">
-            <!-- extract episode titel -->
-            <xsl:if test="exists($schemaorg-xml('encodesCreativeWork')('name'))">
-              <f:string key="episode_title">
-                <xsl:value-of select="$schemaorg-xml('encodesCreativeWork')('name')"/>
-              </f:string>
-            </xsl:if>
-
-            <!-- Extract episode number -->
-            <xsl:if test="$schemaorg-xml('encodesCreativeWork')('episodeNumber')">
-              <f:string key="episode">
-                <xsl:value-of select="$schemaorg-xml('encodesCreativeWork')('episodeNumber')"/>
-              </f:string>
-            </xsl:if>
-
-            <!-- Quite nested structure here. We already know that the map encodesCreativeWork exists, now we are checking
-                 for the submap partOfSeason and when that exists, we know that the numberOfEpisodes is present, as this
-                 field is creating the map partOfSeason. -->
-            <!-- Extract number of episodes-->
-            <xsl:if test="map:contains($schemaorg-xml('encodesCreativeWork'), 'partOfSeason')">
-              <f:string key="number_of_episodes">
-                <xsl:value-of select="$schemaorg-xml('encodesCreativeWork')('partOfSeason')('numberOfEpisodes')"/>
-              </f:string>
-            </xsl:if>
-          </xsl:if>
-
-          <!-- extract start time-->
-          <xsl:if test="$schemaorg-xml('startTime')">
-            <f:string key="startTime">
-              <xsl:value-of select="$schemaorg-xml('startTime')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- extract end time-->
-          <xsl:if test="$schemaorg-xml('endTime')">
-            <f:string key="endTime">
-              <xsl:value-of select="$schemaorg-xml('endTime')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Calculate duration from start and end times-->
-          <xsl:if test="$schemaorg-xml('duration')">
-            <xsl:variable name="startTime">
-              <xsl:value-of select="$schemaorg-xml('startTime')"/>
-            </xsl:variable>
-            <xsl:variable name="endTime">
-              <xsl:value-of select="$schemaorg-xml('endTime')"/>
-            </xsl:variable>
-            <xsl:variable name="durationInMilliseconds">
-              <xsl:value-of select="my:toMilliseconds($startTime, $endTime)"/>
-            </xsl:variable>
-            <f:string key="duration_ms">
-              <xsl:value-of select="$durationInMilliseconds"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract color boolean-->
-          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:color') != ''">
-            <f:string key="color">
-              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:color') "/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract videoQuality -->
-          <xsl:if test="$schemaorg-xml('videoQuality')">
-            <f:string key="video_quality">
-              <xsl:value-of select="$schemaorg-xml('videoQuality')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract surround sound-->
-          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:surround_sound') != ''">
-            <f:string key="surround_sound">
-              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:surround_sound')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract premiere-->
-          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:premiere') != ''">
-            <f:string key="premiere">
-              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:premiere')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract aspect ratio-->
-          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio') != ''">
-            <f:string key="aspect_ratio">
-              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract boolean for live broadcast -->
-          <xsl:if test="f:exists($schemaorg-xml('publication'))">
-            <xsl:if test="f:exists($schemaorg-xml('publication')('isLiveBroadcast'))">
-              <f:string key="live_broadcast">
-                <xsl:value-of select="$schemaorg-xml('publication')('isLiveBroadcast')"/>
-              </f:string>
-            </xsl:if>
-          </xsl:if>
-
-          <!-- Extract boolean for retransmission -->
-          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:retransmission')">
-            <f:string key="retransmission">
-              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:retransmission')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract abstract -->
-          <xsl:if test="f:exists($schemaorg-xml('abstract'))">
-            <f:string key="abstract">
-              <xsl:value-of select="$schemaorg-xml('abstract')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract description -->
-          <xsl:if test="f:exists($schemaorg-xml('description'))">
-            <f:string key="description">
-              <xsl:value-of select="$schemaorg-xml('description')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract sub genre -->
-          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:genre_sub')">
-            <f:string key="genre_sub">
-              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:genre_sub')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract boolean for subtitles -->
-          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:has_subtitles')">
-            <f:string key="has_subtitles">
-              <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:has_subtitles')"/>
-            </f:string>
-          </xsl:if>
-
-          <!-- Extract boolean for subtitles for hearing impaired  -->
-          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal',
-                                                    'kb:has_subtitles_for_hearing_impaired')">
-            <f:string key="has_subtitles_for_hearing_impaired">
+            <f:string key="internal_transformation_error_description">
               <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal',
-                                                                'kb:has_subtitles_for_hearing_impaired')"/>
+                                                                'kb:transformation_error_description')"/>
             </f:string>
-          </xsl:if>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:try>
+              <!-- Calls the main template which handles transformation between schemaorg and solr -->
+              <xsl:call-template name="schemaorgToSolr"/>
 
-          <!--Extract the array of identifiers to a variable, where the individual maps can be accessed. -->
-          <xsl:variable name="identifers" as="item()*">
-            <xsl:copy-of select="array:flatten($schemaorg-xml('identifier'))"/>
-          </xsl:variable>
-          <!--For each identifier in the variable $identifiers check for specific properties and map them to their
-              respective solr counterpart.-->
-          <xsl:for-each select="$identifers">
-            <xsl:call-template name="identifierExtractor"/>
-          </xsl:for-each>
-
-          <!-- Extract internal fields -->
-          <xsl:call-template name="kbInternal">
-            <xsl:with-param name="internalMap" select="$schemaorg-xml('kb:internal')"/>
-          </xsl:call-template>
-        </xsl:if>
-
+              <!-- Handles all types of errors.-->
+              <xsl:catch errors="*">
+                <xsl:for-each select="$identifers">
+                  <xsl:if test="map:get(., 'PropertyID') = 'Origin'">
+                    <f:string key="origin">
+                      <xsl:value-of select="map:get(., 'value')"/>
+                    </f:string>
+                  </xsl:if>
+                </xsl:for-each>
+                <f:string key="internal_transformation_error">
+                  <xsl:value-of select="f:true()"/>
+                </f:string>
+                <f:string key="internal_transformation_error_description">
+                  <xsl:value-of select="$err:description"/>
+                </f:string>
+              </xsl:catch>
+            </xsl:try>
+          </xsl:otherwise>
+        </xsl:choose>
       </f:map>
     </xsl:variable>
 
     <xsl:value-of select="f:xml-to-json($solrjson)"/>
+  </xsl:template>
+
+  <!--TEMPLATE FOR CONVERTING SCHEMAORG JSON TO SOLR DOCUMENTS.-->
+  <xsl:template name="schemaorgToSolr">
+    <!-- THIS IS THE BIGGEST AND BADDEST HACK IN TOWN! TO MAKE TEST METHODS AND XSLTS PRETTY AND MANAGEABLE,
+                 WE SHOULD REALLY IMPLEMENT THIS SCHEMA2SOLR TRANSFORMATION FOR MODS RESOURCES AS WELL. CURRENTLY, THIS
+                 BRANCH CAN'T GENERATE ANY SOLR-DOCUMENTS FOR MODS RECORDS, WHICH SHOULD BE DO-ABLE. -->
+    <xsl:if test="contains(map:get($schemaorg-xml,'@type'), 'VideoObject') or
+                          contains(map:get($schemaorg-xml,'@type'), 'AudioObject') or
+                          contains(map:get($schemaorg-xml,'@type'), 'MediaObject')">
+
+      <xsl:if test="f:exists($schemaorg-xml('keywords'))">
+        <!--Save categories to a variable as a sequence. -->
+        <xsl:variable name="categories" as="item()*" select="tokenize($schemaorg-xml('keywords'), ',')"/>
+        <!--Create array of categories, which fits with the multivalued solr field -->
+        <f:array key="categories">
+          <xsl:for-each select="$categories">
+            <f:string><xsl:value-of select="normalize-space(.)"/></f:string>
+          </xsl:for-each>
+        </f:array>
+      </xsl:if>
+
+      <!-- Extract collection-->
+      <xsl:if test="exists($schemaorg-xml('isPartOf'))">
+        <!-- Variable to find collections in. -->
+        <xsl:variable name="isPartOf" as="item()*">
+          <xsl:copy-of select="array:flatten($schemaorg-xml('isPartOf'))"/>
+        </xsl:variable>
+
+        <xsl:for-each select="$isPartOf">
+          <xsl:if test="map:get(., '@type') = 'Collection'">
+            <f:string key="collection">
+              <xsl:value-of select="map:get(., 'name')"/>
+            </f:string>
+          </xsl:if>
+        </xsl:for-each>
+
+      </xsl:if>
+
+      <!-- Extract main genre -->
+      <xsl:if test="$schemaorg-xml('genre')">
+        <f:string key="genre">
+          <xsl:value-of select="$schemaorg-xml('genre')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- extract title-->
+      <xsl:if test="$schemaorg-xml('name')">
+        <f:string key="title">
+          <xsl:value-of select="$schemaorg-xml('name')"/>
+        </f:string>
+
+        <f:string key="title_sort_da">
+          <xsl:value-of select="$schemaorg-xml('name')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- extract alternate title-->
+      <xsl:if test="$schemaorg-xml('alternateName')">
+        <f:string key="original_title">
+          <xsl:value-of select="$schemaorg-xml('alternateName')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract the creater affiliation. Two fields are required here as creator_affiliation can change over time.
+           Therefore, we are also extracting the creator_affiliation_generic which contains the same value for e.g.
+           DR P1 from 1960 'program 1' and 2000's 'P1'. Here the value would be drp1. -->
+      <xsl:if test="f:exists(map:get($schemaorg-xml, 'publication'))">
+        <xsl:if test="f:exists(my:getNestedMapValue2Levels($schemaorg-xml, 'publication','publishedOn'))">
+
+          <xsl:if test="not(f:empty(my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn',  'broadcastDisplayName')))">
+            <f:string key="creator_affiliation">
+              <xsl:value-of select="my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn',  'broadcastDisplayName')"/>
+            </f:string>
+          </xsl:if>
+
+          <xsl:if test="not(empty(my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn', 'alternateName')))">
+            <f:string key="creator_affiliation_generic">
+              <xsl:value-of select="my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn', 'alternateName')"/>
+            </f:string>
+          </xsl:if>
+
+          <xsl:if test="not(f:empty(my:getNestedMapValue4Levels($schemaorg-xml, 'publication',
+                                                            'publishedOn', 'broadcaster', 'legalName')))">
+            <f:string key="broadcaster">
+              <xsl:value-of select="my:getNestedMapValue4Levels($schemaorg-xml, 'publication',
+                                                              'publishedOn', 'broadcaster', 'legalName')"/>
+            </f:string>
+          </xsl:if>
+        </xsl:if>
+      </xsl:if>
+
+
+      <!-- Creates the notes field, which originates from the mods2solr XSLT and acts as a catch all field for metadata
+           The values in this field are also present in the specific abstract and description fields.-->
+      <xsl:if test="$schemaorg-xml('abstract') or $schemaorg-xml('description')">
+        <f:array key="notes">
+          <xsl:if test="$schemaorg-xml('abstract')">
+            <f:string>
+              <xsl:value-of select="$schemaorg-xml('abstract')"/>
+            </f:string>
+          </xsl:if>
+          <xsl:if test="$schemaorg-xml('description')">
+            <f:string>
+              <xsl:value-of select="$schemaorg-xml('description')"/>
+            </f:string>
+          </xsl:if>
+        </f:array>
+      </xsl:if>
+
+      <!-- Extract content url-->
+      <!-- TODO: What about resourceID?-->
+      <xsl:if test="$schemaorg-xml('contentUrl')">
+        <f:string key="streaming_url">
+          <xsl:value-of select="$schemaorg-xml('contentUrl')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract data on the encoded creative work, if present-->
+      <xsl:if test="map:contains($schemaorg-xml, 'encodesCreativeWork')">
+        <!-- extract episode titel -->
+        <xsl:if test="exists($schemaorg-xml('encodesCreativeWork')('name'))">
+          <f:string key="episode_title">
+            <xsl:value-of select="$schemaorg-xml('encodesCreativeWork')('name')"/>
+          </f:string>
+        </xsl:if>
+
+        <!-- Extract episode number -->
+        <xsl:if test="$schemaorg-xml('encodesCreativeWork')('episodeNumber')">
+          <f:string key="episode">
+            <xsl:value-of select="$schemaorg-xml('encodesCreativeWork')('episodeNumber')"/>
+          </f:string>
+        </xsl:if>
+
+        <!-- Quite nested structure here. We already know that the map encodesCreativeWork exists, now we are checking
+             for the submap partOfSeason and when that exists, we know that the numberOfEpisodes is present, as this
+             field is creating the map partOfSeason. -->
+        <!-- Extract number of episodes-->
+        <xsl:if test="map:contains($schemaorg-xml('encodesCreativeWork'), 'partOfSeason')">
+          <f:string key="number_of_episodes">
+            <xsl:value-of select="$schemaorg-xml('encodesCreativeWork')('partOfSeason')('numberOfEpisodes')"/>
+          </f:string>
+        </xsl:if>
+      </xsl:if>
+
+      <!-- extract start time-->
+      <xsl:if test="$schemaorg-xml('startTime')">
+        <f:string key="startTime">
+          <xsl:value-of select="$schemaorg-xml('startTime')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- extract end time-->
+      <xsl:if test="$schemaorg-xml('endTime')">
+        <f:string key="endTime">
+          <xsl:value-of select="$schemaorg-xml('endTime')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Calculate duration from start and end times-->
+      <xsl:if test="$schemaorg-xml('duration')">
+        <xsl:variable name="startTime">
+          <xsl:value-of select="$schemaorg-xml('startTime')"/>
+        </xsl:variable>
+        <xsl:variable name="endTime">
+          <xsl:value-of select="$schemaorg-xml('endTime')"/>
+        </xsl:variable>
+        <xsl:variable name="durationInMilliseconds">
+          <xsl:value-of select="my:toMilliseconds($startTime, $endTime)"/>
+        </xsl:variable>
+        <f:string key="duration_ms">
+          <xsl:value-of select="$durationInMilliseconds"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract color boolean-->
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:color') != ''">
+        <f:string key="color">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:color') "/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract videoQuality -->
+      <xsl:if test="$schemaorg-xml('videoQuality')">
+        <f:string key="video_quality">
+          <xsl:value-of select="$schemaorg-xml('videoQuality')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract surround sound-->
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:surround_sound') != ''">
+        <f:string key="surround_sound">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:surround_sound')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract premiere-->
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:premiere') != ''">
+        <f:string key="premiere">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:premiere')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract aspect ratio-->
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio') != ''">
+        <f:string key="aspect_ratio">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract boolean for live broadcast -->
+      <xsl:if test="f:exists($schemaorg-xml('publication'))">
+        <xsl:if test="f:exists($schemaorg-xml('publication')('isLiveBroadcast'))">
+          <f:string key="live_broadcast">
+            <xsl:value-of select="$schemaorg-xml('publication')('isLiveBroadcast')"/>
+          </f:string>
+        </xsl:if>
+      </xsl:if>
+
+      <!-- Extract boolean for retransmission -->
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:retransmission')">
+        <f:string key="retransmission">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:retransmission')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract abstract -->
+      <xsl:if test="f:exists($schemaorg-xml('abstract'))">
+        <f:string key="abstract">
+          <xsl:value-of select="$schemaorg-xml('abstract')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract description -->
+      <xsl:if test="f:exists($schemaorg-xml('description'))">
+        <f:string key="description">
+          <xsl:value-of select="$schemaorg-xml('description')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract sub genre -->
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:genre_sub')">
+        <f:string key="genre_sub">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:genre_sub')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract boolean for subtitles -->
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:has_subtitles')">
+        <f:string key="has_subtitles">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:has_subtitles')"/>
+        </f:string>
+      </xsl:if>
+
+      <!-- Extract boolean for subtitles for hearing impaired  -->
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal',
+                                                        'kb:has_subtitles_for_hearing_impaired')">
+        <f:string key="has_subtitles_for_hearing_impaired">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal',
+                                                                    'kb:has_subtitles_for_hearing_impaired')"/>
+        </f:string>
+      </xsl:if>
+
+      <!--For each identifier in the variable $identifiers check for specific properties and map them to their
+          respective solr counterpart.-->
+      <xsl:for-each select="$identifers">
+        <xsl:call-template name="identifierExtractor"/>
+      </xsl:for-each>
+
+      <!-- Extract internal fields -->
+      <xsl:call-template name="kbInternal">
+        <xsl:with-param name="internalMap" select="$schemaorg-xml('kb:internal')"/>
+      </xsl:call-template>
+    </xsl:if>
   </xsl:template>
 
   <!-- EXTRACT IDENTIFIERS FROM THE SCHEMA.ORG ARRAY OF IDENTIFIERS. -->

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -221,21 +221,21 @@
           </xsl:if>
 
           <!-- Extract surround sound-->
-        <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:surround_sound') != ''">
+          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:surround_sound') != ''">
             <f:string key="surround_sound">
               <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:surround_sound')"/>
             </f:string>
           </xsl:if>
 
           <!-- Extract premiere-->
-        <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:premiere') != ''">
+          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:premiere') != ''">
             <f:string key="premiere">
               <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:premiere')"/>
             </f:string>
           </xsl:if>
 
           <!-- Extract aspect ratio-->
-        <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio') != ''">
+          <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio') != ''">
             <f:string key="aspect_ratio">
               <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio')"/>
             </f:string>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -745,6 +745,13 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     c8f496cf-4e0b-4682-8eee-67dfe07525d2,8ac98f6e-5653-492a-ab8c-c1462edaeb4a?>
   </field>
 
+  <field name="internal_transformation_error" type="boolean" default="false">
+    <?description This field tells if any of the XSLT transformations have failed during creation of the metadata document?>
+  </field>
+
+  <field name="internal_transformation_error_description" type="text_general">
+    <?description If any of the XSLT metadata transformations have failed during creation of the document, the error will be contained in this field.?>
+  </field>
   <!-- ================================================================ -->
   <!-- ====== Fields related to copyright and access conditions   ===== -->
   <!-- ================================================================ -->

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -344,10 +344,14 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
 
     }
 
+    @Test
+    void testErrorCatching() throws IOException {
+        Map<String, String> fakeManifestation = Map.of("manifestation", "test");
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_4f706cda, fakeManifestation);
 
-
-
-
+        Assertions.assertTrue(transformedJSON.contains("\"kb:transformation_error_description\":" +
+                "\"First argument to parse-xml() is not a well-formed and namespace-well-formed XML document."));
+    }
 
     private static void printSchemaOrgJson(String xml) throws IOException {
         Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/",

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -36,8 +36,8 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
 
     @Test
     public void testSetup() throws IOException {
-        //printSchemaOrgJson(PVICA_RECORD_74e22fd8);
-        printSchemaOrgJson(TestFiles.PVICA_RECORD_4f706cda);
+        printSchemaOrgJson(TestFiles.PVICA_RECORD_74e22fd8);
+        //printSchemaOrgJson(TestFiles.PVICA_RECORD_4f706cda);
         //printSchemaOrgJson(PVICA_RECORD_1F3A6A66);
         //printSchemaOrgJson(PVICA_RECORD_44979f67);
     }


### PR DESCRIPTION
Add try-catch to XSLTs. I haven't figured how to create a unittest for it. To see the functionality in action you could add the following inside a try-tag and then run the following tests `dk.kb.present.transform.XSLTPreservicaSchemaOrgTransformerTest#testSetup` and `dk.kb.present.transform.XSLTPreservicaToSolrTransformerTest#prettyPrintTransformation`:

 `<f:string key="tester">
    <xsl:value-of select="20 div 0"/>
  </f:string>`