### PR TITLE
Make the transformations handle basic differences between doms and preservica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added XSLT support for parsing Preservica and DOMS records through the same transformation.
+
 ### Changed
 - Changed a lot of transformation tests to use preservica 7 data instead of preservica 5.  
 

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -1038,14 +1038,18 @@
     </xsl:choose>
   </xsl:template>
 
-        <!-- Template to strip namespace from elements -->
+  <!-- Template to strip namespace from elements.
+        This is needed as DOMS records are defining namespace prefixes for each and every child,
+        while preservica records only create them for parent records. -->
   <xsl:template match="*" mode="strip-ns">
   <xsl:element name="{local-name()}">
     <xsl:apply-templates select="@*|node()" mode="strip-ns"/>
   </xsl:element>
   </xsl:template>
 
-          <!-- Template to strip namespace from attributes -->
+  <!-- Template to strip namespace from attributes.
+        This is needed as DOMS records are defining namespace prefixes for each and every child,
+        while preservica records only create them for parent records.-->
   <xsl:template match="@*" mode="strip-ns">
   <xsl:attribute name="{local-name()}">
     <xsl:value-of select="."/>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -46,6 +46,10 @@
           <xsl:value-of select="."/>
     </xsl:variable>
 
+    <xsl:variable name="pidHandles">
+      <xsl:value-of select="distinct-values(//pidhandle:pidhandle/handle)"/>
+    </xsl:variable>
+
     <!-- Determine the type of schema.org object in hand.-->
     <xsl:variable name="type">
       <xsl:choose>
@@ -71,6 +75,7 @@
             <xsl:with-param name="pbCore" select="$pbCore"/>
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+            <xsl:with-param name="pidHandles" select="$pidHandles"/>
           </xsl:call-template>
         </xsl:when>
         <xsl:when test="$type = 'AudioObject'">
@@ -78,6 +83,7 @@
             <xsl:with-param name="pbCore" select="$pbCore"/>
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+            <xsl:with-param name="pidHandles" select="$pidHandles"/>
           </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>
@@ -85,6 +91,7 @@
             <xsl:with-param name="pbCore" select="$pbCore"/>
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+            <xsl:with-param name="pidHandles" select="$pidHandles"/>
           </xsl:call-template>
         </xsl:otherwise>
       </xsl:choose>
@@ -101,6 +108,7 @@
     <xsl:param name="pbCore"/>
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
+    <xsl:param name="pidHandles"/>
 
     <f:map>
       <!-- Creates the first three fields for docs. -->
@@ -114,6 +122,7 @@
           <xsl:call-template name="pbc-metadata">
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+            <xsl:with-param name="pidHandles" select="$pidHandles"/>
           </xsl:call-template>
 
           <!-- This is the only field directly present in pbc:PBCoreDescriptionDocument, which is only used for video
@@ -185,13 +194,14 @@
     <xsl:param name="pbCore"/>
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
+    <xsl:param name="pidHandles"/>
 
     <!-- As the generic template currently is the same as the AudioObject, then this template is called here-->
     <xsl:call-template name="generic-transformation">
       <xsl:with-param name="pbCore" select="$pbCore"/>
       <xsl:with-param name="type" select="$type"/>
       <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-
+      <xsl:with-param name="pidHandles" select="$pidHandles"/>
     </xsl:call-template>
   </xsl:template>
 
@@ -203,6 +213,7 @@
     <xsl:param name="pbCore"/>
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
+    <xsl:param name="pidHandles"/>
 
     <f:map>
       <!-- Creates the first three fields for docs. -->
@@ -220,6 +231,7 @@
               <xsl:call-template name="pbc-metadata">
                 <xsl:with-param name="type" select="$type"/>
                 <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
+                <xsl:with-param name="pidHandles" select="$pidHandles"/>
               </xsl:call-template>
             </xsl:for-each>
           </xsl:when>
@@ -294,6 +306,7 @@
   <xsl:template name="pbc-metadata">
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
+    <xsl:param name="pidHandles"/>
     <!-- TODO: Investigate relation between titel and originaltitel. Some logic related to metadata delivery type exists. -->
     <!-- Create fields headline and alternativeHeadline if needed.
          Determine if title and original title are alike. Both fields should always be in metadata -->
@@ -635,11 +648,7 @@
         </xsl:for-each>
       </xsl:if>
       <!-- Extracts PID as identifier if present.-->
-      <xsl:if test="//pidhandle:pidhandle/handle">
-        <xsl:variable name="pidHandles">
-          <xsl:value-of select="distinct-values(//pidhandle:pidhandle/handle)"/>
-        </xsl:variable>
-
+      <xsl:if test="$pidHandles != ''">
         <f:map>
           <f:string key="@type">PropertyValue</f:string>
           <f:string key="PropertyID">PID</f:string>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -444,41 +444,69 @@
           </xsl:if>
         </xsl:for-each>
 
-        <!-- Extract metadata from PBC extensions related to episodes -->
         <xsl:for-each select="./pbcoreExtension/extension">
-          <!-- Extract episode number if present.
-               Checks for 'episodenr' in PBC extension and checks that there is a substring after the key.-->
-          <xsl:if test="f:contains(., 'episodenr:') and f:string-length(substring-after(., 'episodenr:')) > 0">
-            <f:number key="episodeNumber">
-              <xsl:value-of select="substring-after(., 'episodenr:')"/>
-            </f:number>
-          </xsl:if>
-        </xsl:for-each>
+          <xsl:choose>
+            <xsl:when test="f:contains(substring-after(., 'episodenr:'), ':')">
+                <xsl:variable name="episodeInfo">
+                  <xsl:value-of select="substring-after(., 'episodenr:')"/>
+                </xsl:variable>
 
-        <!-- Extract metadata from PBC extensions related to season length. -->
-        <xsl:for-each select="./pbcoreExtension/extension">
-          <!-- Extract number of episodes in a season, if present.
-               Checks for 'antalepisoder' in PBC extension and checks that the value is not an empty string or 0.
-               Create partOfSeason field, if any metadata is present. -->
-          <xsl:if test="f:contains(., 'antalepisoder:') and
-                        not(f:contains(., 'antalepisoder:0')) and
-                        f:string-length(substring-after(., 'antalepisoder:')) > 0">
-            <!-- TODO: Figure if  there is a difference between no value and 0.
-                 Could one mean that a series is related but no data on it and
-                 the other means individual program with no series? -->
-            <f:map key="partOfSeason">
-              <f:string key="@type">
-                <xsl:choose>
-                  <xsl:when test="$type = 'VideoObject'">TVSeason</xsl:when>
-                  <xsl:when test="$type = 'AudioObject'">RadioSeason</xsl:when>
-                  <xsl:otherwise>CreativeWorkSeason</xsl:otherwise>
-                </xsl:choose>
-              </f:string>
-                <f:number key="numberOfEpisodes">
-                  <xsl:value-of select="substring-after(., 'antalepisoder:')"/>
+                <f:number key="episodeNumber">
+                  <xsl:value-of select="substring-before($episodeInfo, ':')"/>
                 </f:number>
-            </f:map>
-          </xsl:if>
+                <f:map key="partOfSeason">
+                  <f:string key="@type">
+                    <xsl:choose>
+                      <xsl:when test="$type = 'VideoObject'">TVSeason</xsl:when>
+                      <xsl:when test="$type = 'AudioObject'">RadioSeason</xsl:when>
+                      <xsl:otherwise>CreativeWorkSeason</xsl:otherwise>
+                    </xsl:choose>
+                  </f:string>
+                  <f:number key="numberOfEpisodes">
+                    <xsl:value-of select="substring-after($episodeInfo, ':')"/>
+                  </f:number>
+                </f:map>
+
+            </xsl:when>
+            <xsl:otherwise>
+              <!-- Extract metadata from PBC extensions related to episodes -->
+              <xsl:for-each select="./pbcoreExtension/extension">
+                <!-- Extract episode number if present.
+                     Checks for 'episodenr' in PBC extension and checks that there is a substring after the key.-->
+                <xsl:if test="f:contains(., 'episodenr:') and f:string-length(substring-after(., 'episodenr:')) > 0">
+                  <f:number key="episodeNumber">
+                    <xsl:value-of select="substring-after(., 'episodenr:')"/>
+                  </f:number>
+                </xsl:if>
+              </xsl:for-each>
+
+              <!-- Extract metadata from PBC extensions related to season length. -->
+              <xsl:for-each select="./pbcoreExtension/extension">
+                <!-- Extract number of episodes in a season, if present.
+                     Checks for 'antalepisoder' in PBC extension and checks that the value is not an empty string or 0.
+                     Create partOfSeason field, if any metadata is present. -->
+                <xsl:if test="f:contains(., 'antalepisoder:') and
+                          not(f:contains(., 'antalepisoder:0')) and
+                          f:string-length(substring-after(., 'antalepisoder:')) > 0">
+                  <!-- TODO: Figure if  there is a difference between no value and 0.
+                       Could one mean that a series is related but no data on it and
+                       the other means individual program with no series? -->
+                  <f:map key="partOfSeason">
+                    <f:string key="@type">
+                      <xsl:choose>
+                        <xsl:when test="$type = 'VideoObject'">TVSeason</xsl:when>
+                        <xsl:when test="$type = 'AudioObject'">RadioSeason</xsl:when>
+                        <xsl:otherwise>CreativeWorkSeason</xsl:otherwise>
+                      </xsl:choose>
+                    </f:string>
+                    <f:number key="numberOfEpisodes">
+                      <xsl:value-of select="substring-after(., 'antalepisoder:')"/>
+                    </f:number>
+                  </f:map>
+                </xsl:if>
+              </xsl:for-each>
+            </xsl:otherwise>
+          </xsl:choose>
         </xsl:for-each>
       </f:map>
     </xsl:if>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -32,15 +32,26 @@
   <xsl:param name="mTime"/>
   <!-- Access condition for DR material. Currently, this param contains a placeholder. -->
   <xsl:param name="conditionsOfAccess"/>
-  
+  <xsl:include href="xslt/utils.xsl"/>
+
+
   <!-- MAIN TEMPLATE. This template delegates, which fields are to be created for each schema.org object.
        Currently, the template handles transformations from Preservica records to SCHEMA.ORG VideoObjects and AudioObjects. -->
   <xsl:template match="/">
+
+    <xsl:variable name="pbCore">
+          <xsl:for-each select="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument">
+            <xsl:apply-templates mode="strip-ns"/>
+          </xsl:for-each>
+          <xsl:value-of select="."/>
+    </xsl:variable>
+
     <!-- Determine the type of schema.org object in hand.-->
     <xsl:variable name="type">
       <xsl:choose>
-        <xsl:when test="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatMediaType = 'Moving Image'">VideoObject</xsl:when>
-        <xsl:when test="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatMediaType = 'Sound'">AudioObject</xsl:when>
+        <!-- XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbc:pbcoreInstantiation/pbc:formatMediaType = 'Moving Image'"-->
+        <xsl:when test="$pbCore/pbcoreInstantiation/formatMediaType = 'Moving Image'">VideoObject</xsl:when>
+        <xsl:when test="$pbCore/pbcoreInstantiation/formatMediaType = 'Sound'">AudioObject</xsl:when>
         <xsl:otherwise>MediaObject</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
@@ -48,7 +59,7 @@
 
     <!-- Saves all extensions in a variable used to check if one or more conditions are met in any of them.
          This is done to create one nested object in the JSON with values from multiple PBC extensions. -->
-    <xsl:variable name="pbcExtensions" select="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreExtension/extension"/>
+    <xsl:variable name="pbcExtensions" select="$pbCore/pbcoreExtension/extension"/>
 
     <xsl:variable name="json">
       <!-- TODO: Generel todo: Figure how to determine language for the strings "@language" that can be used throughout the schema.-->
@@ -57,18 +68,21 @@
       <xsl:choose>
         <xsl:when test="$type = 'VideoObject'">
           <xsl:call-template name="video-transformation">
+            <xsl:with-param name="pbCore" select="$pbCore"/>
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
           </xsl:call-template>
         </xsl:when>
         <xsl:when test="$type = 'AudioObject'">
           <xsl:call-template name="audio-transformation">
+            <xsl:with-param name="pbCore" select="$pbCore"/>
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
           </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>
           <xsl:call-template name="generic-transformation">
+            <xsl:with-param name="pbCore" select="$pbCore"/>
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
           </xsl:call-template>
@@ -84,6 +98,7 @@
         pbcExtensions: A parameter containing all PBCore Extensions for better retrieval of specific extensions during
                        the transformation. -->
   <xsl:template name="video-transformation">
+    <xsl:param name="pbCore"/>
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
 
@@ -95,7 +110,7 @@
 
       <xsl:try>
         <!-- Extract PBCore metadata-->
-        <xsl:for-each select="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument">
+        <xsl:for-each select="$pbCore">
           <xsl:call-template name="pbc-metadata">
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
@@ -111,24 +126,29 @@
         </xsl:for-each>
 
         <!-- Extract manifestation -->
-        <xsl:call-template name="extract-manifestation-preservica"/>
+        <xsl:call-template name="extract-manifestation-preservica">
+          <xsl:with-param name="pbCore" select="$pbCore"/>
+        </xsl:call-template>
 
         <!-- Create the kb:internal map. This map contains all metadata, that are not represented in schema.org, but were
              available from the preservica records.-->
         <f:map key="kb:internal">
         <!-- Transforms values that does not fit directly into Schema.org into an internal map. -->
         <xsl:call-template name="kb-internal">
+          <xsl:with-param name="pbCore" select="$pbCore"/>
           <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
           <xsl:with-param name="type" select="$type"/>
         </xsl:call-template>
 
         <!-- This template extracts internal fields, that are only relevant for video objects. Therefore, they have been
              removed from the overall kb-internal template called above. The fields are: aspect_ratio and color.-->
-        <xsl:call-template name="internal-video-fields"/>
+        <xsl:call-template name="internal-video-fields">
+          <xsl:with-param name="pbCore" select="$pbCore"/>
+        </xsl:call-template>
 
         <!-- This template also extracts internal fields only relevant for video. The rest of the extension extraction
              is handled in the kb-internal template called above. -->
-        <xsl:for-each select="//pbc:PBCoreDescriptionDocument/pbcoreExtension/extension">
+        <xsl:for-each select="$pbCore//pbcoreExtension/extension">
           <xsl:call-template name="video-extension-extractor"/>
         </xsl:for-each>
         </f:map>
@@ -162,11 +182,13 @@
         pbcExtensions: A parameter containing all PBCore Extensions for better retrieval of specific extensions during
                        the transformation. -->
   <xsl:template name="audio-transformation">
+    <xsl:param name="pbCore"/>
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
 
     <!-- As the generic template currently is the same as the AudioObject, then this template is called here-->
     <xsl:call-template name="generic-transformation">
+      <xsl:with-param name="pbCore" select="$pbCore"/>
       <xsl:with-param name="type" select="$type"/>
       <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
 
@@ -178,6 +200,7 @@
         pbcExtensions: A parameter containing all PBCore Extensions for better retrieval of specific extensions during
                        the transformation.-->
   <xsl:template name="generic-transformation">
+    <xsl:param name="pbCore"/>
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
 
@@ -192,8 +215,8 @@
         <!-- We cant assume that all records contain PBCore metadata as some OAI harvests might fail and not extract it.
              We do need to set origin anyway, therefore this choose-statement. -->
         <xsl:choose>
-          <xsl:when test="/XIP/Metadata/Content">
-            <xsl:for-each select="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument">
+          <xsl:when test="$pbCore != ''">
+            <xsl:for-each select="$pbCore">
               <xsl:call-template name="pbc-metadata">
                 <xsl:with-param name="type" select="$type"/>
                 <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
@@ -212,13 +235,16 @@
         </xsl:choose>
 
         <!-- Extract manifestation -->
-        <xsl:call-template name="extract-manifestation-preservica"/>
+        <xsl:call-template name="extract-manifestation-preservica">
+          <xsl:with-param name="pbCore" select="$pbCore"/>
+        </xsl:call-template>
 
         <!-- If type is MediaObject we don't create the internal map. -->
         <xsl:if test="$type != 'MediaObject'">
           <f:map key="kb:internal">
           <!-- Transforms values that does not fit directly into Schema.org into an internal map. -->
             <xsl:call-template name="kb-internal">
+              <xsl:with-param name="pbCore" select="$pbCore"/>
               <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
               <xsl:with-param name="type" select="$type"/>
             </xsl:call-template>
@@ -273,10 +299,18 @@
          Determine if title and original title are alike. Both fields should always be in metadata -->
     <!-- TODO: Do some validation of titles - check with metadata schema when they are set.    -->
     <xsl:variable name="title">
-      <xsl:value-of select="./pbcoreTitle[1]/title"/>
+      <xsl:for-each select="./pbcoreTitle">
+        <xsl:if test="./titleType = 'titel'">
+          <xsl:value-of select="./title"/>
+        </xsl:if>
+      </xsl:for-each>
     </xsl:variable>
     <xsl:variable name="original-title">
-      <xsl:value-of select="./pbcoreTitle[2]/title"/>
+      <xsl:for-each select="/pbcoreTitle">
+        <xsl:if test="./titleType = 'originaltitel'">
+          <xsl:value-of select="./title"/>
+        </xsl:if>
+      </xsl:for-each>
     </xsl:variable>
 
     <xsl:choose>
@@ -311,9 +345,12 @@
     </xsl:variable>
     <xsl:variable name="publisherGeneral">
       <xsl:for-each select="./pbcorePublisher">
-        <xsl:if test="./publisherRole ='channel_name'">
-          <xsl:value-of select="./publisher"/>
-        </xsl:if>
+        <xsl:choose>
+          <xsl:when test="./publisherRole ='channel_name'">
+            <xsl:value-of select="./publisher"/>
+          </xsl:when>
+          <xsl:otherwise></xsl:otherwise>
+        </xsl:choose>
       </xsl:for-each>
     </xsl:variable>
 
@@ -340,7 +377,7 @@
             <f:string key="broadcastDisplayName">
               <xsl:value-of select="$publisherSpecific"/>
             </f:string>
-            <xsl:if test="$publisherGeneral != ''"/>
+            <xsl:if test="f:exists($publisherGeneral) and not(f:empty($publisherGeneral)) and $publisherGeneral != ''">
             <f:string key="alternateName">
               <xsl:value-of select="$publisherGeneral"/>
             </f:string>
@@ -365,6 +402,7 @@
               </xsl:when>
               <xsl:otherwise></xsl:otherwise>
             </xsl:choose>
+            </xsl:if>
           </f:map>
         </xsl:if>
         <!-- TODO: Figure if it is possible to extract broadcaster in any meaningful way for the field 'broadcaster',
@@ -469,10 +507,16 @@
     <xsl:if test="./pbcoreInstantiation/pbcoreDateAvailable/dateAvailableStart and
                   ./pbcoreInstantiation/pbcoreDateAvailable/dateAvailableEnd">
       <xsl:variable name="start-time">
-        <xsl:value-of select="xs:dateTime(normalize-space(./pbcoreInstantiation/pbcoreDateAvailable/dateAvailableStart))"/>
+        <xsl:variable name="startTimeString">
+          <xsl:value-of select="./pbcoreInstantiation/pbcoreDateAvailable/dateAvailableStart"/>
+        </xsl:variable>
+        <xsl:value-of select="my:convertDatetimeToZulu($startTimeString)"/>
       </xsl:variable>
       <xsl:variable name="end-time">
-        <xsl:value-of select="xs:dateTime(normalize-space(./pbcoreInstantiation/pbcoreDateAvailable/dateAvailableEnd))"/>
+        <xsl:variable name="endTimeString">
+          <xsl:value-of select="./pbcoreInstantiation/pbcoreDateAvailable/dateAvailableEnd"/>
+        </xsl:variable>
+        <xsl:value-of select="my:convertDatetimeToZulu($endTimeString)"/>
       </xsl:variable>
       <f:string key="startTime">
         <xsl:value-of select="$start-time"/>
@@ -527,7 +571,9 @@
       <f:map>
         <f:string key="@type">PropertyValue</f:string>
         <f:string key="PropertyID">RecordID</f:string>
-        <f:string key="value"><xsl:value-of select="$recordID"/></f:string>
+        <f:string key="value">
+          <xsl:value-of select="$recordID"/>
+        </f:string>
       </f:map>
       <xsl:if test="//pbcoreIdentifier">
         <xsl:for-each select="./pbcoreIdentifier">
@@ -575,11 +621,13 @@
         </f:map>
       </xsl:if>
       <!-- Extract accession ref as schema.org identifier --> <!-- TODO: This could properly be done with loads of the identifiers in the kb:internal map.-->
-      <f:map>
-        <f:string key="@type">PropertyValue</f:string>
-        <f:string key="PropertyID">InternalAccessionRef</f:string>
-        <f:string key="value"><xsl:value-of select="/XIP/Metadata/Content/LegacyXIP/AccessionRef"/></f:string>
-      </f:map>
+      <xsl:if test="/XIP/Metadata/Content/LegacyXIP/AccessionRef">
+        <f:map>
+          <f:string key="@type">PropertyValue</f:string>
+          <f:string key="PropertyID">InternalAccessionRef</f:string>
+          <f:string key="value"><xsl:value-of select="/XIP/Metadata/Content/LegacyXIP/AccessionRef"/></f:string>
+        </f:map>
+      </xsl:if>
     </f:array>
 
     <!-- Extracts collection -->
@@ -595,14 +643,15 @@
 
   <!-- EXTRACT MANIFESTATION FROM METADATA.-->
   <xsl:template name="extract-manifestation-preservica">
+    <xsl:param name="pbCore"/>
     <xsl:if test="$manifestation != ''">
       <xsl:variable name="manifestationRef">
         <xsl:value-of select="$manifestation"/>
       </xsl:variable>
       <xsl:variable name="urlPrefix">
         <xsl:choose>
-          <xsl:when test="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatMediaType = 'Moving Image'">mp4:bart-access-copies-tv/</xsl:when>
-          <xsl:when test="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatMediaType = 'Sound'">mp3:bart-access-copies-radio/</xsl:when>
+          <xsl:when test="$pbCore/pbcoreInstantiation/formatMediaType = 'Moving Image'">mp4:bart-access-copies-tv/</xsl:when>
+          <xsl:when test="$pbCore/pbcoreInstantiation/formatMediaType = 'Sound'">mp3:bart-access-copies-radio/</xsl:when>
           <xsl:otherwise></xsl:otherwise>
         </xsl:choose>
       </xsl:variable>
@@ -636,6 +685,7 @@
        This kb:internal map was how we've handled internal values in the past, see line 109 in this file:
        https://github.com/kb-dk/ds-present/blob/spolorm-now-works/src/main/resources/xslt/mods2schemaorg.xsl -->
   <xsl:template name="kb-internal">
+    <xsl:param name="pbCore"/>
     <xsl:param name="pbcExtensions"/>
     <xsl:param name="type"/>
 
@@ -651,7 +701,7 @@
     </xsl:if>
 
     <!-- Extract subgenre if present -->
-    <xsl:for-each select="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreGenre/genre">
+    <xsl:for-each select="$pbCore/pbcoreGenre/genre">
       <xsl:if test="contains(., 'undergenre:') and substring-after(., 'undergenre:') != ''">
         <f:string key="kb:genre_sub">
           <xsl:value-of select="normalize-space(substring-after(., 'undergenre:'))"/>
@@ -660,10 +710,10 @@
     </xsl:for-each>
     <!-- Create boolean for surround-->
     <xsl:choose>
-      <xsl:when test="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatChannelConfiguration = 'surround'">
+      <xsl:when test="$pbCore/pbcoreInstantiation/formatChannelConfiguration = 'surround'">
         <f:boolean key="kb:surround_sound"><xsl:value-of select="true()"/></f:boolean>
       </xsl:when>
-      <xsl:when test="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatChannelConfiguration = 'ikke surround'">
+      <xsl:when test="$pbCore/pbcoreInstantiation/formatChannelConfiguration = 'ikke surround'">
         <f:boolean key="kb:surround_sound"><xsl:value-of select="false()"/></f:boolean>
       </xsl:when>
     </xsl:choose>
@@ -681,7 +731,7 @@
       </xsl:when>
     </xsl:choose>
     <!-- Extract format identifiers -->
-    <xsl:for-each select="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreFormatID">
+    <xsl:for-each select="$pbCore/pbcoreInstantiation/pbcoreFormatID">
       <xsl:choose>
         <xsl:when test="formatIdentifierSource = 'ritzau'">
           <f:string key="kb:format_identifier_ritzau">
@@ -711,7 +761,7 @@
     </xsl:choose>
     <!-- Extracts multiple extensions to the internal KB map. These extensions can contain many different values.
          Some have external value, while others primarily are for internal usage.-->
-    <xsl:for-each select="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreExtension/extension">
+    <xsl:for-each select="$pbCore/pbcoreExtension/extension">
       <xsl:call-template name="extension-extractor">
       <xsl:with-param name="type" select="$type"/>
       </xsl:call-template>
@@ -738,16 +788,17 @@
   <!-- Transforms internal fields, that are only present for tv/video metadata. These fields are:
        aspect_ratio and color.-->
   <xsl:template name="internal-video-fields">
+    <xsl:param name="pbCore"/>
     <!-- Extract aspect ratio-->
-    <xsl:if test="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatAspectRatio">
+    <xsl:if test="$pbCore/pbcoreInstantiation/formatAspectRatio">
       <f:string key="kb:aspect_ratio">
-        <xsl:value-of select="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatAspectRatio"/>
+        <xsl:value-of select="$pbCore/pbcoreInstantiation/formatAspectRatio"/>
       </f:string>
     </xsl:if>
 
     <!-- Create boolean for color for tv resources-->
     <xsl:choose>
-      <xsl:when test="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbcoreInstantiation/formatColors = 'farve'">
+      <xsl:when test="$pbCore/pbcoreInstantiation/formatColors = 'farve'">
         <f:boolean key="kb:color"><xsl:value-of select="true()"/></f:boolean>
       </xsl:when>
       <xsl:otherwise>
@@ -955,8 +1006,20 @@
         </f:string>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
 
+        <!-- Template to strip namespace from elements -->
+  <xsl:template match="*" mode="strip-ns">
+  <xsl:element name="{local-name()}">
+    <xsl:apply-templates select="@*|node()" mode="strip-ns"/>
+  </xsl:element>
+  </xsl:template>
 
+          <!-- Template to strip namespace from attributes -->
+  <xsl:template match="@*" mode="strip-ns">
+  <xsl:attribute name="{local-name()}">
+    <xsl:value-of select="."/>
+  </xsl:attribute>
   </xsl:template>
 
 </xsl:transform>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -444,6 +444,7 @@
           </xsl:if>
         </xsl:for-each>
 
+
         <xsl:for-each select="./pbcoreExtension/extension">
           <xsl:choose>
             <xsl:when test="f:contains(substring-after(., 'episodenr:'), ':')">
@@ -466,11 +467,10 @@
                     <xsl:value-of select="substring-after($episodeInfo, ':')"/>
                   </f:number>
                 </f:map>
-
             </xsl:when>
             <xsl:otherwise>
               <!-- Extract metadata from PBC extensions related to episodes -->
-              <xsl:for-each select="./pbcoreExtension/extension">
+              <xsl:for-each select=".">
                 <!-- Extract episode number if present.
                      Checks for 'episodenr' in PBC extension and checks that there is a substring after the key.-->
                 <xsl:if test="f:contains(., 'episodenr:') and f:string-length(substring-after(., 'episodenr:')) > 0">
@@ -481,7 +481,7 @@
               </xsl:for-each>
 
               <!-- Extract metadata from PBC extensions related to season length. -->
-              <xsl:for-each select="./pbcoreExtension/extension">
+              <xsl:for-each select=".">
                 <!-- Extract number of episodes in a season, if present.
                      Checks for 'antalepisoder' in PBC extension and checks that the value is not an empty string or 0.
                      Create partOfSeason field, if any metadata is present. -->

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -34,6 +34,13 @@
   <xsl:param name="conditionsOfAccess"/>
   <xsl:include href="xslt/utils.xsl"/>
 
+  <xsl:variable name="InternalAccessionRef">
+    <xsl:value-of select="/XIP/Metadata/Content/LegacyXIP/AccessionRef"/>
+  </xsl:variable>
+
+  <xsl:variable name="pidHandles">
+    <xsl:value-of select="distinct-values(//pidhandle:pidhandle/handle)"/>
+  </xsl:variable>
 
   <!-- MAIN TEMPLATE. This template delegates, which fields are to be created for each schema.org object.
        Currently, the template handles transformations from Preservica records to SCHEMA.ORG VideoObjects and AudioObjects. -->
@@ -44,10 +51,6 @@
             <xsl:apply-templates mode="strip-ns"/>
           </xsl:for-each>
           <xsl:value-of select="."/>
-    </xsl:variable>
-
-    <xsl:variable name="pidHandles">
-      <xsl:value-of select="distinct-values(//pidhandle:pidhandle/handle)"/>
     </xsl:variable>
 
     <!-- Determine the type of schema.org object in hand.-->
@@ -75,7 +78,6 @@
             <xsl:with-param name="pbCore" select="$pbCore"/>
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-            <xsl:with-param name="pidHandles" select="$pidHandles"/>
           </xsl:call-template>
         </xsl:when>
         <xsl:when test="$type = 'AudioObject'">
@@ -83,7 +85,6 @@
             <xsl:with-param name="pbCore" select="$pbCore"/>
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-            <xsl:with-param name="pidHandles" select="$pidHandles"/>
           </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>
@@ -91,7 +92,6 @@
             <xsl:with-param name="pbCore" select="$pbCore"/>
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-            <xsl:with-param name="pidHandles" select="$pidHandles"/>
           </xsl:call-template>
         </xsl:otherwise>
       </xsl:choose>
@@ -108,7 +108,6 @@
     <xsl:param name="pbCore"/>
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
-    <xsl:param name="pidHandles"/>
 
     <f:map>
       <!-- Creates the first three fields for docs. -->
@@ -122,7 +121,6 @@
           <xsl:call-template name="pbc-metadata">
             <xsl:with-param name="type" select="$type"/>
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-            <xsl:with-param name="pidHandles" select="$pidHandles"/>
           </xsl:call-template>
 
           <!-- This is the only field directly present in pbc:PBCoreDescriptionDocument, which is only used for video
@@ -194,14 +192,12 @@
     <xsl:param name="pbCore"/>
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
-    <xsl:param name="pidHandles"/>
 
     <!-- As the generic template currently is the same as the AudioObject, then this template is called here-->
     <xsl:call-template name="generic-transformation">
       <xsl:with-param name="pbCore" select="$pbCore"/>
       <xsl:with-param name="type" select="$type"/>
       <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-      <xsl:with-param name="pidHandles" select="$pidHandles"/>
     </xsl:call-template>
   </xsl:template>
 
@@ -213,7 +209,6 @@
     <xsl:param name="pbCore"/>
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
-    <xsl:param name="pidHandles"/>
 
     <f:map>
       <!-- Creates the first three fields for docs. -->
@@ -231,7 +226,6 @@
               <xsl:call-template name="pbc-metadata">
                 <xsl:with-param name="type" select="$type"/>
                 <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
-                <xsl:with-param name="pidHandles" select="$pidHandles"/>
               </xsl:call-template>
             </xsl:for-each>
           </xsl:when>
@@ -306,7 +300,6 @@
   <xsl:template name="pbc-metadata">
     <xsl:param name="type"/>
     <xsl:param name="pbcExtensions"/>
-    <xsl:param name="pidHandles"/>
     <!-- TODO: Investigate relation between titel and originaltitel. Some logic related to metadata delivery type exists. -->
     <!-- Create fields headline and alternativeHeadline if needed.
          Determine if title and original title are alike. Both fields should always be in metadata -->
@@ -658,11 +651,11 @@
         </f:map>
       </xsl:if>
       <!-- Extract accession ref as schema.org identifier --> <!-- TODO: This could properly be done with loads of the identifiers in the kb:internal map.-->
-      <xsl:if test="/XIP/Metadata/Content/LegacyXIP/AccessionRef">
+      <xsl:if test="$InternalAccessionRef != ''">
         <f:map>
           <f:string key="@type">PropertyValue</f:string>
           <f:string key="PropertyID">InternalAccessionRef</f:string>
-          <f:string key="value"><xsl:value-of select="/XIP/Metadata/Content/LegacyXIP/AccessionRef"/></f:string>
+          <f:string key="value"><xsl:value-of select="$InternalAccessionRef"/></f:string>
         </f:map>
       </xsl:if>
     </f:array>

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -16,6 +16,48 @@
   </xsl:param>
 
   <!-- FUNCTIONS -->
+
+  <!-- Convert a datetime from a given timezone to UTC time.-->
+  <xsl:function name="my:convertDatetimeToZulu">
+    <xsl:param name="datetime"/>
+
+    <xsl:variable name="wellFormatedDatetime">
+      <xsl:value-of select="my:getDatetimeWithValidTimezone($datetime)"/>
+    </xsl:variable>
+
+    <xsl:value-of select="f:adjust-dateTime-to-timezone($wellFormatedDatetime, xs:dayTimeDuration('PT0H'))"/>
+
+  </xsl:function>
+
+  <!-- Validate that the timezone in datetimes are present as +HH:MM. If not, then they are converted. -->
+  <xsl:function name="my:getDatetimeWithValidTimezone">
+    <xsl:param name="datetimeString"/>
+    <xsl:choose>
+      <xsl:when test="f:ends-with($datetimeString, 'Z')">
+        <xsl:value-of select="$datetimeString"/>
+      </xsl:when>
+      <xsl:when test="f:string-length(substring-after($datetimeString, '+')) != 5">
+        <xsl:variable name="datetimeNoTimezone">
+          <xsl:value-of select="substring-before($datetimeString, '+')"/>
+        </xsl:variable>
+        <xsl:variable name="timezoneInfo">
+          <xsl:value-of select="substring-after($datetimeString, '+')"/>
+        </xsl:variable>
+        <xsl:variable name="timezoneHour">
+          <xsl:value-of select="substring($timezoneInfo, 1, 2)"/>
+        </xsl:variable>
+        <xsl:variable name="timezoneMinute">
+          <xsl:value-of select="substring($timezoneInfo, 3,2)"/>
+        </xsl:variable>
+        <xsl:value-of select="concat($datetimeNoTimezone, '+', $timezoneHour, ':', $timezoneMinute)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="xs:dateTime(normalize-space($datetimeString))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+
+
   <!-- Get milliseconds between two datetimes. -->
   <xsl:function name="my:toMilliseconds" as="xs:integer">
     <xsl:param name="startDate" as="xs:dateTime"/>

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -17,7 +17,11 @@
 
   <!-- FUNCTIONS -->
 
-  <!-- Convert a datetime from a given timezone to UTC time.-->
+  <!-- Convert a datetime from a given timezone to UTC time.
+        Datetimes harvested from Preservica can be both UTC and UTC+1. Schema.org and solr datetimes needs to
+        be in UTC time, therefore this conversion is needed.
+
+        This function also validates, that the datetime object is properly formatted.-->
   <xsl:function name="my:convertDatetimeToZulu">
     <xsl:param name="datetime"/>
 
@@ -26,10 +30,11 @@
     </xsl:variable>
 
     <xsl:value-of select="f:adjust-dateTime-to-timezone($wellFormatedDatetime, xs:dayTimeDuration('PT0H'))"/>
-
   </xsl:function>
 
-  <!-- Validate that the timezone in datetimes are present as +HH:MM. If not, then they are converted. -->
+  <!-- Validate that the timezone in datetimes are present as +HH:MM. If not, then they are converted.
+        XSLT requires timezones to contain timezones as +HH:MM. However, DOMS records contains the timezone as +HHMM.
+        This method converts the DOMS format to the format, which XSLT understands.-->
   <xsl:function name="my:getDatetimeWithValidTimezone">
     <xsl:param name="datetimeString"/>
     <xsl:choose>

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -37,6 +37,8 @@ public class TestFiles {
     public static final String PVICA_RECORD_53ce4817 = "internal_test_files/preservica7/53ce4817-56ce-4e41-bac4-ba2dda938199.xml";
 
     public static final String PVICA_RECORD_2b462c63 = "internal_test_files/preservica7/2b462c63-8bb8-477a-89d9-70675c22c163.xml";
+    public static final String PVICA_DOMS_MIG_bd612d1e = "internal_test_files/domsMigrated/bd612d1e-b90b-48f7-87ce-898da240950b-20240612T105945.xml";
+    public static final String PVICA_DOMS_MIG_eaea0362 = "internal_test_files/domsMigrated/eaea0362-bbad-43ec-8d5e-07df6957923b-20240612T112310.xml";
 
     // From preservica 6, not in preservica 7 stage
     public static final String PVICA6_RECORD_00a9e71c = "internal_test_files/preservica6/00a9e71c-1264-4e57-9238-b38ec5672fb2.xml";

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -165,9 +165,9 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     void testEmptyEpisodeName() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_9d9785a8);
-        Assertions.assertTrue(transformedJSON.contains("\"encodesCreativeWork\":{" +
-                "\"@type\":\"TVEpisode\"," +
-                "\"episodeNumber\":4"));
+        prettyPrintJson(transformedJSON);
+        Assertions.assertFalse(transformedJSON.contains("\"encodesCreativeWork\":{" +
+                "\"@type\":\"TVEpisode\",\"name\":\"\""));
     }
 
     @Test

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -15,6 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static dk.kb.present.TestUtil.prettyPrintJson;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -98,6 +100,8 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     void testIdentifiers() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_e683b0b8);
+
+        prettyPrintJson(transformedJSON);
 
         Assertions.assertTrue(transformedJSON.contains("\"identifier\":[{\"@type\":\"PropertyValue\",\"PropertyID\":\"Origin\",\"value\":\"ds.test\"}")
                 && transformedJSON.contains("{\"@type\":\"PropertyValue\",\"PropertyID\":\"ritzauId\",\"value\":\"926e730f-b3e6-44b9-aea7-a6ea27ec98ae\"}")
@@ -193,6 +197,7 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     void testAbstractCreation() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_a8afb121);
+        prettyPrintJson(transformedJSON);
         Assertions.assertTrue(transformedJSON.contains("\"abstract\":\"Eng. krimiserie\""));
     }
 
@@ -352,6 +357,31 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     void testDateInjection() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_e683b0b8);
         Assertions.assertTrue(transformedJSON.contains("\"kb:storage_mTime\":"));
+    }
+
+    @Test
+    public void testTransformationOfDomsRecord() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_bd612d1e);
+        assertTrue(transformedJSON.contains("\"@type\":\"VideoObject\""));
+        prettyPrintJson(transformedJSON);
+    }
+
+    @Test
+    public void testDomsBroadcastAlternateName() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_bd612d1e);
+        assertFalse(transformedJSON.contains("\"broadcastDisplayName\":\"Kanal 4\",\"alternateName\":\"\""));
+    }
+
+    @Test
+    public void testDomsNoAccessionRef() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_bd612d1e);
+        assertFalse(transformedJSON.contains("\"PropertyID\":\"InternalAccessionRef\",\"value\":\"\""));
+    }
+
+    @Test public void testDoms() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_eaea0362);
+        prettyPrintJson(transformedJSON);
+
     }
 
 

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -363,7 +363,6 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     public void testTransformationOfDomsRecord() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_bd612d1e);
         assertTrue(transformedJSON.contains("\"@type\":\"VideoObject\""));
-        prettyPrintJson(transformedJSON);
     }
 
     @Test
@@ -378,10 +377,10 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
         assertFalse(transformedJSON.contains("\"PropertyID\":\"InternalAccessionRef\",\"value\":\"\""));
     }
 
-    @Test public void testDoms() throws IOException {
+    @Test
+    public void testDomsEpisodeNumbers() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_eaea0362);
-        prettyPrintJson(transformedJSON);
-
+        assertTrue(transformedJSON.contains("\"episodeNumber\":8,") && transformedJSON.contains("\"numberOfEpisodes\":24"));
     }
 
 


### PR DESCRIPTION
Makes the transformations handle basic differences between doms and preservica data. This PR targets and fixes the following:
* DOMS records contain namespace prefixes on each XML element, which preservica native records doesn't. When processing PBCore child elements, the prefix is now stripped from the record
* Datetime objects can be delivered in UTC and UTC+1 timezones from the OAI-PMH harvest. These are now converted to UTC only.

The changes have been tested locally on 5k DOMS records from preservica devel that I've succesfully indexed in a local solr instance. We should wait for the updated preservica stage test before running a new ingest and index on our shared devel.

NB: I've added a JIRA issue on creating a field for recognizing doms records and prettifying the content of the transformed records. 

 