### PR TITLE
Dra 1137 correction of transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 
 ### Changed
 
@@ -12,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [2.0.0](https://github.com/kb-dk/ds-present/releases/tag/ds-present-2.0.0) 2024-07-17
-###
+### Added
 - Added support for Preservica records migrated from DOMS.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added string normalization of title fields to XSLTs.
+- Added validation of ':' in datetime timezone values in XSLT transformations.
+- Added field migrated_from to documents
 
 ### Changed
+- Bumped solr version to 1.6.13.
+- Changed extraction of field videoFrameSize to clean values as '16:9,' and '16:9, ' to '16:9'.
 
 ### Removed
 

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -144,12 +144,21 @@
             <f:string key="videoQuality"><xsl:value-of select="//pbcoreInstantiation/formatStandard"/></f:string>
           </xsl:if>
 
-          <!-- Extract aspect ratio-->
-          <xsl:if test="$pbCore/pbcoreInstantiation/formatAspectRatio != '' and normalize-space($pbCore/pbcoreInstantiation/formatAspectRatio) != ','">
-            <f:string key="videoFrameSize">
-              <xsl:value-of select="$pbCore/pbcoreInstantiation/formatAspectRatio"/>
-            </f:string>
-          </xsl:if>
+          <!-- Extract aspect ratio -->
+          <!-- Aspect ratio contains many dirty values. such as ',', ', ', '16:9,' and '16:9, '. -->
+          <xsl:choose>
+            <xsl:when test="normalize-space($pbCore/pbcoreInstantiation/formatAspectRatio) = '16:9,' or '16:9, '">
+              <f:string key="videoFrameSize">16:9</f:string>
+            </xsl:when>
+            <xsl:when test="$pbCore/pbcoreInstantiation/formatAspectRatio != '' and normalize-space($pbCore/pbcoreInstantiation/formatAspectRatio) != ',' or ', '">
+              <f:string key="videoFrameSize">
+                <xsl:value-of select="$pbCore/pbcoreInstantiation/formatAspectRatio"/>
+              </f:string>
+            </xsl:when>
+            <!-- If the field doesn't exist, don't do anything -->
+            <xsl:otherwise></xsl:otherwise>
+          </xsl:choose>
+
         </xsl:for-each>
 
         <!-- Create the kb:internal map. This map contains all metadata, that are not represented in schema.org, but were
@@ -332,20 +341,20 @@
     <xsl:choose>
       <xsl:when test="$title = $original-title and $title != '' or ($title != '' and $original-title = '')">
         <f:string key="name">
-          <xsl:value-of select="$title"/>
+          <xsl:value-of select="normalize-space($title)"/>
         </f:string>
       </xsl:when>
       <xsl:when test="$title = '' and $original-title != ''">
         <f:string key="name">
-          <xsl:value-of select="$original-title"/>
+          <xsl:value-of select="normalize-space($original-title)"/>
         </f:string>
       </xsl:when>
       <xsl:otherwise>
         <f:string key="name">
-          <xsl:value-of select="$title"/>
+          <xsl:value-of select="normalize-space($title)"/>
         </f:string>
         <f:string key="alternateName">
-          <xsl:value-of select="$original-title"/>
+          <xsl:value-of select="normalize-space($original-title)"/>
         </f:string>
       </xsl:otherwise>
     </xsl:choose>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -774,6 +774,18 @@
     <xsl:param name="pbcExtensions"/>
     <xsl:param name="type"/>
 
+    <!-- Extration of migration details if present. Implemented as a choose statement. -->
+    <xsl:if test="/XIP/Metadata/Content/migration_details/migrated_from">
+      <xsl:variable name="migrationSource">
+        <xsl:value-of select="/XIP/Metadata/Content/migration_details/migrated_from"/>
+      </xsl:variable>
+      <f:string key="kb:migrated_from">
+        <xsl:choose>
+          <xsl:when test="normalize-space($migrationSource) = 'Radio/tv DOMS - prod'">DOMS</xsl:when>
+        </xsl:choose>
+      </f:string>
+    </xsl:if>
+
     <!-- Internal value for backing ds-storage mTime-->
     <f:string key="kb:storage_mTime">
       <xsl:value-of select="format-number($mTime, '0')"/>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -15,7 +15,7 @@
                xmlns:program_structure="http://doms.statsbiblioteket.dk/types/program_structure/0/1/#"
                xmlns:err="http://www.w3.org/2005/xqt-errors"
                version="3.0">
-  
+
   <xsl:output method="text"/>
 
   <!--INJECTIONS -->
@@ -68,6 +68,7 @@
     <!-- Determine the type of schema.org object in hand.-->
     <xsl:variable name="type">
       <xsl:choose>
+        <!-- /XIP/Metadata[1]/Content/ns2:PBCoreDescriptionDocument/ns2:pbcoreInstantiation/ns2:formatMediaType-->
         <!-- XIP/Metadata/Content/pbc:PBCoreDescriptionDocument/pbc:pbcoreInstantiation/pbc:formatMediaType = 'Moving Image'"-->
         <xsl:when test="$pbCore/pbcoreInstantiation/formatMediaType = 'Moving Image'">VideoObject</xsl:when>
         <xsl:when test="$pbCore/pbcoreInstantiation/formatMediaType = 'Sound'">AudioObject</xsl:when>
@@ -144,7 +145,7 @@
           </xsl:if>
 
           <!-- Extract aspect ratio-->
-          <xsl:if test="$pbCore/pbcoreInstantiation/formatAspectRatio">
+          <xsl:if test="$pbCore/pbcoreInstantiation/formatAspectRatio != '' and normalize-space($pbCore/pbcoreInstantiation/formatAspectRatio) != ','">
             <f:string key="videoFrameSize">
               <xsl:value-of select="$pbCore/pbcoreInstantiation/formatAspectRatio"/>
             </f:string>
@@ -444,12 +445,12 @@
         <f:string key="@type">Country</f:string>
         <xsl:for-each select="./pbcoreExtension/extension">
           <xsl:choose>
-            <xsl:when test="f:contains(. , 'produktionsland:')">
+            <xsl:when test="f:contains(. , 'produktionsland:') and substring-after(. , 'produktionsland:') != ''">
               <f:string key="name">
                 <xsl:value-of select="f:substring-after(. , 'produktionsland:')"/>
               </f:string>
             </xsl:when>
-            <xsl:when test="f:contains(. , 'produktionsland_id:')">
+            <xsl:when test="f:contains(. , 'produktionsland_id:') and substring-after(. , 'produktionsland_id:') != ''">
               <f:string key="identifier">
                 <xsl:value-of select="f:substring-after(. , 'produktionsland_id:')"/>
               </f:string>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -436,12 +436,7 @@
           <xsl:value-of select="$schemaorg-xml('videoFrameSize')"/>
         </f:string>
       </xsl:if>
-      <!--<xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio') != ''">
-        <f:string key="aspect_ratio">
-          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:aspect_ratio')"/>
-        </f:string>
-      </xsl:if>
--->
+
       <!-- Extract boolean for live broadcast -->
       <xsl:if test="f:exists($schemaorg-xml('publication'))">
         <xsl:if test="f:exists($schemaorg-xml('publication')('isLiveBroadcast'))">
@@ -564,6 +559,12 @@
   <!-- TEMPLATE WHICH EXTRACTS VALUES FROM THE KB INTERNAL MAP, THAT HAVE STATUS AS INTERNAL FIELDS IN SOLR AS WELL. -->
   <xsl:template name="kbInternal">
     <xsl:param name="internalMap"/>
+
+    <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:migrated_from') != ''">
+      <f:string key="migrated_from">
+        <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:migrated_from')"/>
+      </f:string>
+    </xsl:if>
 
     <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:storage_mTime') != ''">
       <f:string key="internal_storage_mTime">

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -45,6 +45,7 @@
       <xsl:when test="f:ends-with($datetimeString, 'Z')">
         <xsl:value-of select="$datetimeString"/>
       </xsl:when>
+      <xsl:when test="contains(substring($datetimeString, '+'))"
       <xsl:when test="f:string-length(substring-after($datetimeString, '+')) != 5">
         <xsl:variable name="datetimeNoTimezone">
           <xsl:value-of select="substring-before($datetimeString, '+')"/>

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -45,7 +45,6 @@
       <xsl:when test="f:ends-with($datetimeString, 'Z')">
         <xsl:value-of select="$datetimeString"/>
       </xsl:when>
-      <xsl:when test="contains(substring($datetimeString, '+'))"
       <xsl:when test="f:string-length(substring-after($datetimeString, '+')) != 5">
         <xsl:variable name="datetimeNoTimezone">
           <xsl:value-of select="substring-before($datetimeString, '+')"/>
@@ -58,6 +57,21 @@
         </xsl:variable>
         <xsl:variable name="timezoneMinute">
           <xsl:value-of select="substring($timezoneInfo, 3,2)"/>
+        </xsl:variable>
+        <xsl:value-of select="concat($datetimeNoTimezone, '+', $timezoneHour, ':', $timezoneMinute)"/>
+      </xsl:when>
+      <xsl:when test="not(contains(substring-after($datetimeString, '+'), ':'))">
+        <xsl:variable name="datetimeNoTimezone">
+          <xsl:value-of select="substring-before($datetimeString, '+')"/>
+        </xsl:variable>
+        <xsl:variable name="timezone">
+          <xsl:value-of select="substring-after($datetimeString, '+')"/>
+        </xsl:variable>
+        <xsl:variable name="timezoneHour">
+          <xsl:value-of select="substring($timezone, 1, 2)"/>
+        </xsl:variable>
+        <xsl:variable name="timezoneMinute">
+          <xsl:value-of select="substring($timezone, 4,2)"/>
         </xsl:variable>
         <xsl:value-of select="concat($datetimeNoTimezone, '+', $timezoneHour, ':', $timezoneMinute)"/>
       </xsl:when>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -39,8 +39,9 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 1.6.10: Add fields for holdback management
 1.6.11: Rename schema fields following feedback from metadata review.
 1.6.12: Add kaltura_id to schema and remove old wowza streaming url.
+1.6.13
   -->
-  <field name="_ds_1.6.12_" type="string" indexed="false" stored="false"/>
+  <field name="_ds_1.6.13_" type="string" indexed="false" stored="false"/>
   <uniqueKey>id</uniqueKey>
 
    <!-- START FIELDS  -->
@@ -106,7 +107,6 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     Den grimme ælling.?>
   </field>
 
-
   <!-- Note: The title_sort_da field IS NOT automatically copied from title as title_sort_da is single valued -->
   <field name="title_sort_da" type="sort_da">
     <?description The object title, usable for sorting according to Danish locale.
@@ -155,6 +155,12 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
             descriptions for radio and TV metadata.?>
     <?example     Serien omfatter 189 kort og haves komplet i flere udgaver?>
     <?example     Daguerreotypi, mål: 81 x 70 mm?>
+  </field>
+
+  <field name="migrated_from" type="string">
+    <?description Information on the record being migrated from another metadata system. If this value is present, the record has been migrated from another metadata system into
+            the current one.?>
+    <?example DOMS?>
   </field>
 
   <!-- =======================================================-->

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -48,6 +48,7 @@ public class TestFiles {
     public static final String PVICA_DOMS_MIG_597e79f7 = "internal_test_files/domsMigrated/597e79f7-4fe8-42b0-9ccf-90e1af0f5468.xml";
     public static final String PVICA_DOMS_MIG_4ad48e98 = "internal_test_files/domsMigrated/4ad48e98-b791-43d2-8b32-9cfa23641466.xml";
     public static final String PVICA_DOMS_MIG_cb4bb835 = "internal_test_files/domsMigrated/cb4bb835-8949-4841-b4ad-fe09b4e62790.xml";
+    public static final String PVICA_DOMS_MIG_e2dfb840 = "internal_test_files/domsMigrated/e2dfb840-68a5-45f6-b9b6-232de1af597e.xml";
     public static final String PVICA_HOMEMADE_HOLDBACK_TEST_RECORD = "internal_test_files/homemade/badHoldbackFieldContents.xml";
 
     // From preservica 6, not in preservica 7 stage

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -47,6 +47,7 @@ public class TestFiles {
     public static final String PVICA_DOMS_MIG_dd5f2f60 = "internal_test_files/domsMigrated/dd5f2f60-b13e-44d7-a439-a408777c0f02.xml";
     public static final String PVICA_DOMS_MIG_597e79f7 = "internal_test_files/domsMigrated/597e79f7-4fe8-42b0-9ccf-90e1af0f5468.xml";
     public static final String PVICA_DOMS_MIG_4ad48e98 = "internal_test_files/domsMigrated/4ad48e98-b791-43d2-8b32-9cfa23641466.xml";
+    public static final String PVICA_DOMS_MIG_cb4bb835 = "internal_test_files/domsMigrated/cb4bb835-8949-4841-b4ad-fe09b4e62790.xml";
     public static final String PVICA_HOMEMADE_HOLDBACK_TEST_RECORD = "internal_test_files/homemade/badHoldbackFieldContents.xml";
 
     // From preservica 6, not in preservica 7 stage

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -49,6 +49,7 @@ public class TestFiles {
     public static final String PVICA_DOMS_MIG_4ad48e98 = "internal_test_files/domsMigrated/4ad48e98-b791-43d2-8b32-9cfa23641466.xml";
     public static final String PVICA_DOMS_MIG_cb4bb835 = "internal_test_files/domsMigrated/cb4bb835-8949-4841-b4ad-fe09b4e62790.xml";
     public static final String PVICA_DOMS_MIG_e2dfb840 = "internal_test_files/domsMigrated/e2dfb840-68a5-45f6-b9b6-232de1af597e.xml";
+    public static final String PVICA_DOMS_MIG_73aad1c3 = "internal_test_files/domsMigrated/73aad1c3-5af0-4720-a569-98441edbd245.xml";
     public static final String PVICA_HOMEMADE_HOLDBACK_TEST_RECORD = "internal_test_files/homemade/badHoldbackFieldContents.xml";
 
     // From preservica 6, not in preservica 7 stage

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -50,6 +50,7 @@ import static dk.kb.present.TestFiles.CUMULUS_RECORD_FM;
 import static dk.kb.present.TestFiles.CUMULUS_RECORD_aaf3b130;
 import static dk.kb.present.TestFiles.CUMULUS_RECORD_e2519ce0;
 import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_9779a1b2;
+import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_e2dfb840;
 import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_eaea0362;
 import static dk.kb.present.TestFiles.PVICA_RECORD_0b3f6a54;
 import static dk.kb.present.TestFiles.PVICA_RECORD_2b462c63;
@@ -688,6 +689,12 @@ public class EmbeddedSolrTest {
     @Tag("integration")
     void testKalturaId() throws Exception {
         testStringValuePreservicaField(PVICA_RECORD_e683b0b8, "kaltura_id", "aVeryTrueKalturaID");
+    }
+
+    @Test
+    @Tag("integration")
+    void testMigratedFrom() throws Exception {
+        testStringValuePreservicaField(PVICA_DOMS_MIG_e2dfb840, "migrated_from", "DOMS");
     }
 
     /*

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -425,13 +425,13 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     void testDateTimeNoT() throws IOException {
         String transformed = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_4ad48e98);
-        prettyPrintJson(transformed);
+        assertTrue(transformed.contains("\"startTime\":\"1987-05-04T14:45:00Z\""));
     }
 
     @Test
     void testTimezone() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_cb4bb835);
-        prettyPrintJson(transformedJSON);
+        assertTrue(transformedJSON.contains("\"startTime\":\"1981-05-08T17:00:00Z\""));
     }
 
     @Test

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -429,6 +429,12 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     }
 
     @Test
+    void testTimezone() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_cb4bb835);
+        prettyPrintJson(transformedJSON);
+    }
+
+    @Test
     public void testEmptyValues() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_3b0c391f);
         prettyPrintJson(transformedJSON);

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -449,6 +449,12 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
         assertFalse(transformedJSON.contains("\"videoFrameSize\""));
     }
 
+    @Test
+    public void testMigratedFrom() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_e2dfb840);
+        assertTrue(transformedJSON.contains("kb:migrated_from\":\"DOMS\""));
+    }
+
     private static void printSchemaOrgJson(String xml) throws IOException {
         Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/",
                                                 "conditionsOfAccess", "placeholderCondition");

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -455,6 +455,12 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
         assertTrue(transformedJSON.contains("kb:migrated_from\":\"DOMS\""));
     }
 
+    @Test
+    public void testDomsTitleCleaning() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_73aad1c3);
+        assertTrue(transformedJSON.contains("\"name\":\"Temalørdag: Pavarotti\","));
+    }
+
     private static void printSchemaOrgJson(String xml) throws IOException {
         Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/",
                                                 "conditionsOfAccess", "placeholderCondition");

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -435,9 +435,18 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     }
 
     @Test
-    public void testEmptyValues() throws IOException {
-        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_3b0c391f);
-        prettyPrintJson(transformedJSON);
+    public void testCountryOfOriginNoName() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_e2dfb840);
+        assertFalse(transformedJSON.contains("\"countryOfOrigin\":{\"@type\":\"Country\",\"name\""));
+        assertTrue(transformedJSON.contains("\"countryOfOrigin\":{" +
+                "\"@type\":\"Country\"," +
+                "\"identifier\":\"0\"}"));
+    }
+
+    @Test
+    public void testFormatAspectRatio() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_e2dfb840);
+        assertFalse(transformedJSON.contains("\"videoFrameSize\""));
     }
 
     private static void printSchemaOrgJson(String xml) throws IOException {

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -431,6 +431,11 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
     }
 
     @Test
+    void testMigratedFrom(){
+        assertPvicaContains(TestFiles.PVICA_DOMS_MIG_e2dfb840, "\"migrated_from\":\"DOMS\"");
+    }
+
+    @Test
     void testEmptyFields() throws IOException {
         String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_3b0c391f);
         prettyPrintJson(solrString);


### PR DESCRIPTION
More XSLT changes catching non-pretty transformed DOMS records. Adds a migrated_from field but mainly prettifies the fields:
- Title/name
- alternateName
- videoFrameSize/aspect_ratio
- countryOfOrigin/country_of_origin