### PR TITLE
Dra 481 prepare solr for stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for dynamically updating values in OpenAPI spec through internal JIRA issue [DRA-139](https://kb-dk.atlassian.net/browse/DRA-139)
 - Added sample config files and documentation to distribution tar archive.
+- Added distribution zip of solr configset
 
 ### Changed
 - Switch configuration style to camelCase [DRA-431](https://kb-dk.atlassian.net/browse/DRA-431)

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <license.name>Apache License, Version 2.0</license.name>
         <license.url>https://www.apache.org/licenses/LICENSE-2.0.txt</license.url>
         <timestamp>${maven.build.timestamp}</timestamp>
+        <solr.config.version>1.6.3</solr.config.version> <!-- Semantic versioning of solr config and schema -->
 
         <project.package>dk.kb.present</project.package>
     </properties>
@@ -682,7 +683,7 @@
                     </httpConnector>
                 </configuration>
             </plugin>
-            <plugin>
+          <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.6.0</version>
                 <configuration>
@@ -697,6 +698,22 @@
                             <goal>single</goal>
                         </goals>
                         <phase>package</phase>
+                    </execution>
+                    <execution>
+                      <id>solr-assembly</id> <!-- Unique identifier for this execution -->
+                      <phase>package</phase>
+                      <goals>
+                        <goal>single</goal>
+                      </goals>
+                      <configuration>
+                        <descriptors>
+                          <descriptor>src/main/assembly/solrAssembly.xml</descriptor>
+                        </descriptors>
+                        <!-- Specify the finalName for the specific assembly -->
+                        <finalName>ds_solr9_conf_${solr.config.version}</finalName>
+                        <appendAssemblyId>false</appendAssemblyId>
+                        <attach>true</attach>
+                      </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -50,6 +50,12 @@
         <include>ds-present.build.properties</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>src/main/solr/dssolr/conf</directory>
+      <outputDirectory>solr/conf</outputDirectory>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0644</fileMode>
+    </fileSet>
   </fileSets>
 
 

--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -50,12 +50,6 @@
         <include>ds-present.build.properties</include>
       </includes>
     </fileSet>
-    <fileSet>
-      <directory>src/main/solr/dssolr/conf</directory>
-      <outputDirectory>solr/conf</outputDirectory>
-      <directoryMode>0755</directoryMode>
-      <fileMode>0644</fileMode>
-    </fileSet>
   </fileSets>
 
 

--- a/src/main/assembly/solrAssembly.xml
+++ b/src/main/assembly/solrAssembly.xml
@@ -8,7 +8,7 @@
   <fileSets>
     <fileSet>
       <directory>src/main/solr/dssolr/conf/</directory>
-      <outputDirectory>./ds_solr9_conf_${properties.solr.config.version}/conf</outputDirectory>
+      <outputDirectory>./ds_solr9_conf_${solr.config.version}/conf</outputDirectory>
       <directoryMode>0755</directoryMode>
       <fileMode>0644</fileMode>
     </fileSet>

--- a/src/main/assembly/solrAssembly.xml
+++ b/src/main/assembly/solrAssembly.xml
@@ -1,0 +1,16 @@
+<assembly>
+  <!-- Define solr package -->
+  <id>solr-assembly</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>src/main/solr/dssolr/conf/</directory>
+      <outputDirectory>./ds_solr9_conf_${properties.solr.config.version}/conf</outputDirectory>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0644</fileMode>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -21,6 +21,8 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
        Update this according to Semantic Versioning rules: https://semver.org/
 
        Used by scripts for keeping track of versioning of Solr setup across time and Solr instances.
+       When updating version here, please update the version of pom.properties.solr.config.version as well, as this is
+       used to generate correct configset for production environment.
 
 1.0.1: Added text_shingles
 1.0.2: Defined 'snowball' for all stopword filters


### PR DESCRIPTION
Adds an assembly step for delivering the solr config set as a zip file. 
The only thing a bit worrying here is the versioning of the solr schema, which has to be done in two places now, however I don't see another way of doing it in the schema, which is quite important for our `ds_cloud`-script. 

Naming has been done following this internal guide on naming a solr collection for production at KB: https://kb-dk.atlassian.net/wiki/spaces/DT/pages/13829092/Solr+Cloud+som+service 

