### PR TITLE
Disc 730 spellcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+Spellcheck compontent added to Solr search. If no results are found, the solr reply will come with query suggestions that will give results.
 
 
 ## [1.5.0](https://github.com/kb-dk/ds-present/releases/tag/v1.5.0) - 2024-01-22

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -1028,7 +1028,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <copyField source="alternative_title" dest="freetext"/>
   <copyField source="original_title" dest="freetext"/>
   <copyField source="title" dest="spellcheck"/>
-
+  <copyField source="description" dest="spellcheck"/>
   <copyField source="text" dest="text_shingles">
     <?description Copies the content of the basic text field to the shingles enabled text field, for better phrase search ranking and keyword extraction.?>
   </copyField>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -1027,7 +1027,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <copyField source="subtitle" dest="freetext"/>
   <copyField source="alternative_title" dest="freetext"/>
   <copyField source="original_title" dest="freetext"/>
-  <copyField source="title" dest="spellcheck"/> <!--This is a large field to copy just for spellcheck  -->
+  <copyField source="title" dest="spellcheck"/> <!--Important field. Will give high ranking(accuracy) when for spellcheck searches -->
   <copyField source="description" dest="spellcheck"/> <!--This is a large field to copy just for spellcheck  -->
   <copyField source="text" dest="text_shingles">
     <?description Copies the content of the basic text field to the shingles enabled text field, for better phrase search ranking and keyword extraction.?>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -1027,8 +1027,8 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <copyField source="subtitle" dest="freetext"/>
   <copyField source="alternative_title" dest="freetext"/>
   <copyField source="original_title" dest="freetext"/>
-  <copyField source="title" dest="spellcheck"/>
-  <copyField source="description" dest="spellcheck"/>
+  <copyField source="title" dest="spellcheck"/> <!--This is a large field to copy just for spellcheck  -->
+  <copyField source="description" dest="spellcheck"/> <!--This is a large field to copy just for spellcheck  -->
   <copyField source="text" dest="text_shingles">
     <?description Copies the content of the basic text field to the shingles enabled text field, for better phrase search ranking and keyword extraction.?>
   </copyField>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -884,6 +884,12 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?description Field for strict title matching. Matches exact title?>
     <?example     Query for "romeo" will return nothing, while a query for "romeo and juliet" will return the titel?>
   </field>
+
+  <field name="spellcheck" type="text_en" indexed="true" stored="true" multiValued="true" 
+                   termVectors="true"
+                   termPositions="true"
+                   termOffsets="true"/>
+
   <!-- END FIELDS  -->
 
   <!-- START FIELDTYPE DEFINITIONS-->
@@ -1021,6 +1027,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <copyField source="subtitle" dest="freetext"/>
   <copyField source="alternative_title" dest="freetext"/>
   <copyField source="original_title" dest="freetext"/>
+  <copyField source="title" dest="spellcheck"/>
 
   <copyField source="text" dest="text_shingles">
     <?description Copies the content of the basic text field to the shingles enabled text field, for better phrase search ranking and keyword extraction.?>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -885,7 +885,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     Query for "romeo" will return nothing, while a query for "romeo and juliet" will return the titel?>
   </field>
 
-  <field name="spellcheck" type="text_en" indexed="true" stored="true" multiValued="true" 
+  <field name="spellcheck" type="text_general" indexed="true" stored="true" multiValued="true" 
                    termVectors="true"
                    termPositions="true"
                    termOffsets="true"/>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -902,6 +902,7 @@
       <int name="maxInspections">5</int>
       <int name="minQueryLength">3</int>
       <float name="maxQueryFrequency">0.5</float>
+      <float name="thresholdTokenFrequency">0.001</float>
     </lst>
   </searchComponent>
  
@@ -925,6 +926,7 @@
   </searchComponent>
   -->
  
+ <!-- 
  <requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
     <lst name="defaults">
       <str name="spellcheck.dictionary">default</str>
@@ -944,46 +946,9 @@
       <str>spellcheck</str>
     </arr>
   </requestHandler>
+  -->
+
  
-<requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
-    <lst name="defaults">
-      <str name="spellcheck.dictionary">default</str>
-      <str name="spellcheck">on</str>
-      <str name="df">title</str>
-      <str name="spellcheck.extendedResults">true</str>
-      <str name="spellcheck.count">10</str>
-      <str name="spellcheck.alternativeTermCount">5</str>
-      <str name="spellcheck.maxResultsForSuggest">5</str>
-      <str name="spellcheck.collate">true</str>
-      <str name="spellcheck.collateExtendedResults">true</str>
-      <str name="spellcheck.maxCollationTries">10</str>
-      <str name="spellcheck.maxCollations">5</str>
-      <str name="spellcheck.build">true</str> 
-    </lst>
-    <arr name="last-components">
-      <str>spellcheck</str>
-    </arr>
-  </requestHandler>
- 
- 
-<searchComponent name="spellcheck" class="solr.SpellCheckComponent">
-  <lst name="spellchecker">
-    <str name="name">default</str>
-    <str name="field">spellcheck</str>
-    <str name="classname">solr.DirectSolrSpellChecker</str>
-    <str name="distanceMeasure">internal</str>
-    <float name="accuracy">0.1</float>
-    <int name="maxEdits">2</int>
-    <int name="minPrefix">1</int>
-    <int name="maxInspections">5</int>
-    <int name="minQueryLength">4</int>
-    <int name="maxQueryLength">40</int>
-    <float name="maxQueryFrequency">4</float>
-    <float name="thresholdTokenFrequency">0.001</float>
-  </lst>
-</searchComponent>
- 
-  
   <!-- The following are some of the implicit Update Request Handlers
   <requestHandler name="/update/json" class="solr.UpdateRequestHandler">
         <lst name="invariants">

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -890,7 +890,7 @@
  -->
   
  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
-    <str name="queryAnalyzerFieldType">spellcheck</str>
+    <str name="queryAnalyzerFieldType">text_general</str>
     <lst name="spellchecker">
       <str name="name">default</str>
       <str name="field">spellcheck</str>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -877,7 +877,7 @@
         Load tokens from the following field for spell checking,
         analyzer for the field's type as defined in schema.xml are used
     -->
-    <str name="field">freetext</str>
+    <str name="field">title</str>
     <!-- Optional, by default use in-memory index (RAMDirectory) -->
     <str name="spellcheckIndexDir">./spellchecker</str>
     <!-- Set the accuracy (float) to be used for the suggestions. Default is 0.5 -->

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -897,7 +897,7 @@
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <str name="distanceMeasure">internal</str>
       <float name="accuracy">0.5</float>
-      <int name="maxEdits">2</int>
+      <int name="maxEdits">3</int>
       <int name="minPrefix">1</int>
       <int name="maxInspections">5</int>
       <int name="minQueryLength">3</int>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -810,7 +810,7 @@
        
        
       
-      <str name="spellcheck">true</str>
+      <str name="spellcheck">true</str>      
       <str name="spellcheck.dictionary">default</str>
       <str name="spellcheck.df">spellcheck</str>
       <str name="df">spellcheck</str>
@@ -906,7 +906,7 @@
   </searchComponent>
  -->
  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
-    <str name="queryAnalyzerFieldType">text_general</str>
+    <str name="queryAnalyzerFieldType">spellcheck</str>
     <lst name="spellchecker">
                   
       <str name="name">default</str>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -887,7 +887,7 @@
     <int name="minQueryLength">4</int>
     <int name="maxQueryLength">40</int>
     <float name="maxQueryFrequency">4</float>
-    <float name="thresholdTokenFrequency">10</float>
+    <float name="thresholdTokenFrequency">0.001</float>
   </lst>
 </searchComponent>
  

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -861,7 +861,7 @@
     </lst>
   </searchComponent>
 
-
+<!-- 
 <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
   <lst name="spellchecker">
     <str name="name">default</str>
@@ -872,7 +872,8 @@
     <int name="maxChanges">10</int>
   </lst>
 </searchComponent>
-<!-- 
+ -->
+ 
 <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
   <lst name="spellchecker">
     <str name="name">default</str>
@@ -889,7 +890,7 @@
     <float name="thresholdTokenFrequency">10</float>
   </lst>
 </searchComponent>
- -->
+ 
   
   <!-- The following are some of the implicit Update Request Handlers
   <requestHandler name="/update/json" class="solr.UpdateRequestHandler">

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -858,6 +858,86 @@
     </lst>
   </searchComponent>
 
+
+
+
+<searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+
+  <lst name="spellchecker">
+    <!--
+        Optional, it is required when more than one spellchecker is configured.
+        Select non-default name with spellcheck.dictionary in request handler.
+    -->
+    <str name="name">default</str>
+    <!-- The classname is optional, defaults to IndexBasedSpellChecker -->
+    <str name="classname">solr.IndexBasedSpellChecker</str>
+    <!--
+        Load tokens from the following field for spell checking,
+        analyzer for the field's type as defined in schema.xml are used
+    -->
+    <str name="field">spell</str>
+    <!-- Optional, by default use in-memory index (RAMDirectory) -->
+    <str name="spellcheckIndexDir">./spellchecker</str>
+    <!-- Set the accuracy (float) to be used for the suggestions. Default is 0.5 -->
+    <str name="accuracy">0.7</str>
+    <!-- Require terms to occur in 1/100th of 1% of documents in order to be included in the dictionary -->
+    <float name="thresholdTokenFrequency">.0001</float>
+  </lst>
+  <!-- a spellchecker that can break or combine words. (Solr 4.0 see SOLR-2993) -->
+  <lst name="spellchecker">
+    <str name="name">wordbreak</str>
+    <str name="classname">solr.WordBreakSolrSpellChecker</str>
+    <str name="field">spell</str>
+    <str name="combineWords">true</str>
+    <str name="breakWords">true</str>
+    <int name="maxChanges">3</int>
+  </lst>
+  <!-- Example of using different distance measure -->
+  <lst name="spellchecker">
+    <str name="name">jarowinkler</str>
+    <str name="field">lowerfilt</str>
+    <!-- Use a different Distance Measure -->
+    <str name="distanceMeasure">org.apache.lucene.search.spell.JaroWinklerDistance</str>
+    <str name="spellcheckIndexDir">./spellchecker</str>
+  </lst>
+
+  <!-- This field type's analyzer is used by the QueryConverter to tokenize the value for "q" parameter -->
+  <str name="queryAnalyzerFieldType">textSpell</str>
+</searchComponent>
+
+
+<!--
+    The SpellingQueryConverter to convert raw (CommonParams.Q) queries into tokens.  Uses a simple regular expression
+    to strip off field markup, boosts, ranges, etc. but it is not guaranteed to match an exact parse from the query parser.
+
+Optional, defaults to solr.SpellingQueryConverter
+-->
+<queryConverter name="queryConverter" class="solr.SpellingQueryConverter"/>
+
+
+<requestHandler name="/spellCheck" class="solr.SearchHandler">
+  <lst name="defaults">
+    <!-- Optional, must match spell checker's name as defined above, defaults to "default" -->
+    <str name="spellcheck.dictionary">default</str>
+    <!-- Also generate Word Break Suggestions (Solr 4.0 see SOLR-2993) -->
+    <str name="spellcheck.dictionary">wordbreak</str>
+    <!-- omp = Only More Popular -->
+    <str name="spellcheck.onlyMorePopular">false</str>
+    <!-- exr = Extended Results -->
+    <str name="spellcheck.extendedResults">false</str>
+    <!--  The number of suggestions to return -->
+    <str name="spellcheck.count">10</str>
+  </lst>
+  <!--  Add to a RequestHandler
+       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+       REPEAT NOTE:  YOU LIKELY DO NOT WANT A SEPARATE REQUEST HANDLER FOR THIS COMPONENT.  THIS IS DONE HERE SOLELY FOR
+       THE SIMPLICITY OF THE EXAMPLE.  YOU WILL LIKELY WANT TO BIND THE COMPONENT TO THE /select STANDARD REQUEST HANDLER.
+       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  -->
+  <arr name="last-components">
+    <str>spellcheck</str>
+  </arr>
+</requestHandler>
   
   <!-- The following are some of the implicit Update Request Handlers
   <requestHandler name="/update/json" class="solr.UpdateRequestHandler">

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -880,7 +880,7 @@
     <str name="field">spellcheck</str>
     <str name="classname">solr.DirectSolrSpellChecker</str>
     <str name="distanceMeasure">internal</str>
-    <float name="accuracy">0.5</float>
+    <float name="accuracy">0.1</float>
     <int name="maxEdits">2</int>
     <int name="minPrefix">1</int>
     <int name="maxInspections">5</int>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -873,7 +873,7 @@
     <int name="maxInspections">5</int>
     <int name="minQueryLength">4</int>
     <int name="maxQueryLength">40</int>
-    <float name="maxQueryFrequency">0.01</float>
+    <float name="maxQueryFrequency">4</float>
     <float name="thresholdTokenFrequency">10</float>
   </lst>
 </searchComponent>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -810,7 +810,7 @@
        
        
       
-      <str name="spellcheck">true</str>      
+      <!--  <str name="spellcheck">true</str> Enable to set it default-->      
       <str name="spellcheck.dictionary">default</str>
       <str name="spellcheck.df">spellcheck</str>
       <str name="df">spellcheck</str>
@@ -876,18 +876,6 @@
     </lst>
   </searchComponent>
 
-<!-- 
-<searchComponent name="spellcheck" class="solr.SpellCheckComponent">
-  <lst name="spellchecker">
-    <str name="name">default</str>
-    <str name="classname">solr.WordBreakSolrSpellChecker</str>
-    <str name="field">spellcheck</str>
-    <str name="combineWords">true</str>
-    <str name="breakWords">true</str>
-    <int name="maxChanges">10</int>
-  </lst>
-</searchComponent>
- -->
   
  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
     <str name="queryAnalyzerFieldType">text_general</str>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -810,11 +810,9 @@
        
        
       
-      <!--  <str name="spellcheck">true</str> Enable to set it default-->      
-      <str name="spellcheck.dictionary">default</str>
-      <str name="spellcheck.df">spellcheck</str>
-      <str name="df">spellcheck</str>
-      <str name="spellcheck.extendedResults">true</str>
+      <!--  <str name="spellcheck">true</str> Enable to set it default-->            
+      <str name="spellcheck.df">spellcheck</str>      
+      <str name="spellcheck.extendedResults">true</str> <!-- Probably disable later.But usefull to see what is in data -->
       <str name="spellcheck.count">10</str>
       <str name="spellcheck.alternativeTermCount">5</str>
       <str name="spellcheck.maxResultsForSuggest">5</str>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -897,7 +897,7 @@
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <str name="distanceMeasure">internal</str>
       <float name="accuracy">0.5</float>
-      <int name="maxEdits">3</int>
+      <int name="maxEdits">6</int>
       <int name="minPrefix">1</int>
       <int name="maxInspections">5</int>
       <int name="minQueryLength">3</int>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -875,7 +875,7 @@
         Load tokens from the following field for spell checking,
         analyzer for the field's type as defined in schema.xml are used
     -->
-    <str name="field">spell</str>
+    <str name="field">freetext</str>
     <!-- Optional, by default use in-memory index (RAMDirectory) -->
     <str name="spellcheckIndexDir">./spellchecker</str>
     <!-- Set the accuracy (float) to be used for the suggestions. Default is 0.5 -->
@@ -884,6 +884,7 @@
     <float name="thresholdTokenFrequency">.0001</float>
   </lst>
   <!-- a spellchecker that can break or combine words. (Solr 4.0 see SOLR-2993) -->
+ <!-- 
   <lst name="spellchecker">
     <str name="name">wordbreak</str>
     <str name="classname">solr.WordBreakSolrSpellChecker</str>
@@ -892,15 +893,16 @@
     <str name="breakWords">true</str>
     <int name="maxChanges">3</int>
   </lst>
+  -->
   <!-- Example of using different distance measure -->
+ <!-- 
   <lst name="spellchecker">
     <str name="name">jarowinkler</str>
     <str name="field">lowerfilt</str>
-    <!-- Use a different Distance Measure -->
     <str name="distanceMeasure">org.apache.lucene.search.spell.JaroWinklerDistance</str>
     <str name="spellcheckIndexDir">./spellchecker</str>
   </lst>
-
+ -->
   <!-- This field type's analyzer is used by the QueryConverter to tokenize the value for "q" parameter -->
   <str name="queryAnalyzerFieldType">textSpell</str>
 </searchComponent>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -808,7 +808,21 @@
        <str name="f.notes.hl.preserveMulti">false</str>
        <str name="hl.fl">notes</str>
        
-       <str name="spellcheck">true</str>
+       
+      <str name="spellcheck">true</str>       
+      <str name="spellcheck.dictionary">default</str>
+      <str name="spellcheck">on</str>
+      <str name="df">spellcheck</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.count">10</str>
+      <str name="spellcheck.alternativeTermCount">5</str>
+      <str name="spellcheck.maxResultsForSuggest">5</str>
+      <str name="spellcheck.collate">true</str>
+      <str name="spellcheck.collateExtendedResults">true</str>
+      <str name="spellcheck.maxCollationTries">10</str>
+      <str name="spellcheck.maxCollations">5</str>
+      <str name="spellcheck.build">true</str> 
+     
      </lst>
        <arr name="last-components">
          <str>spellcheck</str>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -861,6 +861,18 @@
     </lst>
   </searchComponent>
 
+
+<searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+  <lst name="spellchecker">
+    <str name="name">wordbreak</str>
+    <str name="classname">solr.WordBreakSolrSpellChecker</str>
+    <str name="field">spellcheck</str>
+    <str name="combineWords">true</str>
+    <str name="breakWords">true</str>
+    <int name="maxChanges">10</int>
+  </lst>
+</searchComponent>
+<!-- 
 <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
   <lst name="spellchecker">
     <str name="name">default</str>
@@ -877,7 +889,7 @@
     <float name="thresholdTokenFrequency">10</float>
   </lst>
 </searchComponent>
-
+ -->
   
   <!-- The following are some of the implicit Update Request Handlers
   <requestHandler name="/update/json" class="solr.UpdateRequestHandler">

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -864,7 +864,7 @@
 
 <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
   <lst name="spellchecker">
-    <str name="name">wordbreak</str>
+    <str name="name">default</str>
     <str name="classname">solr.WordBreakSolrSpellChecker</str>
     <str name="field">spellcheck</str>
     <str name="combineWords">true</str>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -907,6 +907,21 @@
  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
     <str name="queryAnalyzerFieldType">text_general</str>
     <lst name="spellchecker">
+             
+      <str name="dictionary">default</str>
+      
+      <str name="df">spellcheck</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.count">10</str>
+      <str name="spellcheck.alternativeTermCount">5</str>
+      <str name="spellcheck.maxResultsForSuggest">5</str>
+      <str name="spellcheck.collate">true</str>
+      <str name="spellcheck.collateExtendedResults">true</str>
+      <str name="spellcheck.maxCollationTries">10</str>
+      <str name="spellcheck.maxCollations">5</str>
+      <str name="spellcheck.build">true</str> 
+      
+      
       <str name="name">default</str>
       <str name="field">spellcheck</str>
       <str name="classname">solr.DirectSolrSpellChecker</str>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -810,21 +810,21 @@
        
        
       
-      <!--  <str name="spellcheck">true</str> Enable to set it default-->            
+      <!--  <str name="spellcheck">true</str> Enable to set it default. Must now be called with spellcheck=true parameter -->            
       <str name="spellcheck.df">spellcheck</str>      
       <str name="spellcheck.extendedResults">true</str> <!-- Probably disable later.But usefull to see what is in data -->
       <str name="spellcheck.count">10</str>
       <str name="spellcheck.alternativeTermCount">5</str>
       <str name="spellcheck.maxResultsForSuggest">5</str>
-      <str name="spellcheck.collate">true</str>
-      <str name="spellcheck.collateExtendedResults">true</str>
+      <str name="spellcheck.collate">true</str>  <!-- Important this will combine words and give a full query back -->
+      <str name="spellcheck.collateExtendedResults">true</str> > <!-- Probably disable later.But usefull to see what is in data -->
       <str name="spellcheck.maxCollationTries">10</str>
       <str name="spellcheck.maxCollations">5</str>
       <str name="spellcheck.build">true</str>              
      
      </lst>
        <arr name="last-components">
-         <str>spellcheck</str>
+         <str>spellcheck</str> <!-- It is possible to add more spellchecker compontents than one -->
        </arr>
     </requestHandler>
 
@@ -878,17 +878,17 @@
  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
     <str name="queryAnalyzerFieldType">text_general</str>
     <lst name="spellchecker">
-      <str name="name">default</str>
-      <str name="field">spellcheck</str>
+      <str name="name">default</str> <!-- This is the default spellcheck compontent. Use names if more spellcheckers are defined -->
+      <str name="field">spellcheck</str> <!-- Custom field only used for spellcheck -->
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <str name="distanceMeasure">internal</str>
-      <float name="accuracy">0.5</float>
-      <int name="maxEdits">2</int> 
-      <int name="minPrefix">1</int>
+      <float name="accuracy">0.5</float> <!-- Not sure what is a good number. Depend on the analysis for the spellcheck field. -->
+      <int name="maxEdits">2</int> <!-- Important parameter. This limit is for each word. Value 2 seems sweet spot -->
+      <int name="minPrefix">1</int> <!-- First letter of word must be correct. People rarely misspell first letter. (ignores casing) -->
       <int name="maxInspections">5</int>
-      <int name="minQueryLength">3</int>
+      <int name="minQueryLength">3</int> <!-- Important parameter. Maybe increase for 4 or 5 --> 
       <float name="maxQueryFrequency">0.5</float>
-      <float name="thresholdTokenFrequency">0.001</float>
+      <float name="thresholdTokenFrequency">0.001</float> <!-- Important parameter. This is set very low. Increase when we have a large corpus -->
     </lst>
   </searchComponent>
  

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -807,7 +807,8 @@
        <str name="hl.encoder">html</str>
        <str name="f.notes.hl.preserveMulti">false</str>
        <str name="hl.fl">notes</str>
-        
+       
+       <str name="spellcheck">true</str>
      </lst>
        <arr name="last-components">
          <str>spellcheck</str>
@@ -860,88 +861,23 @@
     </lst>
   </searchComponent>
 
-
-
-
 <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
-
   <lst name="spellchecker">
-    <!--
-        Optional, it is required when more than one spellchecker is configured.
-        Select non-default name with spellcheck.dictionary in request handler.
-    -->
     <str name="name">default</str>
-    <!-- The classname is optional, defaults to IndexBasedSpellChecker -->
-    <str name="classname">solr.IndexBasedSpellChecker</str>
-    <!--
-        Load tokens from the following field for spell checking,
-        analyzer for the field's type as defined in schema.xml are used
-    -->
     <str name="field">title</str>
-    <!-- Optional, by default use in-memory index (RAMDirectory) -->
-    <str name="spellcheckIndexDir">./spellchecker</str>
-    <!-- Set the accuracy (float) to be used for the suggestions. Default is 0.5 -->
-    <str name="accuracy">0.7</str>
-    <!-- Require terms to occur in 1/100th of 1% of documents in order to be included in the dictionary -->
-    <float name="thresholdTokenFrequency">.0001</float>
+    <str name="classname">solr.DirectSolrSpellChecker</str>
+    <str name="distanceMeasure">internal</str>
+    <float name="accuracy">0.5</float>
+    <int name="maxEdits">2</int>
+    <int name="minPrefix">1</int>
+    <int name="maxInspections">5</int>
+    <int name="minQueryLength">4</int>
+    <int name="maxQueryLength">40</int>
+    <float name="maxQueryFrequency">0.01</float>
+    <float name="thresholdTokenFrequency">.01</float>
   </lst>
-  <!-- a spellchecker that can break or combine words. (Solr 4.0 see SOLR-2993) -->
- <!-- 
-  <lst name="spellchecker">
-    <str name="name">wordbreak</str>
-    <str name="classname">solr.WordBreakSolrSpellChecker</str>
-    <str name="field">spell</str>
-    <str name="combineWords">true</str>
-    <str name="breakWords">true</str>
-    <int name="maxChanges">3</int>
-  </lst>
-  -->
-  <!-- Example of using different distance measure -->
- <!-- 
-  <lst name="spellchecker">
-    <str name="name">jarowinkler</str>
-    <str name="field">lowerfilt</str>
-    <str name="distanceMeasure">org.apache.lucene.search.spell.JaroWinklerDistance</str>
-    <str name="spellcheckIndexDir">./spellchecker</str>
-  </lst>
- -->
-  <!-- This field type's analyzer is used by the QueryConverter to tokenize the value for "q" parameter -->
-  <str name="queryAnalyzerFieldType">textSpell</str>
 </searchComponent>
 
-
-<!--
-    The SpellingQueryConverter to convert raw (CommonParams.Q) queries into tokens.  Uses a simple regular expression
-    to strip off field markup, boosts, ranges, etc. but it is not guaranteed to match an exact parse from the query parser.
-
-Optional, defaults to solr.SpellingQueryConverter
--->
-<queryConverter name="queryConverter" class="solr.SpellingQueryConverter"/>
-
-
-<requestHandler name="/spellCheck" class="solr.SearchHandler">
-  <lst name="defaults">
-    <!-- Optional, must match spell checker's name as defined above, defaults to "default" -->
-    <str name="spellcheck.dictionary">default</str>
-    <!-- Also generate Word Break Suggestions (Solr 4.0 see SOLR-2993) -->
-    <str name="spellcheck.dictionary">wordbreak</str>
-    <!-- omp = Only More Popular -->
-    <str name="spellcheck.onlyMorePopular">false</str>
-    <!-- exr = Extended Results -->
-    <str name="spellcheck.extendedResults">false</str>
-    <!--  The number of suggestions to return -->
-    <str name="spellcheck.count">10</str>
-  </lst>
-  <!--  Add to a RequestHandler
-       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-       REPEAT NOTE:  YOU LIKELY DO NOT WANT A SEPARATE REQUEST HANDLER FOR THIS COMPONENT.  THIS IS DONE HERE SOLELY FOR
-       THE SIMPLICITY OF THE EXAMPLE.  YOU WILL LIKELY WANT TO BIND THE COMPONENT TO THE /select STANDARD REQUEST HANDLER.
-       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  -->
-  <arr name="last-components">
-    <str>spellcheck</str>
-  </arr>
-</requestHandler>
   
   <!-- The following are some of the implicit Update Request Handlers
   <requestHandler name="/update/json" class="solr.UpdateRequestHandler">

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -812,6 +812,7 @@
       
       <str name="spellcheck">true</str>
       <str name="spellcheck.dictionary">default</str>
+      <str name="spellcheck.df">spellcheck</str>
       <str name="df">spellcheck</str>
       <str name="spellcheck.extendedResults">true</str>
       <str name="spellcheck.count">10</str>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -809,7 +809,9 @@
        <str name="hl.fl">notes</str>
         
      </lst>
-         
+       <arr name="last-components">
+         <str>spellcheck</str>
+       </arr>
     </requestHandler>
 
 

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -809,19 +809,7 @@
        <str name="hl.fl">notes</str>
        
        
-      <str name="spellcheck">true</str>       
-      <str name="spellcheck.dictionary">default</str>
-      <str name="spellcheck">on</str>
-      <str name="df">spellcheck</str>
-      <str name="spellcheck.extendedResults">true</str>
-      <str name="spellcheck.count">10</str>
-      <str name="spellcheck.alternativeTermCount">5</str>
-      <str name="spellcheck.maxResultsForSuggest">5</str>
-      <str name="spellcheck.collate">true</str>
-      <str name="spellcheck.collateExtendedResults">true</str>
-      <str name="spellcheck.maxCollationTries">10</str>
-      <str name="spellcheck.maxCollations">5</str>
-      <str name="spellcheck.build">true</str> 
+      <str name="spellcheck">true</str>             
      
      </lst>
        <arr name="last-components">
@@ -907,23 +895,10 @@
  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
     <str name="queryAnalyzerFieldType">text_general</str>
     <lst name="spellchecker">
-             
-      <str name="dictionary">default</str>
-      
-      <str name="df">spellcheck</str>
-      <str name="spellcheck.extendedResults">true</str>
-      <str name="spellcheck.count">10</str>
-      <str name="spellcheck.alternativeTermCount">5</str>
-      <str name="spellcheck.maxResultsForSuggest">5</str>
-      <str name="spellcheck.collate">true</str>
-      <str name="spellcheck.collateExtendedResults">true</str>
-      <str name="spellcheck.maxCollationTries">10</str>
-      <str name="spellcheck.maxCollations">5</str>
-      <str name="spellcheck.build">true</str> 
-      
-      
+                  
       <str name="name">default</str>
       <str name="field">spellcheck</str>
+      <str name="df">spellcheck</str>
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <str name="distanceMeasure">internal</str>
       <float name="accuracy">0.5</float>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -864,7 +864,7 @@
 <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
   <lst name="spellchecker">
     <str name="name">default</str>
-    <str name="field">title</str>
+    <str name="field">spellcheck</str>
     <str name="classname">solr.DirectSolrSpellChecker</str>
     <str name="distanceMeasure">internal</str>
     <float name="accuracy">0.5</float>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -897,7 +897,7 @@
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <str name="distanceMeasure">internal</str>
       <float name="accuracy">0.5</float>
-      <int name="maxEdits">2</int>
+      <int name="maxEdits">2</int> 
       <int name="minPrefix">1</int>
       <int name="maxInspections">5</int>
       <int name="minQueryLength">3</int>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -897,7 +897,7 @@
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <str name="distanceMeasure">internal</str>
       <float name="accuracy">0.5</float>
-      <int name="maxEdits">6</int>
+      <int name="maxEdits">2</int>
       <int name="minPrefix">1</int>
       <int name="maxInspections">5</int>
       <int name="minQueryLength">3</int>
@@ -906,48 +906,6 @@
     </lst>
   </searchComponent>
  
- <!-- Denne virker med "thoma"
- <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
-    <str name="queryAnalyzerFieldType">spellcheck</str>
-    <lst name="spellchecker">
-                  
-      <str name="name">default</str>
-      <str name="field">spellcheck</str>
-      <str name="df">spellcheck</str>
-      <str name="classname">solr.DirectSolrSpellChecker</str>
-      <str name="distanceMeasure">internal</str>
-      <float name="accuracy">0.5</float>
-      <int name="maxEdits">2</int>
-      <int name="minPrefix">1</int>
-      <int name="maxInspections">5</int>
-      <int name="minQueryLength">3</int>
-      <float name="maxQueryFrequency">0.5</float>
-    </lst>
-  </searchComponent>
-  -->
- 
- <!-- 
- <requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
-    <lst name="defaults">
-      <str name="spellcheck.dictionary">default</str>
-      <str name="spellcheck">on</str>
-      <str name="df">spellcheck</str>
-      <str name="spellcheck.extendedResults">true</str>
-      <str name="spellcheck.count">10</str>
-      <str name="spellcheck.alternativeTermCount">5</str>
-      <str name="spellcheck.maxResultsForSuggest">5</str>
-      <str name="spellcheck.collate">true</str>
-      <str name="spellcheck.collateExtendedResults">true</str>
-      <str name="spellcheck.maxCollationTries">10</str>
-      <str name="spellcheck.maxCollations">5</str>
-      <str name="spellcheck.build">true</str> 
-    </lst>
-    <arr name="last-components">
-      <str>spellcheck</str>
-    </arr>
-  </requestHandler>
-  -->
-
  
   <!-- The following are some of the implicit Update Request Handlers
   <requestHandler name="/update/json" class="solr.UpdateRequestHandler">

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -873,6 +873,80 @@
   </lst>
 </searchComponent>
  -->
+ <!-- 
+ <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+    <str name="queryAnalyzerFieldType">text_general</str>
+    <lst name="spellchecker">
+      <str name="name">default</str>
+      <str name="field">title</str>
+      <str name="classname">solr.DirectSolrSpellChecker</str>
+      <str name="distanceMeasure">internal</str>
+      <float name="accuracy">0.5</float>
+      <int name="maxEdits">2</int>
+      <int name="minPrefix">1</int>
+      <int name="maxInspections">5</int>
+      <int name="minQueryLength">3</int>
+      <float name="maxQueryFrequency">0.5</float>
+    </lst>
+  </searchComponent>
+ -->
+ <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+    <str name="queryAnalyzerFieldType">text_general</str>
+    <lst name="spellchecker">
+      <str name="name">default</str>
+      <str name="field">spellcheck</str>
+      <str name="classname">solr.DirectSolrSpellChecker</str>
+      <str name="distanceMeasure">internal</str>
+      <float name="accuracy">0.5</float>
+      <int name="maxEdits">2</int>
+      <int name="minPrefix">1</int>
+      <int name="maxInspections">5</int>
+      <int name="minQueryLength">3</int>
+      <float name="maxQueryFrequency">0.5</float>
+    </lst>
+  </searchComponent>
+ 
+ 
+ <requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
+    <lst name="defaults">
+      <str name="spellcheck.dictionary">default</str>
+      <str name="spellcheck">on</str>
+      <str name="df">spellcheck</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.count">10</str>
+      <str name="spellcheck.alternativeTermCount">5</str>
+      <str name="spellcheck.maxResultsForSuggest">5</str>
+      <str name="spellcheck.collate">true</str>
+      <str name="spellcheck.collateExtendedResults">true</str>
+      <str name="spellcheck.maxCollationTries">10</str>
+      <str name="spellcheck.maxCollations">5</str>
+      <str name="spellcheck.build">true</str> 
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+ 
+<requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
+    <lst name="defaults">
+      <str name="spellcheck.dictionary">default</str>
+      <str name="spellcheck">on</str>
+      <str name="df">title</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.count">10</str>
+      <str name="spellcheck.alternativeTermCount">5</str>
+      <str name="spellcheck.maxResultsForSuggest">5</str>
+      <str name="spellcheck.collate">true</str>
+      <str name="spellcheck.collateExtendedResults">true</str>
+      <str name="spellcheck.maxCollationTries">10</str>
+      <str name="spellcheck.maxCollations">5</str>
+      <str name="spellcheck.build">true</str> 
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+ 
  
 <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
   <lst name="spellchecker">

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -888,12 +888,12 @@
   </lst>
 </searchComponent>
  -->
- <!-- 
+  
  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
-    <str name="queryAnalyzerFieldType">text_general</str>
+    <str name="queryAnalyzerFieldType">spellcheck</str>
     <lst name="spellchecker">
       <str name="name">default</str>
-      <str name="field">title</str>
+      <str name="field">spellcheck</str>
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <str name="distanceMeasure">internal</str>
       <float name="accuracy">0.5</float>
@@ -904,7 +904,8 @@
       <float name="maxQueryFrequency">0.5</float>
     </lst>
   </searchComponent>
- -->
+ 
+ <!-- Denne virker med "thoma"
  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
     <str name="queryAnalyzerFieldType">spellcheck</str>
     <lst name="spellchecker">
@@ -922,7 +923,7 @@
       <float name="maxQueryFrequency">0.5</float>
     </lst>
   </searchComponent>
- 
+  -->
  
  <requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
     <lst name="defaults">

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -809,7 +809,19 @@
        <str name="hl.fl">notes</str>
        
        
-      <str name="spellcheck">true</str>             
+      
+      <str name="spellcheck">true</str>
+      <str name="spellcheck.dictionary">default</str>
+      <str name="df">spellcheck</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.count">10</str>
+      <str name="spellcheck.alternativeTermCount">5</str>
+      <str name="spellcheck.maxResultsForSuggest">5</str>
+      <str name="spellcheck.collate">true</str>
+      <str name="spellcheck.collateExtendedResults">true</str>
+      <str name="spellcheck.maxCollationTries">10</str>
+      <str name="spellcheck.maxCollations">5</str>
+      <str name="spellcheck.build">true</str>              
      
      </lst>
        <arr name="last-components">

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -874,7 +874,7 @@
     <int name="minQueryLength">4</int>
     <int name="maxQueryLength">40</int>
     <float name="maxQueryFrequency">0.01</float>
-    <float name="thresholdTokenFrequency">.01</float>
+    <float name="thresholdTokenFrequency">10</float>
   </lst>
 </searchComponent>
 


### PR DESCRIPTION
A very good first attempt. 
Example call and try using variantions of "Carina Jensen"
http://devel11:10007/solr/ds-write/select?indent=true&q.op=AND&q=carina%20Jense&rows=1&facet=false&spellcheck=true

**Spellcheck will only be called if no results are found.**

**Frontend only needs to read the json-attribute`collationQuery:"carina jensen"`**  (Can be several, max 5)

Implementation details:

Added comment to important spellcheck parameters. Tried tweak them to a good value for the current corpus.

Only fields **title** and **description** are copied to the spellcheck field. Description is a big field, so there is redundant data in 
the index. But it will not cost performance for searches that have  results.

**ds-discover** needs to accept the spellcheck parameter without warnings. (new task)

collection **ds** has been alligned with **ds-write**. So it is already active for frontenders.
