### PR TITLE
Dra 948 doms transformation cleanup 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce KalturaID as identifier in schema.org JSON
 - Updated solr tests, to use Preservica 7 setup.
 - Update logging in HoldbackDatePicker class making it clearer, that origins in a holdback context comes from TVMeter data.
+- Updated XSLT to strip namespace prefixes from PbcoreDescriptionDocuments, to make them alike for all records
 
 ### Removed
 - Removed all traces of streaming_url and contentUrl for video and audio records.

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -48,8 +48,18 @@
        Currently, the template handles transformations from Preservica records to SCHEMA.ORG VideoObjects and AudioObjects. -->
   <xsl:template match="/">
 
+    <!-- We cannot rely on namespaces being present in the records. Therefore everything at content level has namespaces removed. This makes it possible to work with PBCore
+    metadata defined as PBCoreDescriptionDocument and PBCoreDescriptionDocument:PBCoreDescriptionDocument.-->
+    <xsl:variable name="contentObjects">
+      <xsl:for-each select="/XIP/Metadata/Content">
+        <xsl:apply-templates mode="strip-ns"/>
+      </xsl:for-each>
+      <xsl:value-of select="."/>
+    </xsl:variable>
+
+    <!-- As above, we are removing the namespaces for everything inside the PBCoreDescriptionDocument as some records have ns1, ns2, ns3 and so on for the same field. -->
     <xsl:variable name="pbCore">
-          <xsl:for-each select="/XIP/Metadata/Content/pbc:PBCoreDescriptionDocument">
+          <xsl:for-each select="$contentObjects/PBCoreDescriptionDocument">
             <xsl:apply-templates mode="strip-ns"/>
           </xsl:for-each>
           <xsl:value-of select="."/>

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -25,8 +25,12 @@
   <xsl:function name="my:convertDatetimeToZulu">
     <xsl:param name="datetime"/>
 
+    <xsl:variable name="validatedDatetimeT">
+      <xsl:value-of select="my:validateTimezoneT($datetime)"/>
+    </xsl:variable>
+
     <xsl:variable name="wellFormatedDatetime">
-      <xsl:value-of select="my:getDatetimeWithValidTimezone($datetime)"/>
+      <xsl:value-of select="my:getDatetimeWithValidTimezone($validatedDatetimeT)"/>
     </xsl:variable>
 
     <xsl:value-of select="f:adjust-dateTime-to-timezone($wellFormatedDatetime, xs:dayTimeDuration('PT0H'))"/>
@@ -62,6 +66,25 @@
     </xsl:choose>
   </xsl:function>
 
+  <xsl:function name="my:validateTimezoneT">
+    <xsl:param name="datetimeString"/>
+
+    <xsl:choose>
+      <xsl:when test="substring($datetimeString, 11, 1) = 'T'">
+        <xsl:value-of select="$datetimeString"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="date">
+          <xsl:value-of select="substring($datetimeString, 1, 10)"/>
+        </xsl:variable>
+        <xsl:variable name="timeAndZone">
+          <xsl:value-of select="substring($datetimeString, 11)"/>
+        </xsl:variable>
+
+        <xsl:value-of select="f:concat($date, 'T', $timeAndZone)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
 
   <!-- Get milliseconds between two datetimes. -->
   <xsl:function name="my:toMilliseconds" as="xs:integer">

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -43,6 +43,8 @@ public class TestFiles {
     public static final String PVICA_DOMS_MIG_9779a1b2 = "internal_test_files/domsMigrated/9779a1b2-88ff-408c-9352-ad614615b2e7-20240531T022942.xml";
     public static final String PVICA_DOMS_MIG_9ed10d66 = "internal_test_files/domsMigrated/9ed10d66-4791-4390-8db9-bb0bed7aebcb-20240531T023244.xml";
     public static final String PVICA_DOMS_MIG_82514cd9 = "internal_test_files/domsMigrated/82514cd9-c30c-4963-8b5c-7c7d32684c17.xml";
+    public static final String PVICA_DOMS_MIG_dd5f2f60 = "internal_test_files/domsMigrated/dd5f2f60-b13e-44d7-a439-a408777c0f02.xml";
+    public static final String PVICA_DOMS_MIG_597e79f7 = "internal_test_files/domsMigrated/597e79f7-4fe8-42b0-9ccf-90e1af0f5468.xml";
     public static final String PVICA_HOMEMADE_HOLDBACK_TEST_RECORD = "internal_test_files/homemade/badHoldbackFieldContents.xml";
 
     // From preservica 6, not in preservica 7 stage

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -38,6 +38,7 @@ public class TestFiles {
 
     public static final String PVICA_RECORD_2b462c63 = "internal_test_files/preservica7/2b462c63-8bb8-477a-89d9-70675c22c163.xml";
     public static final String PVICA_RECORD_5238ea5d = "internal_test_files/preservica7/5238ea5d-9627-4b08-9a76-356dfb8bebd0.xml";
+    public static final String PVICA_RECORD_3b0c391f = "internal_test_files/preservica7/3b0c391f-b7ef-4b48-a9e8-428a92288c0b.xml";
     public static final String PVICA_DOMS_MIG_bd612d1e = "internal_test_files/domsMigrated/bd612d1e-b90b-48f7-87ce-898da240950b-20240612T105945.xml";
     public static final String PVICA_DOMS_MIG_eaea0362 = "internal_test_files/domsMigrated/eaea0362-bbad-43ec-8d5e-07df6957923b-20240612T112310.xml";
     public static final String PVICA_DOMS_MIG_9779a1b2 = "internal_test_files/domsMigrated/9779a1b2-88ff-408c-9352-ad614615b2e7-20240531T022942.xml";
@@ -45,6 +46,7 @@ public class TestFiles {
     public static final String PVICA_DOMS_MIG_82514cd9 = "internal_test_files/domsMigrated/82514cd9-c30c-4963-8b5c-7c7d32684c17.xml";
     public static final String PVICA_DOMS_MIG_dd5f2f60 = "internal_test_files/domsMigrated/dd5f2f60-b13e-44d7-a439-a408777c0f02.xml";
     public static final String PVICA_DOMS_MIG_597e79f7 = "internal_test_files/domsMigrated/597e79f7-4fe8-42b0-9ccf-90e1af0f5468.xml";
+    public static final String PVICA_DOMS_MIG_4ad48e98 = "internal_test_files/domsMigrated/4ad48e98-b791-43d2-8b32-9cfa23641466.xml";
     public static final String PVICA_HOMEMADE_HOLDBACK_TEST_RECORD = "internal_test_files/homemade/badHoldbackFieldContents.xml";
 
     // From preservica 6, not in preservica 7 stage

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -413,6 +413,15 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
         assertTrue(transformedJSON.contains("\"genre\":\"film\""));
     }
 
+    @Test
+    public void testDomsRecordsNotConvertingToMediaObject() throws IOException {
+        String transformedTV = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_dd5f2f60);
+        assertTrue(transformedTV.contains("\"@type\":\"VideoObject\","));
+
+        String transformedRadio = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
+        assertTrue(transformedRadio.contains("\"@type\":\"AudioObject\","));
+    }
+
     private static void printSchemaOrgJson(String xml) throws IOException {
         Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/",
                                                 "conditionsOfAccess", "placeholderCondition");

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -422,6 +422,18 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
         assertTrue(transformedRadio.contains("\"@type\":\"AudioObject\","));
     }
 
+    @Test
+    void testDateTimeNoT() throws IOException {
+        String transformed = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_4ad48e98);
+        prettyPrintJson(transformed);
+    }
+
+    @Test
+    public void testEmptyValues() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_3b0c391f);
+        prettyPrintJson(transformedJSON);
+    }
+
     private static void printSchemaOrgJson(String xml) throws IOException {
         Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/",
                                                 "conditionsOfAccess", "placeholderCondition");

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -430,6 +430,12 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
 
     }
 
+    @Test
+    void testEmptyFields() throws IOException {
+        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_3b0c391f);
+        prettyPrintJson(solrString);
+    }
+
     /**
      * Wrapper for {@link #assertMultiTestsThroughSchemaTransformation(String, Consumer[])} which verifies that the
      * transformed record contains the given {@code substring}.


### PR DESCRIPTION
First part of DRA 948 tackling DOMS records being indexed as MediaObjects due to no-namespace prefixes for PbcoreDescriptionDocuments. 

To run tests please do a `kb init`