### PR TITLE
Disc 579 update xslt preservica6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Added [1.3.0]
 - Added ReflectUtil class containing methods used for testing. Using these methods instead of internal mockito methods makes the project not depend on mockitos old internal class.
 - Add mTime from ds-storage to solr documents
+- Add support for XSLT transformation of Preservica records from preservica 6.
 
 ### Changed
 - Updated OpenAPI YAML with new example values

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>dk.kb.present</groupId>
     <artifactId>ds-present</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <description>Transforming access layer for metadata, by the Royal Danish Library. Acts as a proxy for [ds-storage](https://github.com/kb-dk/ds-storage) providing multiple views on metadata, such as MODS, JSON-LD and SolrJsonDocument.</description>
 

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -45,6 +45,14 @@
         <xsl:choose>
           <!--Check if an error has occurred in hte previous transformer. Otherwise, continue with this transformation -->
           <xsl:when test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:transformation_error') = 'true'">
+            <xsl:for-each select="$identifers">
+              <xsl:if test="map:get(., 'PropertyID') = 'Origin'">
+                <f:string key="origin">
+                  <xsl:value-of select="map:get(., 'value')"/>
+                </f:string>
+              </xsl:if>
+            </xsl:for-each>
+
             <f:string key="internal_transformation_error">
               <xsl:value-of select="f:true()"/>
             </f:string>

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -34,6 +34,7 @@ public class TestFiles {
     public static final String PVICA_RECORD_4f706cda = "internal_test_files/tvMetadata/4f706cda-f474-46c8-824b-5a62ed5a8bee.xml";
     public static final String PVICA_RECORD_2973e7fa = "internal_test_files/tvMetadata/2973e7fa-0531-4c37-8b8d-5726c553b30b.xml";
     public static final String PVICA6_RECORD_00a9e71c = "internal_test_files/preservica6/00a9e71c-1264-4e57-9238-b38ec5672fb2.xml";
+    public static final String PVICA6_RECORD_d4ea826f = "internal_test_files/preservica6/d4ea826f-03d2-4379-9b75-1e84648bf7df.xml";
     public static final String CUMULUS_RECORD_05fea810 = "xml/copyright_extraction/05fea810-7181-11e0-82d7-002185371280.xml";
     public static final String CUMULUS_RECORD_3956d820 = "xml/copyright_extraction/3956d820-7b7d-11e6-b2b3-0016357f605f.xml";
     public static final String CUMULUS_RECORD_096c9090 = "xml/copyright_extraction/096c9090-717f-11e0-82d7-002185371280.xml";

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -33,6 +33,7 @@ public class TestFiles {
     public static final String PVICA_RECORD_5b29fca1 = "internal_test_files/tvMetadata/5b29fca1-5e6a-4ef2-a5d2-a7550a25388d.xml";
     public static final String PVICA_RECORD_4f706cda = "internal_test_files/tvMetadata/4f706cda-f474-46c8-824b-5a62ed5a8bee.xml";
     public static final String PVICA_RECORD_2973e7fa = "internal_test_files/tvMetadata/2973e7fa-0531-4c37-8b8d-5726c553b30b.xml";
+    public static final String PVICA6_RECORD_00a9e71c = "internal_test_files/preservica6/00a9e71c-1264-4e57-9238-b38ec5672fb2.xml";
     public static final String CUMULUS_RECORD_05fea810 = "xml/copyright_extraction/05fea810-7181-11e0-82d7-002185371280.xml";
     public static final String CUMULUS_RECORD_3956d820 = "xml/copyright_extraction/3956d820-7b7d-11e6-b2b3-0016357f605f.xml";
     public static final String CUMULUS_RECORD_096c9090 = "xml/copyright_extraction/096c9090-717f-11e0-82d7-002185371280.xml";

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -183,6 +183,7 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     void testNoNullKeywords() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_3006e2f8);
+        TestUtil.prettyPrintJson(transformedJSON);
         Assertions.assertFalse(transformedJSON.contains("null"));
     }
 

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -36,7 +36,7 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
 
     @Test
     public void testSetup() throws IOException {
-        printSchemaOrgJson(TestFiles.PVICA_RECORD_74e22fd8);
+        printSchemaOrgJson(TestFiles.PVICA6_RECORD_00a9e71c);
         //printSchemaOrgJson(TestFiles.PVICA_RECORD_4f706cda);
         //printSchemaOrgJson(PVICA_RECORD_1F3A6A66);
         //printSchemaOrgJson(PVICA_RECORD_44979f67);

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -353,8 +353,12 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
     }
 
     @Test
+    void testOriginForFailedTransformation(){
+        assertPvicaContains(TestFiles.PVICA6_RECORD_d4ea826f, "\"origin\":");
+    }
+    @Test
     public void prettyPrintTransformation() throws Exception {
-        String solrJson = TestUtil.getTransformedToSolrJsonThroughSchemaJson(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_2973e7fa);
+        String solrJson = TestUtil.getTransformedToSolrJsonThroughSchemaJson(PRESERVICA2SCHEMAORG, TestFiles.PVICA6_RECORD_d4ea826f);
         TestUtil.prettyPrintJson(solrJson);
     }
 


### PR DESCRIPTION
XSLT PR: 

Updates the XSLT to be able to handle records from both preservica 5 and 6. This is done by  using a lot more variables. 

NB: When this PR gets merged and solr gets updated there will be a lot of records with no streamingUrl, as records from pvica 6 doesnt contain this information yet. We should keep this in mind for demos. 