### PR TITLE
Disc 587 suggest dictionary

### DIFF
--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -87,7 +87,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?query_example ?>
   </field>
 
-  <field name="title" type="text_general" multiValued="true"> <!-- Only present in maps collection test data-->
+  <field name="title" type="text_general" multiValued="true" stored="true"> <!-- Only present in maps collection test data-->
     <?description The object title.?>
     <?example     Den grimme ælling.?>
   </field>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -854,6 +854,7 @@
       <str name="field">title</str>      
       <str name="suggestAnalyzerFieldType">string</str>
       <str name="buildOnStartup">true</str>         <!-- Good enough for now -->
+      <str name="buildOnCommit">true</str>
     </lst>
   </searchComponent>
 

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -839,6 +839,7 @@
       <lst name="defaults">
       <str name="suggest">true</str>
       <str name="suggest.count">10</str>
+      <str name="suggest.dictionary">dr_title_suggest</str>
       </lst>
       <arr name="components">
         <str>suggest</str>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -837,9 +837,9 @@
 
     <requestHandler name="/suggest" class="solr.SearchHandler" startup="lazy">
       <lst name="defaults">
-      <str name="suggest">true</str>
-      <str name="suggest.count">10</str>
-      <str name="suggest.dictionary">dr_title_suggest</str>
+        <str name="suggest.dictionary">dr_title_suggest</str>
+        <str name="suggest">true</str>
+        <str name="suggest.count">10</str>
       </lst>
       <arr name="components">
         <str>suggest</str>


### PR DESCRIPTION
Default suggest dictionary has been added to config. 

I had some problems getting the suggest component working on devel. This was due to it not being build when new collections were created. It was correctly build when solr was restarted and when the configuration was updated. When the component haven't been build it can be build during query by adding `&suggest.build=true` to the query. I've added a note on this in our setup documentation