### PR TITLE
Move facet field creation to XSLT to handle upper casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Changed how the solr field creator_affiliation_facet is constructed.
 
 ## [1.9.3](https://github.com/kb-dk/ds-present/releases/tag/ds-present-1.9.3) 2024-07-03
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <license.name>Apache License, Version 2.0</license.name>
         <license.url>https://www.apache.org/licenses/LICENSE-2.0.txt</license.url>
         <timestamp>${maven.build.timestamp}</timestamp>
-        <solr.config.version>1.6.8</solr.config.version> <!-- Semantic versioning of solr config and schema -->
+        <solr.config.version>1.6.9</solr.config.version> <!-- Semantic versioning of solr config and schema -->
 
         <project.package>dk.kb.present</project.package>
     </properties>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -171,8 +171,15 @@
 
           <xsl:if test="not(f:empty(my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn',  'broadcastDisplayName'))) and
                         my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn',  'broadcastDisplayName') != ''">
-            <f:string key="creator_affiliation">
+
+            <xsl:variable name="creatorAffiliation">
               <xsl:value-of select="my:getNestedMapValue3Levels($schemaorg-xml, 'publication', 'publishedOn',  'broadcastDisplayName')"/>
+            </xsl:variable>
+            <f:string key="creator_affiliation">
+              <xsl:value-of select="$creatorAffiliation"/>
+            </f:string>
+            <f:string key="creator_affiliation_facet">
+              <xsl:value-of select="upper-case($creatorAffiliation)"/>
             </f:string>
           </xsl:if>
 

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -35,8 +35,9 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 1.6.6: Add temporal_start_month field and make temporal_start_year and temporal_star_month fq fields.
 1.6.7: Add temporal_start_hour_da field.
 1.6.8: Add creator_affiliation_facet field.
+1.6.9: Change facet field type to uppercase all values.
   -->
-  <field name="_ds_1.6.8_" type="string" indexed="false" stored="false"/>
+  <field name="_ds_1.6.9_" type="string" indexed="false" stored="false"/>
   <uniqueKey>id</uniqueKey>
 
    <!-- START FIELDS  -->
@@ -1109,7 +1110,6 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     A query for Hans Christian Andersen would produce a higher ranking than H.C Andersen.?>
   </copyField>
 
-  <copyField source="creator_affiliation" dest="creator_affiliation_facet"/>
   <copyField source="creator_name" dest="freetext"/>
   <copyField source="creator_full_name" dest="freetext"/>
   <copyField source="creator_given_name" dest="freetext"/>


### PR DESCRIPTION
Moved creation of facet field to XSLT instead of making use of copy field. This is done like this to keep the facet field type as optimized as possible. docValues cant be used on a solr.TextField whcich would be needed to handle the casing in the schema.