### PR TITLE
DRA-236. Removed spellcheck.maxCollationTries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Removed spellcheck.maxCollationTries from spellcheck component. It crashed Solr on core reload (after configuration changes)
 
 ## [1.7.2](https://github.com/kb-dk/ds-present/releases/tag/ds-present-1.7.2) - 2024-03-1
 

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -818,7 +818,7 @@
       <str name="spellcheck.maxResultsForSuggest">5</str>
       <str name="spellcheck.collate">true</str>  <!-- Important this will combine words and give a full query back -->
       <str name="spellcheck.collateExtendedResults">true</str> > <!-- Probably disable later.But usefull to see what is in data -->
-      <str name="spellcheck.maxCollationTries">10</str>
+      <!-- <str name="spellcheck.maxCollationTries">10</str>  This will crash reload of core after configuration change--> 
       <str name="spellcheck.maxCollations">5</str>
       <str name="spellcheck.build">false</str>  <!-- Much overhead building it every query. Not recommended and will not scale -->              
      


### PR DESCRIPTION
Remove spellcheck.maxCollationTries since it crashed solr when reloading core after configuration change.

Reload core with:
`curl -X POST "http://localhost:8983/api/collections/ds/" -H 'Content-Type: application/json' -d '{"modify":{"config": "dssolr" } }'`


Full description in the Jira Issue.