### PR TITLE
Dra 988 switch to kaltura entryid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed how the solr field creator_affiliation_facet is constructed.
 - Elevated some fields in XSLTs from the kb:internal map to proper schema.org values and non internal solr fields.
-- Bumped solr-config to v. 1.6.10
+- Bumped solr-config to v. 1.6.12
 - Updated XSLTs to handle edge cases, where multiple 'hovedgenre' are present in data. If multiple are present, the shortest string is used as genre in the schema.org JSON.
+- Introduce kaltura_id in solr documents and solr schema
+- Introduce KalturaID as identifier in schema.org JSON
+- Updated solr tests, to use Preservica 7 setup.
+- Update logging in HoldbackDatePicker class making it clearer, that origins in a holdback context comes from TVMeter data.
+
+### Removed
+- Removed all traces of streaming_url and contentUrl for video and audio records.
 
 ## [1.9.3](https://github.com/kb-dk/ds-present/releases/tag/ds-present-1.9.3) 2024-07-03
 ### Changed

--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -42,9 +42,6 @@ openapi:
 oldimageserver:
   url: "http://kb-images.kb.dk"
 
-streamingserver:
-  url: "http://example.com/streaming/"
-
 # Used for verifying access to metadata https://github.com/kb-dk/ds-license
 # If allowall is set to true (default is false), all access is granted. Use only for devel + stage
 licensemodule:

--- a/conf/ds-present-environment.yaml.SAMPLE
+++ b/conf/ds-present-environment.yaml.SAMPLE
@@ -42,11 +42,6 @@ oldimageserver:
   url: "http://kb-images.kb.dk"
 
 
-# In generel we are moving towards kaltura streaming instead of the local wowza installation.
-streamingserver:
-  # Wowza has a non-obvious URL, the /vod/_definst_/ part of the URL is important here.
-  url: "https://<wowzastreamingserver>.dk:1947/vod/_definst_/"
-
 # Used for verifying access to metadata https://github.com/kb-dk/ds-license
 # If allowall is set to true (default is false), all access is granted. Use only for devel + stage
 licensemodule:

--- a/conf/ds-present-kb-origins.yaml
+++ b/conf/ds-present-kb-origins.yaml
@@ -20,7 +20,6 @@ pvicaviews: &PRESERVICA_VIEWS
             stylesheet: 'xslt/preservica2schemaorg.xsl'
             injections:
               #- imageserver: ${path:imageservers[default=true].url}
-              - streamingserver: ${path:streamingserver.url}
               - old_imageserver: ${path:oldimageserver.url}
   - SolrJSON:
       mime: 'application/json'
@@ -30,7 +29,6 @@ pvicaviews: &PRESERVICA_VIEWS
             stylesheet: 'xslt/preservica2schemaorg.xsl'
             injections:
               #- imageserver: ${path:imageservers[default=true].url}
-              - streamingserver: ${path:streamingserver.url}
               - old_imageserver: ${path:oldimageserver.url}
         - xsltsolr:
             stylesheet: 'xslt/schemaorg2solr.xsl'

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <license.name>Apache License, Version 2.0</license.name>
         <license.url>https://www.apache.org/licenses/LICENSE-2.0.txt</license.url>
         <timestamp>${maven.build.timestamp}</timestamp>
-        <solr.config.version>1.6.10</solr.config.version> <!-- Semantic versioning of solr config and schema -->
+        <solr.config.version>1.6.12</solr.config.version> <!-- Semantic versioning of solr config and schema -->
 
         <project.package>dk.kb.present</project.package>
     </properties>

--- a/src/main/java/dk/kb/present/View.java
+++ b/src/main/java/dk/kb/present/View.java
@@ -171,6 +171,11 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
         metadata.put("mTimeHuman", getSolrDate(record.getmTimeHuman()));
         //TODO: Update placeholder when actual value is in place
         metadata.put("conditionsOfAccess", "TODO: placeholderCondition");
+
+        if (record.getKalturaId() != null){
+            metadata.put("kalturaID", record.getKalturaId());
+        }
+
         return metadata;
     }
 

--- a/src/main/java/dk/kb/present/holdback/HoldbackDatePicker.java
+++ b/src/main/java/dk/kb/present/holdback/HoldbackDatePicker.java
@@ -93,7 +93,8 @@ public class HoldbackDatePicker {
     public HoldbackObject getHoldbackDateForRecord(DsRecordDto record) throws IOException {
         HoldbackObject result = new HoldbackObject();
         if (record.getOrigin() == null){
-            log.error("Origin was null. Holdback cannot be calculated for records that are not from origins 'ds.radio' or 'ds.tv'. Returning a result object without values.");
+            log.error("TVMeter origin was null. Holdback cannot be calculated for records that are not from origins 'ds.radio' or 'ds.tv'. Returning a result object without " +
+                    "values.");
             result.setHoldbackPurposeName("");
             result.setHoldbackDate("");
             return result;

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -143,11 +143,6 @@
           </xsl:if>
         </xsl:for-each>
 
-        <!-- Extract manifestation -->
-        <xsl:call-template name="extract-manifestation-preservica">
-          <xsl:with-param name="pbCore" select="$pbCore"/>
-        </xsl:call-template>
-
         <!-- Create the kb:internal map. This map contains all metadata, that are not represented in schema.org, but were
              available from the preservica records.-->
         <f:map key="kb:internal">
@@ -250,11 +245,6 @@
             </f:array>
           </xsl:otherwise>
         </xsl:choose>
-
-        <!-- Extract manifestation -->
-        <xsl:call-template name="extract-manifestation-preservica">
-          <xsl:with-param name="pbCore" select="$pbCore"/>
-        </xsl:call-template>
 
         <!-- If type is MediaObject we don't create the internal map. -->
         <xsl:if test="$type != 'MediaObject'">
@@ -762,44 +752,6 @@
           <f:string key="name"><xsl:value-of select="//pbcoreInstantiation/formatLocation"/></f:string>
         </f:map>
       </f:array>
-    </xsl:if>
-  </xsl:template>
-
-  <!-- EXTRACT MANIFESTATION FROM METADATA.-->
-  <xsl:template name="extract-manifestation-preservica">
-    <xsl:param name="pbCore"/>
-    <xsl:if test="$manifestation != ''">
-      <xsl:variable name="manifestationRef">
-        <xsl:value-of select="$manifestation"/>
-      </xsl:variable>
-      <xsl:variable name="urlPrefix">
-        <xsl:choose>
-          <xsl:when test="$pbCore/pbcoreInstantiation/formatMediaType = 'Moving Image'">mp4:bart-access-copies-tv/</xsl:when>
-          <xsl:when test="$pbCore/pbcoreInstantiation/formatMediaType = 'Sound'">mp3:bart-access-copies-radio/</xsl:when>
-          <xsl:otherwise></xsl:otherwise>
-        </xsl:choose>
-      </xsl:variable>
-      <xsl:variable name="path">
-        <xsl:variable name="path_level1">
-          <xsl:value-of select="concat(substring($manifestationRef,1,2), '/')"/>
-        </xsl:variable>
-        <xsl:variable name="path_level2">
-          <xsl:value-of select="concat(substring($manifestationRef,3,2), '/')"/>
-        </xsl:variable>
-        <xsl:variable name="path_level3">
-          <xsl:value-of select="concat(substring($manifestationRef,5,2), '/')"/>
-        </xsl:variable>
-        <xsl:value-of select="concat($path_level1, $path_level2, $path_level3)"/>
-      </xsl:variable>
-      <xsl:variable name="streamingUrl">
-        <xsl:value-of select="concat($streamingserver, $urlPrefix,
-                                         $path, $manifestationRef,
-                                         '/playlist.m3u8')"/>
-      </xsl:variable>
-      <f:string key="contentUrl">
-        <!-- TODO: Add full url to content when possible-->
-        <xsl:value-of select="$streamingUrl"/>
-      </f:string>
     </xsl:if>
   </xsl:template>
 

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -19,8 +19,6 @@
   <xsl:output method="text"/>
 
   <!--INJECTIONS -->
-  <!-- Streraming server where preservica manifestations can be streamed from.-->
-  <xsl:param name="streamingserver"/>
   <!-- Origin for transformed record.-->
   <xsl:param name="origin"/>
   <!-- ID of the record. -->

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -25,6 +25,8 @@
   <xsl:param name="origin"/>
   <!-- ID of the record. -->
   <xsl:param name="recordID"/>
+  <!-- ID created by kaltura. This ID is the ID of the stream containing the newest presentation copy for this resource. Used for video and audio objects.-->
+  <xsl:param name="kalturaID"/>
   <!-- XML containing the presentation manifestation for the record in hand-->
   <xsl:param name="manifestation"/>
   <!-- Representation of when the record was last modified in the backing ds-storage. The value is a long representing time
@@ -693,6 +695,14 @@
           <xsl:value-of select="$recordID"/>
         </f:string>
       </f:map>
+      <xsl:if test="$kalturaID != ''">
+        <f:map>
+          <f:string key="@type">PropertyValue</f:string>
+          <f:string key="PropertyID">KalturaID</f:string>
+          <f:string key="value"><xsl:value-of select="$kalturaID"/></f:string>
+          <f:string key="description">Kaltura ID of the access copy. Created internally by Kaltura.</f:string>
+        </f:map>
+      </xsl:if>
       <xsl:if test="//pbcoreIdentifier">
         <xsl:for-each select="./pbcoreIdentifier">
           <xsl:choose>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -529,6 +529,12 @@
 
   <!-- EXTRACT IDENTIFIERS FROM THE SCHEMA.ORG ARRAY OF IDENTIFIERS. -->
   <xsl:template name="identifierExtractor">
+    <!-- Finds KalturaID -->
+    <xsl:if test="map:get(., 'PropertyID') = 'KalturaID'">
+      <f:string key="kaltura_id">
+        <xsl:value-of select="map:get(., 'value')"/>
+      </f:string>
+    </xsl:if>
     <!-- Finds origin -->
     <xsl:if test="map:get(., 'PropertyID') = 'Origin'">
       <f:string key="origin">

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -245,13 +245,7 @@
 
       </xsl:if>
 
-      <!-- Extract content url-->
-      <!-- TODO: What about resourceID?-->
-      <xsl:if test="$schemaorg-xml('contentUrl')">
-        <f:string key="streaming_url">
-          <xsl:value-of select="$schemaorg-xml('contentUrl')"/>
-        </f:string>
-      </xsl:if>
+      <!-- Extract file_id -->
       <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:file_id') != ''">
         <f:string key="file_id">
           <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:file_id') "/>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -38,8 +38,9 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 1.6.9: Change facet field type to uppercase all values.
 1.6.10: Add fields for holdback management
 1.6.11: Rename schema fields following feedback from metadata review.
+1.6.12: Add kaltura_id to schema.
   -->
-  <field name="_ds_1.6.10_" type="string" indexed="false" stored="false"/>
+  <field name="_ds_1.6.12_" type="string" indexed="false" stored="false"/>
   <uniqueKey>id</uniqueKey>
 
    <!-- START FIELDS  -->
@@ -634,6 +635,11 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <field name="streaming_url" type="string">
     <?description An URL, where the resource can be streamed.?>
     <?example     www.example.com/streaming/bart-access-copies-tv/00/00/00/000000e1-0000-462a-a2b4-7488244fcca7/playlist.m3u8"?>
+  </field>
+
+  <field name="kaltura_id" type="string">
+    <?description An ID created by kaltura representing the access copy available et kaltura for the given record.?>
+    <?example 0_00abcdef?>
   </field>
 
   <field name="file_id" type="string">

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -38,7 +38,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 1.6.9: Change facet field type to uppercase all values.
 1.6.10: Add fields for holdback management
 1.6.11: Rename schema fields following feedback from metadata review.
-1.6.12: Add kaltura_id to schema.
+1.6.12: Add kaltura_id to schema and remove old wowza streaming url.
   -->
   <field name="_ds_1.6.12_" type="string" indexed="false" stored="false"/>
   <uniqueKey>id</uniqueKey>
@@ -630,11 +630,6 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?description A persistent identifier (PID) is a long lasting reference to the resource. These identifiers can be
                   resolved at http://hdl.handle.net/?>
     <?example     109.1.4/3945e2d1-83a2-40d8-af1c-30f7b3b94390?>
-  </field>
-
-  <field name="streaming_url" type="string">
-    <?description An URL, where the resource can be streamed.?>
-    <?example     www.example.com/streaming/bart-access-copies-tv/00/00/00/000000e1-0000-462a-a2b4-7488244fcca7/playlist.m3u8"?>
   </field>
 
   <field name="kaltura_id" type="string">

--- a/src/main/webapp/mappings_radiotv.html
+++ b/src/main/webapp/mappings_radiotv.html
@@ -116,16 +116,12 @@ metadata are connected in the following way:
     </tr>
     <tr>
         <td>xip:Manifestation/<br/>ComponentManifestation/<br/>FileRef</td>
-        <td>resource_id OR streaming_url</td>
-        <td>contentUrl</td>
-        <td>This id is not directly available in the DeliverableUnit from preservica, but originates from a
+        <td>file_id</td>
+        <td>kb:internal/file_id</td>
+        <td>This id is not directly available in the InformationObject from preservica, but originates from a
             manifestation.
-            It is the ID of a presentation manifestation related to the DeliverableUnit. The connection between them is
-            created in the backing DS-storage. Then the XSLT looks for the child and accesses it through its URI.
-            Furthermore, there is a difference between the solr resource_id and the schema.org contentUrl. The first is
-            just the ID, while the second is a full URL, to where the content can be accessed. To access the full
-            streaming
-            url in the solr index you have to use the field streaming_url.
+            It is the ID of a presentation manifestation related to the InformationObject. The connection between them is
+            created in the backing DS-storage. Then the XSLT injects the ID into the transformation.
         </td>
     </tr>
     <tr>

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -118,7 +118,7 @@ public class TestUtil {
 				"manifestation", "8946d31d-a81c-447f-b84d-ff80644353d2.mp4",
 				"holdbackDate", "2026-01-17T09:34:42Z",
 				"holdbackPurposeName","Aktualitet og debat",
-				"kalturaId", "aVeryTrueKalturaID");
+				"kalturaID", "aVeryTrueKalturaID");
 		String schemaOrgJson = TestUtil.getTransformedWithAccessFieldsAdded(schemaOrgTransformer, record, injections);
 		//prettyPrintJson(schemaOrgJson);
 

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -109,28 +109,6 @@ public class TestUtil {
 	 * Transforms the inputted XML with the given transformer to schema.org compliant JSON, then transforms the
 	 * schema.org JSON to solr documents.
 	 * @param schemaOrgTransformer used to transform from origin specific format to general schema.org json.
-	 * @return a solr document ready for indexing, created from the schema.org representation of the inputted XML.
-	 */
-	@Deprecated
-	public static String getTransformedToSolrJsonThroughSchemaJson(String schemaOrgTransformer, String record) throws IOException {
-		Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/",
-				"streamingserver" ,"https://www.example.com/streamingserver/",
-				"holdbackDate", "2026-01-17T09:34:42Z",
-				"holdbackPurposeName","Aktualitet og debat");
-		String schemaOrgJson = TestUtil.getTransformedWithAccessFieldsAdded(schemaOrgTransformer, record, injections);
-		//prettyPrintJson(schemaOrgJson);
-
-		String placeholderXml = "placeholder.xml";
-		Map<String, String> mapOfJson = Map.of("schemaorgjson", schemaOrgJson);
-		String solrJson = TestUtil.getTransformedWithAccessFieldsAdded(SCHEMA2SOLR, placeholderXml, mapOfJson);
-		//prettyPrintJson(solrJson);
-		return solrJson;
-	}
-
-	/**
-	 * Transforms the inputted XML with the given transformer to schema.org compliant JSON, then transforms the
-	 * schema.org JSON to solr documents.
-	 * @param schemaOrgTransformer used to transform from origin specific format to general schema.org json.
 	 * @param record the record to transform.
 	 * @return a solr document ready for indexing, created from the schema.org representation of the inputted XML.
 	 */
@@ -139,7 +117,8 @@ public class TestUtil {
 				"streamingserver" ,"https://www.example.com/streamingserver/",
 				"manifestation", "8946d31d-a81c-447f-b84d-ff80644353d2.mp4",
 				"holdbackDate", "2026-01-17T09:34:42Z",
-				"holdbackPurposeName","Aktualitet og debat");
+				"holdbackPurposeName","Aktualitet og debat",
+				"kalturaId", "aVeryTrueKalturaID");
 		String schemaOrgJson = TestUtil.getTransformedWithAccessFieldsAdded(schemaOrgTransformer, record, injections);
 		//prettyPrintJson(schemaOrgJson);
 

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -60,7 +60,6 @@ public class TestUtil {
 		HashMap<String, String> metadata = XsltCopyrightMapper.applyXsltCopyrightTransformer(xml);
 
 		metadata.put("recordID", "ds.test:" + Path.of(xmlResource).getFileName().toString());
-		metadata.put("streamingserver", "www.example.com/streaming/");
 		metadata.put("origin", "ds.test");
 		metadata.put("conditionsOfAccess", "placeholderCondition");
 		metadata.put("mTime", "1701261949625000");
@@ -77,7 +76,6 @@ public class TestUtil {
 		String childData = "8946d31d-a81c-447f-b84d-ff80644353d2.mp4";
 
 		metadata.put("recordID", "ds.test:" + Path.of(xmlResource).getFileName().toString());
-		metadata.put("streamingserver", "www.example.com/streaming/");
 		metadata.put("origin", "ds.test");
 		metadata.put("manifestation", childData);
 		metadata.put("conditionsOfAccess", "placeholderCondition");
@@ -99,7 +97,6 @@ public class TestUtil {
 		HashMap<String, String> metadata = XsltCopyrightMapper.applyXsltCopyrightTransformer(xml);
 
         metadata.put("recordID", "ds.test:" + Path.of(xmlResource).getFileName().toString());
-		metadata.put("streamingserver", "www.example.com/streaming/");
 		metadata.put("origin", "ds.test");
 		//System.out.println("access fields:"+metadata);
 		return transformer.apply(xml, metadata);
@@ -114,7 +111,6 @@ public class TestUtil {
 	 */
 	public static String getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(String schemaOrgTransformer, String record) throws IOException {
 		Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/",
-				"streamingserver" ,"https://www.example.com/streamingserver/",
 				"manifestation", "8946d31d-a81c-447f-b84d-ff80644353d2.mp4",
 				"holdbackDate", "2026-01-17T09:34:42Z",
 				"holdbackPurposeName","Aktualitet og debat",
@@ -146,7 +142,6 @@ public class TestUtil {
 		String yamlStr =
 				"stylesheet: '" + PRESERVICA2SOLR + "'\n" +
 						"injections:\n" +
-						"  - streamingserver: 'example.com/streaming'\n" +
 						"  - origin: 'ds.test'\n";
 		prettyPrintSolrJson(record, yamlStr);
 	}

--- a/src/test/java/dk/kb/present/ViewTest.java
+++ b/src/test/java/dk/kb/present/ViewTest.java
@@ -115,27 +115,6 @@ class ViewTest {
 
     @Test
     @Tag("integration")
-    void pvicaEmptyChild() throws Exception {
-        if (Resolver.getPathFromClasspath(TestFiles.PVICA_RECORD_df3dc9cf) == null){
-            fail("Missing internal test files");
-        }
-        YAML conf = YAML.resolveLayeredConfigs("test_setup.yaml");
-        YAML radioConf = conf.getYAMLList(".origins").get(2);
-        View jsonldView = new View(radioConf.getSubMap("\"ds.radio\"").getYAMLList("views").get(1),
-                                    radioConf.getSubMap("\"ds.radio\"").getString("origin"));
-        String pvica = Resolver.resolveUTF8String(TestFiles.PVICA_RECORD_df3dc9cf);
-
-        DsRecordDto recordDto = new DsRecordDto().data(pvica).id("test.id").mTimeHuman("2023-11-29 13:45:49+0100").mTime(1701261949625000L).origin("ds.radio");
-
-        DsRecordDto emptyChildDto = new DsRecordDto().id("test.emptyChild").mTime(1701261949625000L);
-        recordDto.setChildren(List.of(emptyChildDto));
-
-        String jsonld = jsonldView.apply(recordDto);
-        assertFalse(jsonld.contains("\"contentUrl\":"));
-    }
-
-    @Test
-    @Tag("integration")
     void solrFromPvica() throws Exception {
         if (Resolver.getPathFromClasspath(TestFiles.PVICA_RECORD_df3dc9cf) == null){
             fail("Missing internal test files");

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -684,6 +684,12 @@ public class EmbeddedSolrTest {
         testStringValuePreservicaField(PVICA_DOMS_MIG_eaea0362, "holdback_name", "Aktualitet og debat");
     }
 
+    @Test
+    @Tag("integration")
+    void testKalturaId() throws Exception {
+        testStringValuePreservicaField(PVICA_RECORD_e683b0b8, "kaltura_id", "aVeryTrueKalturaID");
+    }
+
     /*
      * ------- Private helper methods below --------------
      */

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -350,7 +350,7 @@ public class EmbeddedSolrTest {
     @Test
     void testPreservicaPremiere() throws Exception {
         if (Resolver.getPathFromClasspath("internal_test_files/preservica7") != null) {
-            SolrDocument record = singlePreservicaIndex(PVICA_RECORD_b346acc8);
+            SolrDocument record = singlePreservica7Index(PVICA_RECORD_b346acc8);
             assertFalse((Boolean) record.getFieldValue("premiere"));
         } else {
             log.info("Preservica test files are not present. Embedded Solr tests for preservica metadata are not run.");
@@ -744,13 +744,6 @@ public class EmbeddedSolrTest {
         return getRecordByDerivedId(modsFile);
     }
 
-    @Deprecated
-    private SolrDocument singlePreservicaIndex(String preservicaFile) throws Exception {
-        indexPreservicaRecord(preservicaFile);
-        assertEquals(1, getNumberOfTotalDocuments(),
-                "After indexing '" + preservicaFile + "' the index should only hold a single record");
-        return getRecordByDerivedId(preservicaFile);
-    }
 
     private SolrDocument singlePreservica7Index(String preservicaFile) throws Exception {
         indexPreservica7Record(preservicaFile);
@@ -773,13 +766,6 @@ public class EmbeddedSolrTest {
         String solrString = TestUtil.getTransformedFromConfigWithAccessFields(yaml, recordXml);
 
         addRecordToEmbeddedServer(recordXml, solrString);
-    }
-
-    @Deprecated
-    private void indexPreservicaRecord(String preservicaRecord) throws Exception {
-        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJson(PRESERVICA2SCHEMAORG, preservicaRecord);
-        //prettyPrintJson(solrString);
-        addRecordToEmbeddedServer(preservicaRecord, solrString);
     }
 
     private void indexPreservica7Record(String preservicaRecord) throws Exception {
@@ -872,7 +858,7 @@ public class EmbeddedSolrTest {
            log.info("Preservica test file '{}' is not present. Embedded Solr test for field '{}'.",preservicaRecord, solrField);
            fail("Missing internal test files");
         }
-        SolrDocument record = singlePreservicaIndex(preservicaRecord);
+        SolrDocument record = singlePreservica7Index(preservicaRecord);
         assertEquals(fieldValue, record.getFieldValue(solrField));
 
     }
@@ -882,7 +868,7 @@ public class EmbeddedSolrTest {
             log.info("Preservica test file '{}' is not present. Embedded Solr test for field '{}'",preservicaRecord, solrField);
             fail("Missing internal test files");
         }
-        SolrDocument record = singlePreservicaIndex(preservicaRecord);
+        SolrDocument record = singlePreservica7Index(preservicaRecord);
         for (String value:fieldValues) {
             assertTrue(record.getFieldValue(solrField).toString().contains(value));
         }
@@ -893,7 +879,7 @@ public class EmbeddedSolrTest {
             log.info("Preservica test file '{}' is not present. Embedded Solr test for field '{}'",preservicaRecord, solrField);
             fail("Missing internal test files");
         }
-        SolrDocument record = singlePreservicaIndex(preservicaRecord);
+        SolrDocument record = singlePreservica7Index(preservicaRecord);
         assertEquals(fieldValue, record.getFieldValue(solrField));
     }
 
@@ -902,7 +888,7 @@ public class EmbeddedSolrTest {
             log.info("Preservica test file '{}' is not present. Embedded Solr test for field '{}'",preservicaRecord, solrField);
             fail("Missing internal test files");            
         }
-        SolrDocument record = singlePreservicaIndex(preservicaRecord);
+        SolrDocument record = singlePreservica7Index(preservicaRecord);
         assertEquals(fieldValue, record.getFieldValue(solrField));
     }
 
@@ -912,7 +898,7 @@ public class EmbeddedSolrTest {
             fail("Missing internal test files");        
         }
 
-        SolrDocument record = singlePreservicaIndex(preservicaRecord);
+        SolrDocument record = singlePreservica7Index(preservicaRecord);
         assertEquals(fieldValue, record.getFieldValue(solrField));
     }
 
@@ -922,7 +908,7 @@ public class EmbeddedSolrTest {
             fail("Missing internal test files");
         }
 
-        SolrDocument record = singlePreservicaIndex(preservicaRecord);
+        SolrDocument record = singlePreservica7Index(preservicaRecord);
         assertEquals(fieldValue, record.getFieldValue(solrField));
     }
 

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -48,11 +48,7 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
                                                         "{\"@type\":\"Collection\"," +
                                                         "\"name\":\"Det Kgl. Bibliotek; Radio\\/TV-Samlingen\"}"));
     }
-    @Test
-    void testContentUrl() throws IOException {
-        String transformedJSON = TestUtil.getTransformedWithVideoChildAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_3945e2d1, null);
-        Assertions.assertTrue(transformedJSON.contains("\"contentUrl\":\"www.example.com\\/streaming\\/mp4:bart-access-copies-tv\\/89\\/46\\/d3\\/8946d31d-a81c-447f-b84d-ff80644353d2.mp4\\/playlist.m3u8\""));
-    }
+
     @Test
     void testConditionOfAccess() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithVideoChildAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_3945e2d1, null);

--- a/src/test/java/dk/kb/present/transform/XSLTTransformerTestBase.java
+++ b/src/test/java/dk/kb/present/transform/XSLTTransformerTestBase.java
@@ -130,7 +130,6 @@ public abstract class XSLTTransformerTestBase {
             String yamlStr =
                     "stylesheet: '" + getXSLT() + "'\n" +
                             "injections:\n" +
-                            "  - streamingserver: 'example.com/streaming'\n" +
                             "  - origin: 'ds.test'\n";
             YAML yaml = YAML.parse(new ByteArrayInputStream(yamlStr.getBytes(StandardCharsets.UTF_8)));
             solrString = TestUtil.getTransformedFromConfigWithAccessFields(yaml, record);

--- a/src/test/resources/test_setup.yaml
+++ b/src/test/resources/test_setup.yaml
@@ -62,7 +62,6 @@ pvicaviews: &PRESERVICA_VIEWS
             stylesheet: 'xslt/preservica2schemaorg.xsl'
             injections:
               - imageserver: 'https://example.com/imageserver/'
-              - streamingserver: "here_should_be_a_wowza_url"
   - solrjson:
       mime: 'application/json'
       strategy: 'DR'
@@ -71,7 +70,6 @@ pvicaviews: &PRESERVICA_VIEWS
             stylesheet: 'xslt/preservica2schemaorg.xsl'
             injections:
               - imageserver: 'https://example.com/imageserver/'
-              - streamingserver: "here_should_be_a_wowza_url"
         - xsltsolr:
             stylesheet: 'xslt/schemaorg2solr.xsl'
   - raw:
@@ -100,7 +98,6 @@ pvica5views: &PRESERVICA_VIEWS
             stylesheet: 'xslt/preservica2schemaorg.xsl'
             injections:
               - imageserver: 'https://example.com/imageserver/'
-              - streamingserver: "here_should_be_a_wowza_url"
   - solrjson:
       mime: 'application/json'
       strategy: 'DR'
@@ -109,7 +106,6 @@ pvica5views: &PRESERVICA_VIEWS
             stylesheet: 'xslt/preservica2schemaorg.xsl'
             injections:
               - imageserver: 'https://example.com/imageserver/'
-              - streamingserver: "here_should_be_a_wowza_url"
         - xsltsolr:
             stylesheet: 'xslt/schemaorg2solr.xsl'
   - raw:


### PR DESCRIPTION
PR handling the following: 

- Introduce kaltura_id in solr documents and solr schema
- Introduce KalturaID as identifier in schema.org JSON
- Remove all traces of streaming_url and contentUrl for video and audio records. 

Small changes also included:
- Updated solr tests, to use Preservica 7 setup.
- Update logging in HoldbackDatePicker class.