### PR TITLE
Solr configuration update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added [1.4.0]
 - Add solr fields for temporal searching. 
 
+### Fixed
+- Configuration update of existing collection now works: bin/cloud_ds.sh update
+
 ### Added [1.3.0]
 - Added ReflectUtil class containing methods used for testing. Using these methods instead of internal mockito methods makes the project not depend on mockitos old internal class.
 - Add mTime from ds-storage to solr documents

--- a/bin/cloud_sync.sh
+++ b/bin/cloud_sync.sh
@@ -160,8 +160,22 @@ create_new_collection() {
 
 update_existing_collection() {
     echo "Collection $COLLECTION already exist. Assigning config $CONFIG_NAME"
-    $SOLR_SCRIPTS/zkcli.sh -zkhost $ZOOKEEPER -cmd linkconfig -collection $COLLECTION -confname $CONFIG_NAME
 
+    # ZooKeepers linkconfig does change part of the state in Solr 9, but does not result
+    # in an effective config change
+    #$SOLR_SCRIPTS/zkcli.sh -zkhost $ZOOKEEPER -cmd linkconfig -collection $COLLECTION -confname $CONFIG_NAME
+
+    # Solr API v1 index config change should work, according to
+    # https://solr.apache.org/guide/solr/latest/deployment-guide/collection-management.html#modifycollection
+    # Calling this throws
+    # java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class java.lang.String...
+    # URL="http://$SOLR/solr/admin/collections?action=MODIFYCOLLECTION&collection=${COLLECTION}&collection.configName=${CONFIG_NAME}&collection.configName=${CONFIG_NAME}"
+    # curl -s "$URL"
+
+    # Solr API v2 index config change DOES work. At least for Solr 9.4
+    curl -X POST "http://${SOLR}/api/collections/${COLLECTION}" -H 'Content-Type: application/json' \
+         -d '{"modify":{"config": "'$CONFIG_NAME'" } }'
+    
     echo "Reloading collection $COLLECTION"
     RESPONSE=`curl -m 120 -s "http://$SOLR/solr/admin/collections?action=RELOAD&name=$COLLECTION"`
     if [ -z "$(grep 'status":0,' <<< "$RESPONSE")" ]; then
@@ -193,7 +207,7 @@ fi
 # Update existing or create new collection
 #EXISTS=`curl -m 30 -s "http://$SOLR/solr/admin/collections?action=LIST" | grep -o "<str>${COLLECTION}</str>"`
 set +e
-EXISTS=$(curl -m 30 -s "http://$SOLR/solr/admin/collections?action=LIST" | jq -r '.collections[]' | grep '^${COLLECTION}$')
+EXISTS=$(curl -m 30 -s "http://$SOLR/solr/admin/collections?action=LIST" | jq -r '.collections[]' | grep "^${COLLECTION}$")
 set -e
 if [ "." == ".$EXISTS" ]; then
     create_new_collection


### PR DESCRIPTION
Updating the configuration for an existing Solr Cloud 9.4 collection can be done three different ways, all officially supported:

* Using ZooKeeper's `linkconfig`
* Using Solr's `collections` API v1 (plain REST GET params @ `/solr/admin/collections`)
* Using Solr's `collections` API v2 (JSON POSTed to `/api/collections/<collection_name>`)

First one fails silently, second one fails with a ClassCastException, third one works! I should look into this and possibly file a Solr bug report, but that'll be on private time.

This fix makes `bin/cloud_ds.sh update` work. Test with
```shell
bin/cloud_install.sh
bin/cloud_start.sh
bin/cloud_ds.sh new
bin/cloud_ds.sh align
```
Then
* Inspect the schema through `Files` in the Solr admin GUI for `_ds_1.0.3_`
* bump the version in `src/main/solr/dssolr/conf/schema.xml`:
  `<field name="_ds_1.0.3_" type="string" indexed="false" stored="false"/>` →
  `<field name="_ds_1.0.4_" type="string" indexed="false" stored="false"/>`)
* call
  `bin/cloud_ds.sh update`
  
Checking the schema again in the Solr admin GUI (might need a reload) should show the new version.

