### PR TITLE
Disc 546 fields for temporal search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added [1.4.0]
+- Add solr fields for temporal searching. 
+
 ### Added [1.3.0]
 - Added ReflectUtil class containing methods used for testing. Using these methods instead of internal mockito methods makes the project not depend on mockitos old internal class.
 - Add mTime from ds-storage to solr documents
 - Add support for XSLT transformation of Preservica records from preservica 6.
 
-### Changed
+### Changed [1.3.0]
 - Updated OpenAPI YAML with new example values
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>dk.kb.present</groupId>
     <artifactId>ds-present</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <description>Transforming access layer for metadata, by the Royal Danish Library. Acts as a proxy for [ds-storage](https://github.com/kb-dk/ds-storage) providing multiple views on metadata, such as MODS, JSON-LD and SolrJsonDocument.</description>
 

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -226,17 +226,69 @@
         </xsl:if>
       </xsl:if>
 
-      <!-- extract start time-->
+      <!-- If statement creating all fields related to the schema.org value startTime -->
       <xsl:if test="$schemaorg-xml('startTime')">
+        <xsl:variable name="startTimeZulu" as="xs:dateTime">
+          <xsl:value-of select="$schemaorg-xml('startTime')"/>
+        </xsl:variable>
+
+        <!-- Using danish "normal time" which is the european winter time for timezone GMT+1 -->
+        <xsl:variable name="startTimeDK" as="xs:dateTime">
+          <xsl:value-of select="f:adjust-dateTime-to-timezone($startTimeZulu, xs:dayTimeDuration('PT1H'))"/>
+        </xsl:variable>
+        
         <f:string key="startTime">
           <xsl:value-of select="$schemaorg-xml('startTime')"/>
         </f:string>
+
+        <xsl:variable name="temporal_start_time_da_string">
+          <xsl:value-of select="xs:time($startTimeDK)"/>
+        </xsl:variable>
+
+        <!-- The string value of the danish time. -->
+        <f:string key="temporal_start_time_da_string">
+          <xsl:value-of select="$temporal_start_time_da_string"/>
+        </f:string>
+
+        <f:string key="temporal_start_time_da_date">
+          <xsl:value-of select="xs:dateTime(concat('9999-01-01T', $temporal_start_time_da_string))"/>
+        </f:string>
+
+        <f:string key="temporal_start_day_da">
+          <xsl:value-of select="format-dateTime($startTimeDK, '[F]')"/>
+        </f:string>
       </xsl:if>
 
-      <!-- extract end time-->
+      <!-- If statement creating all fields related to the schema.org value endTime -->
       <xsl:if test="$schemaorg-xml('endTime')">
+        <xsl:variable name="endTimeZulu" as="xs:dateTime">
+          <xsl:value-of select="$schemaorg-xml('endTime')"/>
+        </xsl:variable>
+
+        <!-- Using danish "normal time" which is the european winter time for timezone GMT+1 -->
+        <xsl:variable name="endTimeDK" as="xs:dateTime">
+          <xsl:value-of select="f:adjust-dateTime-to-timezone($endTimeZulu, xs:dayTimeDuration('PT1H'))"/>
+        </xsl:variable>
+
         <f:string key="endTime">
           <xsl:value-of select="$schemaorg-xml('endTime')"/>
+        </f:string>
+
+        <xsl:variable name="temporal_end_time_da_string">
+          <xsl:value-of select="xs:time($endTimeDK)"/>
+        </xsl:variable>
+
+        <!-- The string value of the danish time. -->
+        <f:string key="temporal_end_time_da_string">
+          <xsl:value-of select="$temporal_end_time_da_string"/>
+        </f:string>
+
+        <f:string key="temporal_end_time_da_date">
+          <xsl:value-of select="xs:dateTime(concat('9999-01-01T', $temporal_end_time_da_string))"/>
+        </f:string>
+
+        <f:string key="temporal_end_day_da">
+          <xsl:value-of select="format-dateTime($endTimeDK, '[F]')"/>
         </f:string>
       </xsl:if>
 

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -241,8 +241,9 @@
           <xsl:value-of select="$schemaorg-xml('startTime')"/>
         </f:string>
 
+        <!-- Extracts the time from the datetime variable in danish normal time. -->
         <xsl:variable name="temporal_start_time_da_string">
-          <xsl:value-of select="xs:time($startTimeDK)"/>
+          <xsl:value-of select="substring-before(xs:string(xs:time($startTimeDK)),'+')"/>
         </xsl:variable>
 
         <!-- The string value of the danish time. -->
@@ -251,7 +252,7 @@
         </f:string>
 
         <f:string key="temporal_start_time_da_date">
-          <xsl:value-of select="xs:dateTime(concat('9999-01-01T', $temporal_start_time_da_string))"/>
+          <xsl:value-of select="xs:dateTime(concat('9999-01-01T', $temporal_start_time_da_string, 'Z'))"/>
         </f:string>
 
         <f:string key="temporal_start_day_da">
@@ -274,8 +275,9 @@
           <xsl:value-of select="$schemaorg-xml('endTime')"/>
         </f:string>
 
+        <!-- Extracts the time from the datetime variable in danish normal time. -->
         <xsl:variable name="temporal_end_time_da_string">
-          <xsl:value-of select="xs:time($endTimeDK)"/>
+          <xsl:value-of select="substring-before(xs:string(xs:time($endTimeDK)),'+')"/>
         </xsl:variable>
 
         <!-- The string value of the danish time. -->
@@ -284,7 +286,7 @@
         </f:string>
 
         <f:string key="temporal_end_time_da_date">
-          <xsl:value-of select="xs:dateTime(concat('9999-01-01T', $temporal_end_time_da_string))"/>
+          <xsl:value-of select="xs:dateTime(concat('9999-01-01T', $temporal_end_time_da_string, 'Z'))"/>
         </f:string>
 
         <f:string key="temporal_end_day_da">

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -240,6 +240,14 @@
         <f:string key="startTime">
           <xsl:value-of select="$schemaorg-xml('startTime')"/>
         </f:string>
+        
+        <f:string key="startTime_in_summertime">
+
+          <xsl:value-of select="format-dateTime($startTimeZulu, '', 'en', 'en', 'en')"/>
+<!--
+          <xsl:value-of select="in-summer-time($startTimeDK, 'dk')"/>
+-->
+        </f:string>
 
         <!-- Extracts the time from the datetime variable in danish normal time. -->
         <xsl:variable name="temporal_start_time_da_string">

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -234,24 +234,17 @@
 
         <!-- Using danish "normal time" which is the european winter time for timezone GMT+1 -->
         <xsl:variable name="startTimeDK" as="xs:dateTime">
-          <xsl:value-of select="f:adjust-dateTime-to-timezone($startTimeZulu, xs:dayTimeDuration('PT1H'))"/>
+          <!--<xsl:value-of select="f:adjust-dateTime-to-timezone($startTimeZulu, xs:dayTimeDuration('PT1H'))"/>-->
+          <xsl:value-of select="format-dateTime($startTimeZulu, '[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01]', (), (), 'Europe/Copenhagen')"/>
         </xsl:variable>
         
         <f:string key="startTime">
           <xsl:value-of select="$schemaorg-xml('startTime')"/>
         </f:string>
-        
-        <f:string key="startTime_in_summertime">
-
-          <xsl:value-of select="format-dateTime($startTimeZulu, '', 'en', 'en', 'en')"/>
-<!--
-          <xsl:value-of select="in-summer-time($startTimeDK, 'dk')"/>
--->
-        </f:string>
 
         <!-- Extracts the time from the datetime variable in danish normal time. -->
         <xsl:variable name="temporal_start_time_da_string">
-          <xsl:value-of select="substring-before(xs:string(xs:time($startTimeDK)),'+')"/>
+          <xsl:value-of select="xs:string(xs:time($startTimeDK))"/>
         </xsl:variable>
 
         <!-- The string value of the danish time. -->
@@ -276,7 +269,8 @@
 
         <!-- Using danish "normal time" which is the european winter time for timezone GMT+1 -->
         <xsl:variable name="endTimeDK" as="xs:dateTime">
-          <xsl:value-of select="f:adjust-dateTime-to-timezone($endTimeZulu, xs:dayTimeDuration('PT1H'))"/>
+          <!--<xsl:value-of select="f:adjust-dateTime-to-timezone($endTimeZulu, xs:dayTimeDuration('PT1H'))"/>-->
+          <xsl:value-of select="format-dateTime($endTimeZulu, '[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01]', (), (), 'Europe/Copenhagen')"/>
         </xsl:variable>
 
         <f:string key="endTime">
@@ -285,7 +279,7 @@
 
         <!-- Extracts the time from the datetime variable in danish normal time. -->
         <xsl:variable name="temporal_end_time_da_string">
-          <xsl:value-of select="substring-before(xs:string(xs:time($endTimeDK)),'+')"/>
+          <xsl:value-of select="xs:string(xs:time($endTimeDK))"/>
         </xsl:variable>
 
         <!-- The string value of the danish time. -->

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -582,6 +582,42 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     www.example.com/streaming/bart-access-copies-tv/00/00/00/000000e1-0000-462a-a2b4-7488244fcca7/playlist.m3u8"?>
   </field>
 
+  <field name="temporal_start_time_da_string" type="string">
+    <?description The start time of the broadcast in GMT+01:00 (Danish Normal Time) represented as a string?>
+    <?example 17:15:00?>
+  </field>
+
+  <field name="temporal_end_time_da_string" type="string">
+    <?description The end time of the broadcast in GMT+01:00 (Danish Normal Time) represented as a string?>
+    <?example 17:40:00?>
+  </field>
+
+  <!-- TODO: I dont know if this is a valid way to implement this field. -->
+  <field name="temporal_start_time_da_date" type="pdate">
+    <?description A solr date representation of the temporal_start_time_da_string. This date value does NOT represent a
+                  valid datetime, as the date is always 9999-01-01. Furthermore the field and solr thinks that the value is in zulu
+                  time, however the value is in fact in GMT+01:00 (Danish Normal Time). This field should not be used to
+                  query for a specific date.?>
+    <?example 9999-01-01T17:15:00Z?>
+  </field>
+
+  <field name="temporal_end_time_da_date" type="pdate">
+    <?description A solr date representation of the temporal_end_time_da_string. This date value does NOT represent a
+            valid datetime, as the date is always 9999-01-01. Furthermore the field and solr thinks that the value is in zulu
+            time, however the value is in fact in GMT+01:00 (Danish Normal Time). This field should not be used to
+            query for a specific date.?>
+    <?example 9999-01-01T17:40:00Z?>
+  </field>
+
+  <field name="temporal_start_day_da" type="string">
+    <?description The day of the week when the broadcast started.?>
+    <?example Monday?>
+  </field>
+
+  <field name="temporal_end_day_da" type="string">
+    <?description The day of the week when the broadcast ended. ?>
+    <?example Friday?>
+  </field>
 
 
   <!-- =========================================================================== -->

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -408,15 +408,15 @@ public class EmbeddedSolrTest {
 
     @Test
     void testPvicaTemporalFields() throws Exception {
-        testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_time_da_string", "17:15:00" );
-        testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_end_time_da_string", "17:40:00");
+        testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_time_da_string", "18:15:00" );
+        testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_end_time_da_string", "18:40:00");
         testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_day_da", "Saturday");
         testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_end_day_da", "Saturday");
 
-        Date startDate = new Date(253370826900000L);
+        Date startDate = new Date(253370830500000L);
         testDateValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_time_da_date", startDate);
 
-        Date endDate = new Date(253370828400000L);
+        Date endDate = new Date(253370832000000L);
         testDateValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_end_time_da_date", endDate);
 
     /*

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -406,6 +406,25 @@ public class EmbeddedSolrTest {
     }
 
     @Test
+    void testPvicaTemporalFields() throws Exception {
+        testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_time_da_string", "17:15:00" );
+        testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_end_time_da_string", "17:40:00");
+        testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_day_da", "Saturday");
+        testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_end_day_da", "Saturday");
+
+        Date startDate = new Date(253370826900000L);
+        testDateValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_time_da_date", startDate);
+
+        Date endDate = new Date(253370828400000L);
+        testDateValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_end_time_da_date", endDate);
+
+    /*
+    <field name="temporal_start_time_da_date" type="pdate">
+    <field name="temporal_end_time_da_date" type="pdate">
+    */
+    }
+
+    @Test
     void testColor() throws Exception {
         testBooleanValuePreservicaField(PVICA_RECORD_44979f67, "color", true );
     }

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -429,6 +429,7 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
         String solrString;
         try {
             solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJson(PRESERVICA2SCHEMAORG, record);
+            TestUtil.prettyPrintJson(solrString);
         } catch (Exception e) {
             throw new RuntimeException(
                     "Unable to fetch and transform '" + record + "' using XSLT '" + getXSLT() + "'", e);

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -434,7 +434,6 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
         String solrString;
         try {
             solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJson(PRESERVICA2SCHEMAORG, record);
-            TestUtil.prettyPrintJson(solrString);
         } catch (Exception e) {
             throw new RuntimeException(
                     "Unable to fetch and transform '" + record + "' using XSLT '" + getXSLT() + "'", e);

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -3,6 +3,7 @@ package dk.kb.present.transform;
 import dk.kb.present.TestFiles;
 import dk.kb.present.TestUtil;
 import dk.kb.present.util.TestFileProvider;
+import dk.kb.util.Files;
 import dk.kb.util.Resolver;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -10,9 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.function.Consumer;
 
 import static dk.kb.present.transform.XSLTPreservicaSchemaOrgTransformerTest.PRESERVICA2SCHEMAORG;
@@ -314,13 +316,37 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
 
     @Test
     void testTemporalSearchFields(){
-        assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_start_time_da_string\":\"17:15:00\"," +
-                                                                        "\"temporal_start_time_da_date\":\"9999-01-01T17:15:00Z\"," +
+        // TODO: This unit test fails as the timestamps are offset with 1 hour, where they should be offset by 2
+        // due to Sanish summer time. This is not an error in the unit test (check at https://www.worldtimebuddy.com/)
+        // but a conversion error in the code
+        assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_start_time_da_string\":\"18:15:00\"," +
+                                                                        "\"temporal_start_time_da_date\":\"9999-01-01T18:15:00Z\"," +
                                                                         "\"temporal_start_day_da\":\"Saturday\"");
-        assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_end_time_da_string\":\"17:40:00\"," +
-                                                                        "\"temporal_end_time_da_date\":\"9999-01-01T17:40:00Z\"," +
+        assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_end_time_da_string\":\"18:40:00\"," +
+                                                                        "\"temporal_end_time_da_date\":\"9999-01-01T18:40:00Z\"," +
                                                                         "\"temporal_end_day_da\":\"Saturday\"");
     }
+
+    // Adjusted version of testTemporalSearchFields, where the month has been changed from April to February to
+    // check if Danish summer/winter time is obeyed.
+    @Test
+    void testTemporalSearchFieldsWinther() throws IOException {
+        String winter = Resolver.resolveUTF8String(TestFiles.PVICA_RECORD_1f3a6a66)
+                .replace("2012-04-28T", "2012-02-28T");
+        File winterFile = Path.of(Resolver.resolveURL("ds-present-openapi_v1.yaml").getPath())
+                .getParent()
+                .resolve("1f3a6a66_winther.xml")
+                .toFile();
+        Files.saveString(winter, winterFile);
+
+        assertPvicaContains(winterFile.getAbsolutePath(), "\"temporal_start_time_da_string\":\"17:15:00\"," +
+                                                                        "\"temporal_start_time_da_date\":\"9999-01-01T17:15:00Z\"," +
+                                                                        "\"temporal_start_day_da\":\"Tuesday\"");
+        assertPvicaContains(winterFile.getAbsolutePath(), "\"temporal_end_time_da_string\":\"17:40:00\"," +
+                                                                        "\"temporal_end_time_da_date\":\"9999-01-01T17:40:00Z\"," +
+                                                                        "\"temporal_end_day_da\":\"Tuesday\"");
+    }
+
     @Test
     void testNoNotes(){
         assertPvicaNotContains(TestFiles.PVICA_RECORD_b346acc8, "\"notes\":");
@@ -407,7 +433,6 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
             throw new RuntimeException(
                     "Unable to fetch and transform '" + record + "' using XSLT '" + getXSLT() + "'", e);
         }
-
         Arrays.stream(tests).forEach(test -> test.accept(solrString));
     }
 

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -313,6 +313,15 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
     }
 
     @Test
+    void testTemporalSearchFields(){
+        assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_start_time_da_string\":\"17:15:00+01:00\"," +
+                                                                        "\"temporal_start_time_da_date\":\"9999-01-01T17:15:00+01:00\"," +
+                                                                        "\"temporal_start_day_da\":\"Saturday\"");
+        assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_end_time_da_string\":\"17:40:00+01:00\"," +
+                                                                        "\"temporal_end_time_da_date\":\"9999-01-01T17:40:00+01:00\"," +
+                                                                        "\"temporal_end_day_da\":\"Saturday\"");
+    }
+    @Test
     void testNoNotes(){
         assertPvicaNotContains(TestFiles.PVICA_RECORD_b346acc8, "\"notes\":");
     }
@@ -349,7 +358,7 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
 
     @Test
     public void prettyPrintTransformation() throws Exception {
-        String solrJson = TestUtil.getTransformedToSolrJsonThroughSchemaJson(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_2973e7fa);
+        String solrJson = TestUtil.getTransformedToSolrJsonThroughSchemaJson(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_1f3a6a66);
         TestUtil.prettyPrintJson(solrJson);
     }
 

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -314,11 +314,11 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
 
     @Test
     void testTemporalSearchFields(){
-        assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_start_time_da_string\":\"17:15:00+01:00\"," +
-                                                                        "\"temporal_start_time_da_date\":\"9999-01-01T17:15:00+01:00\"," +
+        assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_start_time_da_string\":\"17:15:00\"," +
+                                                                        "\"temporal_start_time_da_date\":\"9999-01-01T17:15:00Z\"," +
                                                                         "\"temporal_start_day_da\":\"Saturday\"");
-        assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_end_time_da_string\":\"17:40:00+01:00\"," +
-                                                                        "\"temporal_end_time_da_date\":\"9999-01-01T17:40:00+01:00\"," +
+        assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_end_time_da_string\":\"17:40:00\"," +
+                                                                        "\"temporal_end_time_da_date\":\"9999-01-01T17:40:00Z\"," +
                                                                         "\"temporal_end_day_da\":\"Saturday\"");
     }
     @Test

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -316,9 +316,7 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
 
     @Test
     void testTemporalSearchFields(){
-        // TODO: This unit test fails as the timestamps are offset with 1 hour, where they should be offset by 2
-        // due to Sanish summer time. This is not an error in the unit test (check at https://www.worldtimebuddy.com/)
-        // but a conversion error in the code
+        // Sanity check time zone conversions at https://www.worldtimebuddy.com/
         assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_start_time_da_string\":\"18:15:00\"," +
                                                                         "\"temporal_start_time_da_date\":\"9999-01-01T18:15:00Z\"," +
                                                                         "\"temporal_start_day_da\":\"Saturday\"");


### PR DESCRIPTION
First try at implementing solr fields for temporal search. 

The values are not represented in schema.org yet. Do we think they should? 

Please have an extra look on the creation and use of the fields `temporal_start_time_da_date` and `temporal_end_time_da_date` as these fields are quite rule bending (by not being valid dates and in a wrong timezone)