### PR TITLE
Disc 628 io records transformation error and DISC-624 empty genre_sub field

### DIFF
--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -636,11 +636,15 @@
       </xsl:if>
       <!-- Extracts PID as identifier if present.-->
       <xsl:if test="$metadataPath//pidhandle:pidhandle/handle">
+        <xsl:variable name="pidHandles">
+          <xsl:value-of select="distinct-values($metadataPath//pidhandle:pidhandle/handle)"/>
+        </xsl:variable>
+
         <f:map>
           <f:string key="@type">PropertyValue</f:string>
           <f:string key="PropertyID">PID</f:string>
           <f:string key="value">
-            <xsl:value-of select="substring-after($metadataPath//pidhandle:pidhandle/handle, 'hdl:')"/>
+            <xsl:value-of select="substring-after($pidHandles, 'hdl:')"/>
           </f:string>
         </f:map>
       </xsl:if>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -330,7 +330,7 @@
       </xsl:if>
 
       <!-- Extract sub genre -->
-      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:genre_sub')">
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:genre_sub') != '' ">
         <f:string key="genre_sub">
           <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:genre_sub')"/>
         </f:string>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -171,8 +171,8 @@
             </f:string>
           </xsl:if>
 
-          <xsl:if test="not(f:empty(my:getNestedMapValue4Levels($schemaorg-xml, 'publication',
-                                                            'publishedOn', 'broadcaster', 'legalName')))">
+          <xsl:if test="my:getNestedMapValue4Levels($schemaorg-xml, 'publication',
+                                                    'publishedOn', 'broadcaster', 'legalName') != ''">
             <f:string key="broadcaster">
               <xsl:value-of select="my:getNestedMapValue4Levels($schemaorg-xml, 'publication',
                                                               'publishedOn', 'broadcaster', 'legalName')"/>

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -33,6 +33,7 @@ public class TestFiles {
     public static final String PVICA_RECORD_5b29fca1 = "internal_test_files/tvMetadata/5b29fca1-5e6a-4ef2-a5d2-a7550a25388d.xml";
     public static final String PVICA_RECORD_4f706cda = "internal_test_files/tvMetadata/4f706cda-f474-46c8-824b-5a62ed5a8bee.xml";
     public static final String PVICA_RECORD_2973e7fa = "internal_test_files/tvMetadata/2973e7fa-0531-4c37-8b8d-5726c553b30b.xml";
+    public static final String PVICA_RECORD_53ce4817 = "internal_test_files/tvMetadata/53ce4817-56ce-4e41-bac4-ba2dda938199.xml";
     public static final String PVICA6_RECORD_00a9e71c = "internal_test_files/preservica6/00a9e71c-1264-4e57-9238-b38ec5672fb2.xml";
     public static final String PVICA6_RECORD_d4ea826f = "internal_test_files/preservica6/d4ea826f-03d2-4379-9b75-1e84648bf7df.xml";
     public static final String CUMULUS_RECORD_05fea810 = "xml/copyright_extraction/05fea810-7181-11e0-82d7-002185371280.xml";

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -356,9 +356,15 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
     void testOriginForFailedTransformation(){
         assertPvicaContains(TestFiles.PVICA6_RECORD_d4ea826f, "\"origin\":");
     }
+
+    @Test
+    void testNoEmptyGenreSubField(){
+        assertPvicaNotContains(TestFiles.PVICA_RECORD_53ce4817, "\"genre_sub\"");
+    }
+
     @Test
     public void prettyPrintTransformation() throws Exception {
-        String solrJson = TestUtil.getTransformedToSolrJsonThroughSchemaJson(PRESERVICA2SCHEMAORG, TestFiles.PVICA6_RECORD_d4ea826f);
+        String solrJson = TestUtil.getTransformedToSolrJsonThroughSchemaJson(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_53ce4817);
         TestUtil.prettyPrintJson(solrJson);
     }
 


### PR DESCRIPTION
I squashed these two issues into the same PR as the code changes where quite small.

- Some IO records have their pid handle twice. These gets compared now and one is extracted. 
- As @thomasegense noted there are a lot of records with the field `genre_sub` with the value being an empty string. This is also fixed.
 
I'll also create an issue on going through the index looking for more fields with empty values as I suspect that I might have introduced these with my JSON parsing XSLT functions.