### PR TITLE
Instrument `/record`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.5.0</version>
+            <version>1.5.1</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.26</version>
+            <version>1.5.0</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->

--- a/src/main/java/dk/kb/present/DSOrigin.java
+++ b/src/main/java/dk/kb/present/DSOrigin.java
@@ -156,9 +156,7 @@ public class DSOrigin {
      * @throws ServiceException if the record could not be retrieved or transformed.
      */
     public String getRecord(String recordID, FormatDto format) throws ServiceException {
-        Timing timing = Stats.GET_RECORD.
-                getChild("origin_" + id, null, null, Stats.EMPTY_STATS).
-                getChild(format.getValue(), null, "record", Stats.DEFAULT_STATS);
+        Timing timing = Stats.getViewTimer(id, format.getValue().toLowerCase(Locale.ROOT));
 
         // Timing is both overall and with sub-timings for retrieval and transformation
         return timing.measure(() -> {

--- a/src/main/java/dk/kb/present/Stats.java
+++ b/src/main/java/dk/kb/present/Stats.java
@@ -1,0 +1,57 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.present;
+
+import dk.kb.present.model.v1.FormatDto;
+import dk.kb.util.Timing;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Holds statistics for operations.
+ */
+public class Stats {
+    private static final Logger log = LoggerFactory.getLogger(Stats.class);
+
+    /**
+     * Empty stats for timing parents that defer all measuring to children.
+     */
+    public static final Timing.STATS[] EMPTY_STATS = new Timing.STATS[]{};
+
+    /**
+     * The elements to display when displaying stats. Performance is not affected, only verbosity.
+     */
+    public static final Timing.STATS[] DEFAULT_STATS = new Timing.STATS[]{
+            Timing.STATS.name, Timing.STATS.subject, Timing.STATS.updates, Timing.STATS.ms_updates, Timing.STATS.updates_s,
+            Timing.STATS.max_ms, Timing.STATS.last_ms};
+
+    /**
+     * Overall statistics for {@link dk.kb.present.api.v1.impl.DsPresentApiServiceImpl#getRecord(String, FormatDto)}.
+     * <p>
+     * This holds sub-statistics for the different origins & views as well as access.
+     */
+    public static final Timing GET_RECORD =
+            new Timing("getRecord", null, "records", DEFAULT_STATS);
+
+    /**
+     * Access resolving statistics for
+     * {@link dk.kb.present.api.v1.impl.DsPresentApiServiceImpl#getRecord(String, FormatDto)}.
+     * <p>
+     * This is a child of {@link #GET_RECORD}.
+     */
+    public static final Timing RECORD_ACCESS =
+            GET_RECORD.getChild("access", null, "checks", DEFAULT_STATS);
+
+}

--- a/src/main/java/dk/kb/present/Stats.java
+++ b/src/main/java/dk/kb/present/Stats.java
@@ -25,8 +25,10 @@ import org.slf4j.LoggerFactory;
 public class Stats {
     /**
      * Empty stats for timing parents that defer all measuring to children.
+     * <p>
+     * Note: Not truly empty as {@link Timing.STATS#name} is still there, but without any other values.
      */
-    public static final Timing.STATS[] EMPTY_STATS = new Timing.STATS[]{};
+    public static final Timing.STATS[] EMPTY_STATS = new Timing.STATS[]{Timing.STATS.name};
 
     /**
      * The elements to display when displaying stats. Performance is not affected, only verbosity.
@@ -52,4 +54,15 @@ public class Stats {
     public static final Timing RECORD_ACCESS =
             GET_RECORD.getChild("access", null, "checks", DEFAULT_STATS);
 
+    /**
+     * Deliver the {@link Timing} responsible for tracting the specified origin with the specified view.
+     * @param origin {@link DSOrigin#getId()}.
+     * @param view {@link View#getId()}.
+     * @return a {@link Timing} for tracking {@link View} processing.
+     */
+    public static Timing getViewTimer(String origin, String view) {
+        return Stats.GET_RECORD.
+                getChild("origin_" + origin, null, null, Stats.EMPTY_STATS).
+                getChild(view, null, "record", Stats.DEFAULT_STATS);
+    }
 }

--- a/src/main/java/dk/kb/present/Stats.java
+++ b/src/main/java/dk/kb/present/Stats.java
@@ -23,8 +23,6 @@ import org.slf4j.LoggerFactory;
  * Holds statistics for operations.
  */
 public class Stats {
-    private static final Logger log = LoggerFactory.getLogger(Stats.class);
-
     /**
      * Empty stats for timing parents that defer all measuring to children.
      */

--- a/src/main/java/dk/kb/present/api/v1/impl/ServiceApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/ServiceApiServiceImpl.java
@@ -6,6 +6,7 @@ import dk.kb.present.model.v1.StatusDto;
 import dk.kb.present.model.v1.WhoamiDto;
 import dk.kb.present.webservice.AccessUtil;
 import dk.kb.util.BuildInfoManager;
+import dk.kb.util.Timing;
 import dk.kb.util.webservice.ImplBase;
 import dk.kb.util.webservice.exception.ServiceException;
 import org.slf4j.Logger;
@@ -82,7 +83,7 @@ public class ServiceApiServiceImpl extends ImplBase implements ServiceApi {
                 .gitCurrentTag(BuildInfoManager.getGitCurrentTag())
                 .gitCommitTime(BuildInfoManager.getGitCommitTime())
                 .health("ok")
-                .stats(Stats.GET_RECORD.toString(false, true));
+                .stats(Stats.GET_RECORD.toString((Timing.STATS[])null, true));
     }
 
     // Test with curl -X GET "http://localhost:9073/ds-present/v1/probe/whoami" -H  "Simulated-OAuth2-Group: foo"

--- a/src/main/java/dk/kb/present/api/v1/impl/ServiceApiServiceImpl.java
+++ b/src/main/java/dk/kb/present/api/v1/impl/ServiceApiServiceImpl.java
@@ -1,5 +1,6 @@
 package dk.kb.present.api.v1.impl;
 
+import dk.kb.present.Stats;
 import dk.kb.present.api.v1.ServiceApi;
 import dk.kb.present.model.v1.StatusDto;
 import dk.kb.present.model.v1.WhoamiDto;
@@ -80,7 +81,8 @@ public class ServiceApiServiceImpl extends ImplBase implements ServiceApi {
                 .gitClosestTag(BuildInfoManager.getGitClosestTag())
                 .gitCurrentTag(BuildInfoManager.getGitCurrentTag())
                 .gitCommitTime(BuildInfoManager.getGitCommitTime())
-                .health("ok");
+                .health("ok")
+                .stats(Stats.GET_RECORD.toString(false, true));
     }
 
     // Test with curl -X GET "http://localhost:9073/ds-present/v1/probe/whoami" -H  "Simulated-OAuth2-Group: foo"

--- a/src/main/openapi/ds-present-openapi_v1.yaml
+++ b/src/main/openapi/ds-present-openapi_v1.yaml
@@ -1113,7 +1113,10 @@ components:
           description: 'The closest tag of the deployed branch.'
         gitCommitTime:
           type: string
-          description: 'The time for the latest commit of the deplyed branch.'
+          description: 'The time for the latest commit of the deployed branch.'
+        stats:
+          type: string
+          description: 'Assorted performance statistics'
 
     Whoami:
       type: object


### PR DESCRIPTION
This pull request adds always-on instrumentation of the `/record` endpoint, logging the time spend on retrieval and transformation of the record data. The stats are bucketed in origin+view, making it possible to pinpoint heavy transformations and/or data sources.

The endpoint `/monitor/status` has been expanded with the overall stats. Testing can be done by starting the service on the developer network (so that it can reach a working `ds-storage`), issuing some requests to `/record` with different views and calling
```shell
curl -s 'http://localhost:9073/ds-present/v1/monitor/status' | jq -r .stats
```
which should yield something like
```
getRecord(3records, 117ms/records, 8records/s, max=225ms, last52ms, [
  access(3checks, 0ms/checks, 10421checks/s, max=0ms, last0ms),
  origin_ds.tv(, [
    json-ld(1record, 207ms/record, 4record/s, max=207ms, last207ms, [
      retrieve(1record, 123ms/record, 8record/s, max=123ms, last123ms),
      transform(1record, 82ms/record, 12record/s, max=82ms, last82ms)
    ]),
    solrjson(2record, 63ms/record, 15record/s, max=76ms, last51ms, [
      retrieve(2record, 14ms/record, 68record/s, max=14ms, last14ms),
      transform(2record, 49ms/record, 20record/s, max=61ms, last36ms)
    ])
  ])
])
```