### PR TITLE
Disc 835 suggest filter

### DIFF
--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -727,6 +727,15 @@
       <xsl:value-of select="format-number($mTime, '0')"/>
     </f:string>
 
+    <xsl:if test="$manifestation != ''">
+      <xsl:variable name="manifestationRef">
+        <xsl:value-of select="f:parse-xml($manifestation)/xip:Manifestation/ComponentManifestation/FileRef"/>
+      </xsl:variable>
+      <f:string key="kb:file_id">
+        <xsl:value-of select="$manifestationRef"/>
+      </f:string>
+    </xsl:if>
+
     <!-- Extract subgenre if present -->
     <xsl:for-each select="/xip:DeliverableUnit/Metadata/pbc:PBCoreDescriptionDocument/pbcoreGenre/genre">
       <xsl:if test="contains(., 'undergenre:') and substring-after(., 'undergenre:') != ''">

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -243,6 +243,12 @@
           <xsl:value-of select="$schemaorg-xml('contentUrl')"/>
         </f:string>
       </xsl:if>
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:file_id') != ''">
+        <f:string key="file_id">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:file_id') "/>
+        </f:string>
+      </xsl:if>
+
 
       <!-- Extract data on the encoded creative work, if present-->
       <xsl:if test="map:contains($schemaorg-xml, 'encodesCreativeWork')">

--- a/src/main/solr/dssolr/conf/lang/dr_synonyms.txt
+++ b/src/main/solr/dssolr/conf/lang/dr_synonyms.txt
@@ -11,5 +11,5 @@ fælleskab => fællesskab
 diciplin => disciplin
 
 # Collapse several terms into one (in this case a multiterm)
-tv-avisen, tvavis, tvavisen, tv-avis, tv avis=> tv avisen
+tv-avisen, tvavis, tvavisen, tv-avis, tv avis, tv-avis-sen=> tv avisen
 bamsekylling, bamse kylling => bamse og kylling

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -25,9 +25,10 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 1.0.1: Added text_shingles
 1.0.2: Defined 'snowball' for all stopword filters
 1.6.0: Spellcheck + Suggest added
-1.6.1: Synonym added to general_text fieldtype that is used for most text fields.  
+1.6.1: Synonym added to general_text fieldtype that is used for most text fields.
+1.6.2: Add fieldType for suggest component
   -->
-  <field name="_ds_1.6.1_" type="string" indexed="false" stored="false"/>
+  <field name="_ds_1.6.2_" type="string" indexed="false" stored="false"/>
   <uniqueKey>id</uniqueKey>
 
    <!-- START FIELDS  -->
@@ -961,6 +962,24 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt" format="snowball"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="lang/dr_synonyms.txt" ignoreCase="true"/>        
+    </analyzer>
+  </fieldType>
+
+  <!-- The suggest component needs its own field type. Currently, this is a copy of the text_general fieldType. -->
+  <!-- TODO: Figure how tho create the best suggest fieldType-->
+  <fieldType name="suggest_field"  class="solr.TextField" multiValued="false" indexed="true" required="false" stored="true"  termVectors="true" storeOffsetsWithPositions="true">
+    <analyzer type="index">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt" format="snowball"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="lang/dr_synonyms.txt" ignoreCase="true"/>
+      <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.StopFilterFactory" words="lang/stopwords_da.txt" format="snowball"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="lang/dr_synonyms.txt" ignoreCase="true"/>
     </analyzer>
   </fieldType>
 

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -857,6 +857,7 @@
         <str name="suggest.dictionary">dr_title_suggest</str>
         <str name="suggest">true</str>
         <str name="suggest.count">10</str>
+        <str name="suggest.cfq">DR</str> <!-- Add default value for contextField. This means that all suggestions are filtered by broadcaster:DR as normal queries are.-->
       </lst>
       <arr name="components">
         <str>suggest</str>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -866,12 +866,12 @@
   <searchComponent name="suggest" class="solr.SuggestComponent">
     <lst name="suggester">
       <str name="name">dr_title_suggest</str>
-      <str name="lookupImpl">FuzzyLookupFactory</str>
+      <str name="lookupImpl">BlendedInfixLookupFactory</str> <!-- Using one of the two implementations that support Context fields  -->
       <str name="dictionaryImpl">DocumentDictionaryFactory</str>
-      <str name="field">title</str>      
-      <str name="suggestAnalyzerFieldType">string</str>
-      <str name="buildOnStartup">true</str>         <!-- Good enough for now -->
-      <str name="buildOnCommit">true</str>
+      <str name="field">title</str>
+      <str name="contextField">broadcaster</str> <!-- Context field, used to filter the suggester on broadcaster:DR -->
+      <str name="suggestAnalyzerFieldType">suggest_field</str> <!-- Currently suggest_field is a copy of text_general -->
+      <str name="buildOnStartup">true</str> <!-- Good enough for now -->
     </lst>
   </searchComponent>
 

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
@@ -186,10 +186,11 @@ public class EmbeddedSolrFieldAnalyseTest {
     @Test
     public void testSuggest() throws SolrServerException, IOException{
         addSynonymFieldTestDocuments1();
+        addDocWithWrongBroadcaster();
 
         SuggesterResponse response = getSuggestResult("tv");
         int amountOfSuggestedTerms = response.getSuggestedTerms().get("dr_title_suggest").size();
-        assertTrue(amountOfSuggestedTerms > 0);
+        assertEquals(1, amountOfSuggestedTerms);
     }
 
     @Test
@@ -339,6 +340,24 @@ public class EmbeddedSolrFieldAnalyseTest {
             document.addField("origin", "ds.test");
             document.addField("title", "Velkommen til radioavisen");
             document.addField("broadcaster", "DR");
+
+            embeddedServer.add(document);
+            embeddedServer.commit();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Error indexing test documents");
+        }
+    }
+    private static void addDocWithWrongBroadcaster() {
+
+        try {
+
+            SolrInputDocument document = new SolrInputDocument();
+            document.addField("id", "negative1");
+            document.addField("origin", "ds.test");
+            document.addField("title", "Velkommen til radioavisen");
+            document.addField("broadcaster", "TV2");
 
             embeddedServer.add(document);
             embeddedServer.commit();

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
@@ -13,9 +13,13 @@ import org.apache.solr.client.solrj.SolrRequest.METHOD;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.SuggesterResponse;
+import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
 
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.core.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -178,6 +182,15 @@ public class EmbeddedSolrFieldAnalyseTest {
         assertEquals("Velkommen til TVavisen", titles.get(0));
 
     }
+
+    @Test
+    public void testSuggest() throws SolrServerException, IOException{
+        addSynonymFieldTestDocuments1();
+
+        SuggesterResponse response = getSuggestResult("tv");
+        int amountOfSuggestedTerms = response.getSuggestedTerms().get("dr_title_suggest").size();
+        assertTrue(amountOfSuggestedTerms > 0);
+    }
     
     
     private long getCreatorNameStrictResultsForQuery(String query) throws Exception {
@@ -219,6 +232,18 @@ public class EmbeddedSolrFieldAnalyseTest {
         solrQuery.setRows(10);
         QueryResponse rsp = embeddedServer.query(solrQuery, METHOD.POST);
         return rsp.getResults().getNumFound();
+
+    }
+
+    private SuggesterResponse getSuggestResult(String query) throws SolrServerException, IOException{
+        SolrParams params = new ModifiableSolrParams().set("qt", "/suggest");
+
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.add(params);
+        solrQuery.add("suggest.q", query);
+        solrQuery.add("suggest.build", "true");
+        solrQuery.setRows(10);
+        return embeddedServer.query(solrQuery, METHOD.POST).getSuggesterResponse();
 
     }
 

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
@@ -356,7 +356,7 @@ public class EmbeddedSolrFieldAnalyseTest {
             SolrInputDocument document = new SolrInputDocument();
             document.addField("id", "negative1");
             document.addField("origin", "ds.test");
-            document.addField("title", "Velkommen til radioavisen");
+            document.addField("title", "Velkommen til tvavisen hos TV2");
             document.addField("broadcaster", "TV2");
 
             embeddedServer.add(document);

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
@@ -191,6 +191,14 @@ public class EmbeddedSolrFieldAnalyseTest {
         int amountOfSuggestedTerms = response.getSuggestedTerms().get("dr_title_suggest").size();
         assertTrue(amountOfSuggestedTerms > 0);
     }
+
+    @Test
+    public void testNegativeSuggest() throws SolrServerException, IOException{
+        addDocForNegativeSuggestTest();
+        SuggesterResponse response = getSuggestResult("tv");
+        int amountOfSuggestedTerms = response.getSuggestedTerms().get("dr_title_suggest").size();
+        assertEquals(0, amountOfSuggestedTerms);
+    }
     
     
     private long getCreatorNameStrictResultsForQuery(String query) throws Exception {
@@ -287,6 +295,7 @@ public class EmbeddedSolrFieldAnalyseTest {
             document.addField("id", "synonym1");
             document.addField("origin", "ds.test");
             document.addField("title", "Velkommen til TVavisen"); // Synonym file: tv-avisen, tvavis, tvavisen, tv-avis
+            document.addField("broadcaster", "DR");
             // => tv avisen
 
             embeddedServer.add(document);
@@ -308,6 +317,7 @@ public class EmbeddedSolrFieldAnalyseTest {
             document.addField("id", "synonym1");
             document.addField("origin", "ds.test");
             document.addField("title", "Velkommen til TV avisen"); // Synonym file: tv-avisen, tvavis, tvavisen, tv-avis
+            document.addField("broadcaster", "DR");
             // => tv avisen
 
             embeddedServer.add(document);
@@ -319,7 +329,27 @@ public class EmbeddedSolrFieldAnalyseTest {
         }
 
     }
-  
-    
-    
+
+    private static void addDocForNegativeSuggestTest() {
+
+        try {
+
+            SolrInputDocument document = new SolrInputDocument();
+            document.addField("id", "negative1");
+            document.addField("origin", "ds.test");
+            document.addField("title", "Velkommen til radioavisen");
+            document.addField("broadcaster", "DR");
+
+            embeddedServer.add(document);
+            embeddedServer.commit();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Error indexing test documents");
+        }
+    }
+
+
+
+
 }


### PR DESCRIPTION
The result from the suggest component should be filtered in the same was as a normal query is by a fq. Suggest component uses a contextField for this. 

This branch **is not** deployed on devel. If deploying to devel to test it, remember to create a new collection before updating configuration. Remember to build the index for the suggester by appending `&suggest.build=true` to the first query to ensure that the index is build. eg: `http://localhost:10007/solr/ds/suggest?suggest.q=dr&suggest.cfq=DR&suggest.count=10&wt=json&suggest.build=true`

To test the functionality try the following query: `http://localhost:10007/solr/ds/suggest?suggest.q=dr&suggest.cfq=DR&suggest.count=10&wt=json` and observe how only result from DR are returned. Confirm that _dræberen med de 100 dolke_ isn't part of the suggestions and then do the same query at the frontend application and se that this TV2 show is infact there.