### PR TITLE
Add solr field temporal_start_hour_da

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added 
 - Added solr field: temporal_start_month
+- Added solr field: temporal_start_hour_da
 
 ## Changed
 - Changed field type for solr field: temporal_start_year

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <license.name>Apache License, Version 2.0</license.name>
         <license.url>https://www.apache.org/licenses/LICENSE-2.0.txt</license.url>
         <timestamp>${maven.build.timestamp}</timestamp>
-        <solr.config.version>1.6.6</solr.config.version> <!-- Semantic versioning of solr config and schema -->
+        <solr.config.version>1.6.7</solr.config.version> <!-- Semantic versioning of solr config and schema -->
 
         <project.package>dk.kb.present</project.package>
     </properties>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -303,6 +303,11 @@
           <xsl:value-of select="$temporal_start_time_da_string"/>
         </f:string>
 
+        <!-- The int value of the danish start hour. -->
+        <f:string key="temporal_start_hour_da">
+          <xsl:value-of select="hours-from-dateTime($startTimeDK)"/>
+        </f:string>
+
         <!-- The string value of the danish date. -->
         <f:string key="temporal_start_date_da_string">
           <xsl:value-of select="xs:string(xs:date($startTimeDK))"/>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -33,6 +33,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 1.6.4: Add temporal_start_date_da_string and temporal_end_date_da_string fields.
 1.6.5: Add temporal_start_year field.
 1.6.6: Add temporal_start_month field and make temporal_start_year and temporal_star_month fq fields.
+1.6.7: Add temporal_start_hour_da field.
   -->
   <field name="_ds_1.6.6_" type="string" indexed="false" stored="false"/>
   <uniqueKey>id</uniqueKey>
@@ -618,7 +619,12 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 
   <field name="temporal_start_month" type="pint" docValues="true">
     <?description The start month of the broadcast as an integer in the range 1-12, where 1 equals January and 12 equals December.?>
-    <?example January?>
+    <?example 1?>
+  </field>
+
+  <field name="temporal_start_hour_da" type="pint" docValues="true">
+    <?description The start hour of the broadcast as an integer in the range 0-24.?>
+    <?example 18?>
   </field>
 
   <field name="temporal_start_time_da_string" type="string">

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -803,6 +803,7 @@
        <str name="facet.field">subject_full_name</str>
        <str name="facet.field">temporal_start_month</str>
        <str name="facet.field">temporal_start_year</str>
+       <str name="facet.field">temporal_start_hour_da</str>
 
         
        <str name="hl">on</str>

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -424,6 +424,7 @@ public class EmbeddedSolrTest {
         testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_day_da", "Saturday");
         testStringValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_end_day_da", "Saturday");
         testIntValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_month", 4);
+        testIntValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_hour_da", 18);
 
         Date startDate = new Date(253370830500000L);
         testDateValuePreservicaField(PVICA_RECORD_1f3a6a66, "temporal_start_time_da_date", startDate);

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -322,6 +322,7 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
     void testTemporalSearchFields(){
         // Sanity check time zone conversions at https://www.worldtimebuddy.com/
         assertPvicaContains(TestFiles.PVICA_RECORD_1f3a6a66, "\"temporal_start_time_da_string\":\"18:15:00\"," +
+                                                                        "\"temporal_start_hour_da\":\"18\"," +
                                                                         "\"temporal_start_date_da_string\":\"2012-04-28\"," +
                                                                         "\"temporal_start_year\":\"2012\"," +
                                                                         "\"temporal_start_month\":\"4\"," +
@@ -346,6 +347,7 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
         Files.saveString(winter, winterFile);
 
         assertPvicaContains(winterFile.getAbsolutePath(), "\"temporal_start_time_da_string\":\"17:15:00\"," +
+                                                                        "\"temporal_start_hour_da\":\"17\"," +
                                                                         "\"temporal_start_date_da_string\":\"2012-02-28\"," +
                                                                         "\"temporal_start_year\":\"2012\"," +
                                                                         "\"temporal_start_month\":\"2\"," +


### PR DESCRIPTION
Adds the field temporal_start_hour_da requested by the frontenders, for building time of day selecter