### PR TITLE
remove wrongly defined git.tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed extraction of field videoFrameSize to clean values as '16:9,' and '16:9, ' to '16:9'.
 
 ### Removed
-
+- Removed non-resolvable git.tag from build.properties
 
 ## [2.0.0](https://github.com/kb-dk/ds-present/releases/tag/ds-present-2.0.0) 2024-07-17
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -421,18 +421,9 @@
                 <includeOnlyProperties>
                   <includeOnlyProperty>git.commit.id</includeOnlyProperty>
                   <includeOnlyProperty>git.branch</includeOnlyProperty>
-                  <includeOnlyProperty>git.tag</includeOnlyProperty>
                   <includeOnlyProperty>git.closest.tag.name</includeOnlyProperty>
                   <includeOnlyProperty>git.commit.author.time</includeOnlyProperty>
                 </includeOnlyProperties>
-                <replacementProperties>
-                  <replacementProperty>
-                    <property>git.tag</property>
-                    <regex>false</regex>
-                    <token>git.tag</token>
-                    <value>unknown</value>
-                  </replacementProperty>
-                </replacementProperties>
               </configuration>
             </plugin>
             <plugin>

--- a/src/main/resources/ds-present.build.properties
+++ b/src/main/resources/ds-present.build.properties
@@ -4,6 +4,5 @@ APPLICATION.VERSION=${pom.version}
 APPLICATION.BUILDTIME=${timestamp}
 GIT.COMMIT.CHECKSUM=${git.commit.id}
 GIT.BRANCH=${git.branch}
-GIT.CURRENT.TAG=${git.tag}
 GIT.CLOSEST.TAG=${git.closest.tag.name}
 GIT.COMMIT.TIME=${git.commit.author.time}


### PR DESCRIPTION
the property git.tag does not exist in the plugin and can't be defined as the other git things. However, the build.properties contains APPLICATION.VERSION which in our case is the same value, so no harm in not resolving it.