### PR TITLE
Dra 763 build error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,11 @@
           <version>2.0.9</version>
         </dependency>
         <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-ext</artifactId>
+          <version>2.0.9</version>
+        </dependency>
+        <dependency>
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
           <version>1.4.14</version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
                     <groupId>jakarta.xml.bind</groupId>
                     <artifactId>jakarta.xml.bind-api</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -189,34 +193,32 @@
             <scope>runtime</scope>
         </dependency>-->
 
-
         <!-- Logging dependencies -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.11</version>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>2.0.11</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-            <version>2.0.9</version>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jul-to-slf4j</artifactId>
+          <version>2.0.9</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-            <version>2.0.9</version>
+          <groupId>org.slf4j</groupId>
+          <artifactId>log4j-over-slf4j</artifactId>
+          <version>2.0.9</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>2.0.9</version>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
+          <version>2.0.9</version>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.4.14</version>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+          <version>1.4.14</version>
         </dependency>
-
         <!-- Unit test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -308,23 +310,15 @@
              <exclusions>
                 <exclusion>
                       <groupId>org.slf4j</groupId>
-                      <artifactId>slf4j-log4j12-impl</artifactId>
-                  </exclusion>
-                  <exclusion>
-                      <groupId>org.slf4j</groupId>
-                      <artifactId>slf4j-log4j12</artifactId>
+                      <artifactId>*</artifactId>
                   </exclusion>
                   <exclusion>
                       <groupId>log4j</groupId>
-                      <artifactId>log4j</artifactId>
-                  </exclusion>
-                    <exclusion>
-                      <groupId>log4j</groupId>
-                      <artifactId>log4j-api</artifactId>
+                      <artifactId>*</artifactId>
                   </exclusion>
                   <exclusion>
                       <groupId>org.apache.logging.log4j</groupId>
-                      <artifactId>log4j-core</artifactId>
+                      <artifactId>*</artifactId>
                   </exclusion>
               </exclusions>
              </dependency>
@@ -337,27 +331,19 @@
                <exclusions>
                  <exclusion> <!-- Solves the "multiple slf bindings" warning -->
                     <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-slf4j-impl</artifactId>
+                    <artifactId>*</artifactId>
                  </exclusion>
                  <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                 </exclusion>
-                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12-impl</artifactId>
+                    <artifactId>*</artifactId>
                  </exclusion>
                  <exclusion>
                     <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
+                    <artifactId>*</artifactId>
                  </exclusion>
                  <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                 </exclusion>
-                 <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
+                   <groupId>org.xerial.snappy</groupId>
+                   <artifactId>snappy-java</artifactId>
                  </exclusion>
                 </exclusions>
               </dependency>

--- a/src/test/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImplTest.java
+++ b/src/test/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImplTest.java
@@ -100,7 +100,7 @@ public class DsPresentApiServiceImplTest {
         }
     }
 
-    @Test
+    /*@Test
     public void testMultiRecordsLicense() throws NoSuchFieldException, ApiException, IOException {
         if (Resolver.getPathFromClasspath("internal_test_files") == null){
             return;
@@ -127,7 +127,7 @@ public class DsPresentApiServiceImplTest {
         StreamingOutput noRecords = presentAPI.getRecords("dsfl", 0L, 1000L, FormatDto.MODS);
         assertEquals(0, PresentFacadeTest.countMETS(noRecords),
                 "Zero accepting license should return exactly 0 records");
-    }
+    }*/
 
     @Test
     public void testSingleRecordLicenseAllowAll() throws NoSuchFieldException, ApiException, IOException {

--- a/src/test/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImplTest.java
+++ b/src/test/java/dk/kb/present/api/v1/impl/DsPresentApiServiceImplTest.java
@@ -100,7 +100,7 @@ public class DsPresentApiServiceImplTest {
         }
     }
 
-    /*@Test
+    @Test
     public void testMultiRecordsLicense() throws NoSuchFieldException, ApiException, IOException {
         if (Resolver.getPathFromClasspath("internal_test_files") == null){
             return;
@@ -127,7 +127,7 @@ public class DsPresentApiServiceImplTest {
         StreamingOutput noRecords = presentAPI.getRecords("dsfl", 0L, 1000L, FormatDto.MODS);
         assertEquals(0, PresentFacadeTest.countMETS(noRecords),
                 "Zero accepting license should return exactly 0 records");
-    }*/
+    }
 
     @Test
     public void testSingleRecordLicenseAllowAll() throws NoSuchFieldException, ApiException, IOException {


### PR DESCRIPTION
Comparing with ds-storage, which is running correctly in stage, ds-present was missing the ```slf4j-ext``` dependency, which storage inherits from another dependency. We should discuss if this is to be included directly in all services.