### PR TITLE
Dra 727 implement ownproduction filter and refactor extractions from metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added string normalization of title fields to XSLTs.
 - Added validation of ':' in datetime timezone values in XSLT transformations.
-- Added field migrated_from to documents
+- Added field migrated_from to documents.
+- Added fields own_production and own_production_code to documents.
 
 ### Changed
 - Bumped solr version to 1.6.13.
 - Changed extraction of field videoFrameSize to clean values as '16:9,' and '16:9, ' to '16:9'.
+- Changed how values are extracted from Preservica records. Now all needed values are extracted at once, saving iterations on the XML stream.
 
 ### Removed
 - Removed non-resolvable git.tag from build.properties

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,7 @@
           <groupId>org.mockito</groupId>
           <artifactId>mockito-inline</artifactId>
           <version>5.2.0</version>
+         <scope>test</scope>
         </dependency>
         <!-- Mockito-core is needed for FieldSetter used in tests.
              Tests using this functionality should probably be re-written to use an updated version of mockito -->

--- a/src/main/java/dk/kb/present/RecordValues.java
+++ b/src/main/java/dk/kb/present/RecordValues.java
@@ -25,14 +25,14 @@ public class RecordValues {
         values.put("endTime", new PathPair<>(endTimePath, ""));
         values.put("form", new PathPair<>(formPath, ""));
         values.put("contentsItem", new PathPair<>(contentsItemPath, ""));
-        values.put("productionCountry", new PathPair<>(productionCountryPath, ""));
+        values.put("origin", new PathPair<>(originPath, ""));
     }
 
     private static final String startTimePath = "/XIP/Metadata/Content/PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreDateAvailable/dateAvailableStart";
     private static final String endTimePath = "/XIP/Metadata/Content/PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreDateAvailable/dateAvailableEnd";
     private static final String formPath = "/XIP/Metadata/Content/record/source/tvmeter/form";
     private static final String contentsItemPath = "/XIP/Metadata/Content/record/source/tvmeter/contentsitem";
-    private static final String productionCountryPath = "/XIP/Metadata/Content/record/source/tvmeter/productioncountry";
+    private static final String originPath = "/XIP/Metadata/Content/record/source/tvmeter/origin";
 
     public String getStartTime() {
         return values.get("startTime").getValue();
@@ -68,12 +68,12 @@ public class RecordValues {
         values.get("contentsItem").setValue(contentsItem);
     }
 
-    public String getProductionCountry() {
-        return values.get("productionCountry").getValue();
+    public String getOrigin(){
+        return values.get("origin").getValue();
     }
 
-    public void setProductionCountry(String productionCountry) {
-        values.get("productionCountry").setValue(productionCountry);
+    public void setOrigin(String origin){
+        values.get("origin").setValue(origin);
     }
 
     public List<String> getPaths(){

--- a/src/main/java/dk/kb/present/RecordValues.java
+++ b/src/main/java/dk/kb/present/RecordValues.java
@@ -1,0 +1,92 @@
+package dk.kb.present;
+
+import dk.kb.present.util.PathPair;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An object containing all values from a single Preservica record, that are to be handled in either a special context or in multiple contexts. The main component of this object is
+ * the {@link #values}-map. This map contains keys, representing the name of each entry, and values of type {@link PathPair}, containing the path to the extracted value as
+ * {@link PathPair#path} and the value extracted from the specified path at {@link PathPair#value}. This value can then be retrieved by getters in {@link RecordValues}.
+ * <br/>
+ * Can be used in conjunction with {@link dk.kb.present.util.saxhandlers.ElementsExtractionHandler} to parse an XML stream for multiple values.
+ */
+public class RecordValues {
+
+    public Map<String, PathPair<String,String>> values = new HashMap<>();
+
+    public RecordValues(){
+        values.put("startTime", new PathPair<>(startTimePath, ""));
+        values.put("endTime", new PathPair<>(endTimePath, ""));
+        values.put("form", new PathPair<>(formPath, ""));
+        values.put("contentsItem", new PathPair<>(contentsItemPath, ""));
+        values.put("productionCountry", new PathPair<>(productionCountryPath, ""));
+    }
+
+    private static final String startTimePath = "/XIP/Metadata/Content/PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreDateAvailable/dateAvailableStart";
+    private static final String endTimePath = "/XIP/Metadata/Content/PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreDateAvailable/dateAvailableEnd";
+    private static final String formPath = "/XIP/Metadata/Content/record/source/tvmeter/form";
+    private static final String contentsItemPath = "/XIP/Metadata/Content/record/source/tvmeter/contentsitem";
+    private static final String productionCountryPath = "/XIP/Metadata/Content/record/source/tvmeter/productioncountry";
+
+    public String getStartTime() {
+        return values.get("startTime").getValue();
+    }
+
+    public void setStartTime(String startTime) {
+        values.get("startTime").setValue(startTime);
+    }
+
+    public String getEndTime() {
+        return values.get("endTime").getValue();
+    }
+
+    public void setEndTime(String endTime) {
+        values.get("endTime").setValue(endTime);
+    }
+
+    public String getFormValue() {
+        return values.get("form").getValue();
+    }
+
+    public void setFormValue(String formValue) {
+        values.get("form").setValue(formValue);
+    }
+
+    public String getContentsItem() {
+        return values.get("contentsItem").getValue();
+    }
+
+    public void setContentsItem(String contentsItem) {
+        values.get("contentsItem").setValue(contentsItem);
+    }
+
+    public String getProductionCountry() {
+        return values.get("productionCountry").getValue();
+    }
+
+    public void setProductionCountry(String productionCountry) {
+        values.get("productionCountry").setValue(productionCountry);
+    }
+
+    public List<String> getPaths(){
+        List<String> paths = new ArrayList<>();
+        for (Map.Entry<String, PathPair<String, String>> entry : values.entrySet()) {
+            paths.add(entry.getValue().getPath());
+        }
+
+        return paths;
+    }
+
+    @Override
+    public String toString() {
+        return "RecordValues{" +
+                "values=" + values +
+                '}';
+    }
+}
+
+

--- a/src/main/java/dk/kb/present/RecordValues.java
+++ b/src/main/java/dk/kb/present/RecordValues.java
@@ -1,7 +1,9 @@
 package dk.kb.present;
 
+import dk.kb.present.util.DataCleanup;
 import dk.kb.present.util.PathPair;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,7 +39,8 @@ public class RecordValues {
     }
 
     public void setStartTime(String startTime) {
-        values.get("startTime").setValue(startTime);
+        String cleanedTime = DataCleanup.getCleanZonedDateTimeFromString(startTime).format(DateTimeFormatter.ISO_INSTANT);
+        values.get("startTime").setValue(cleanedTime);
     }
 
     public String getEndTime() {
@@ -45,7 +48,8 @@ public class RecordValues {
     }
 
     public void setEndTime(String endTime) {
-        values.get("endTime").setValue(endTime);
+        String cleanedTime = DataCleanup.getCleanZonedDateTimeFromString(endTime).format(DateTimeFormatter.ISO_INSTANT);
+        values.get("endTime").setValue(cleanedTime);
     }
 
     public String getFormValue() {

--- a/src/main/java/dk/kb/present/View.java
+++ b/src/main/java/dk/kb/present/View.java
@@ -19,6 +19,7 @@ import dk.kb.present.holdback.HoldbackDatePicker;
 import dk.kb.present.transform.DSTransformer;
 import dk.kb.present.transform.TransformerController;
 import dk.kb.present.util.DataCleanup;
+import dk.kb.present.util.ExtractedPreservicaValues;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.util.webservice.exception.InternalServiceException;
 import dk.kb.util.yaml.YAML;
@@ -128,10 +129,10 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
     @Override
     public String apply(DsRecordDto record) {
         final Map<String, String> metadata = createBasicMetadataMap(record);
-        RecordValues extractedValues = new RecordValues();
+        ExtractedPreservicaValues extractedValues = new ExtractedPreservicaValues();
         String content = record.getData();
 
-        // If origin is either radio or tv (i.e. from preservica) extract some predefined values from the record to a RecordValues object.
+        // If origin is either radio or tv (i.e. from preservica) extract some predefined values from the record to a ExtractedPreservicaValues object.
         if ( content != null && (strategy.equals(Strategy.DR)) || strategy.equals(Strategy.MANIFESTATION)){
             try {
                 extractedValues = DataCleanup.extractValuesFromPreservicaContent(content);
@@ -172,7 +173,7 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
         return content;
     }
 
-    private void updateMetadataMapWithOwnProduction(Map<String, String> metadataMap, RecordValues extractedValues) {
+    private void updateMetadataMapWithOwnProduction(Map<String, String> metadataMap, ExtractedPreservicaValues extractedValues) {
         // If origin is below 2000 the record is produced by DR themselves. See internal notes on subpages to this site for explanations:
         // https://kb-dk.atlassian.net/wiki/spaces/DRAR/pages/40632339/Metadata
         String ownProduction = extractedValues.getOrigin();
@@ -196,11 +197,11 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
     /**
      * Extract start and end date from the record and ensure that they are in a valid format.
      * @param metadataMap containing values given to the transformer creating the view.
-     * @param recordValues containing values that have been extracted from the metadata record.
+     * @param extractedPreservicaValues containing values that have been extracted from the metadata record.
      */
-    private static void extractStartAndEndDatesToMetadataMap(Map<String, String> metadataMap, RecordValues recordValues) {
-        metadataMap.put("startTime", recordValues.getStartTime());
-        metadataMap.put("endTime", recordValues.getEndTime());
+    private static void extractStartAndEndDatesToMetadataMap(Map<String, String> metadataMap, ExtractedPreservicaValues extractedPreservicaValues) {
+        metadataMap.put("startTime", extractedPreservicaValues.getStartTime());
+        metadataMap.put("endTime", extractedPreservicaValues.getEndTime());
     }
 
     /**
@@ -261,7 +262,7 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
      * @param metadata map, which holds values that are to be used in the XSLT transformation later on.
      *                 Holdback values are added to this map.
      */
-    private void updateMetadataMapWithHoldback(DsRecordDto record, Map<String, String> metadata, RecordValues extractedValues) {
+    private void updateMetadataMapWithHoldback(DsRecordDto record, Map<String, String> metadata, ExtractedPreservicaValues extractedValues) {
         try {
             HoldbackObject holdbackObject = HoldbackDatePicker.getInstance().getHoldbackDateForRecord(extractedValues, record.getOrigin());
 

--- a/src/main/java/dk/kb/present/View.java
+++ b/src/main/java/dk/kb/present/View.java
@@ -19,22 +19,16 @@ import dk.kb.present.holdback.HoldbackDatePicker;
 import dk.kb.present.transform.DSTransformer;
 import dk.kb.present.transform.TransformerController;
 import dk.kb.present.util.DataCleanup;
-import dk.kb.present.util.saxhandlers.ElementsExtractionHandler;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.util.webservice.exception.InternalServiceException;
 import dk.kb.util.yaml.YAML;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import javax.ws.rs.core.MediaType;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -134,14 +128,13 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
     @Override
     public String apply(DsRecordDto record) {
         final Map<String, String> metadata = createBasicMetadataMap(record);
-        RecordValues extractedValues;
+        RecordValues extractedValues = new RecordValues();
         String content = record.getData();
 
         // If origin is either radio or tv (i.e. from preservica) extract some predefined values from the record to a RecordValues object.
-        if (content != null && (record.getOrigin().equals("ds.tv")) || record.getOrigin().equals("ds.radio")){
+        if ( content != null && (strategy.equals(Strategy.DR)) || strategy.equals(Strategy.MANIFESTATION)){
             try {
-                extractedValues = extractValuesFromPreservicaContent(content);
-                log.info("RecordValues is: '{}'", extractedValues.values);
+                extractedValues = DataCleanup.extractValuesFromPreservicaContent(content);
             } catch (ParserConfigurationException | SAXException e) {
                 throw new RuntimeException(e);
             }
@@ -150,7 +143,7 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
 
         switch (strategy) {
             case DR:
-                updateMetadataMapWithHoldback(record, metadata);
+                updateMetadataMapWithHoldback(record, metadata, extractedValues);
                 // IMPORTANT: No break here as MANIFESTATION strategy should also be applied.
             case MANIFESTATION:
                 updateMetadataMapWithPreservicaManifestation(record, metadata);
@@ -178,34 +171,13 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
     }
 
     /**
-     * Extract all needed values from a preservica record. These values are either tricky values such as dates, where we know that extra parsing is needed or values that are
-     * used in multiple parts of the processing of the record.
-     * @param content of the record. i.e. the XML data.
-     * @return a {@link RecordValues}-object containing the extracted values.
-     */
-    private RecordValues extractValuesFromPreservicaContent(String content) throws ParserConfigurationException, SAXException {
-        try (InputStream xml = IOUtils.toInputStream(content, StandardCharsets.UTF_8)) {
-            SAXParserFactory factory = SAXParserFactory.newInstance();
-            factory.setNamespaceAware(false);
-            SAXParser saxParser = factory.newSAXParser();
-
-            ElementsExtractionHandler handler = new ElementsExtractionHandler();
-            saxParser.parse(xml, handler);
-
-            return handler.getDataValues();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
      * Extract start and end date from the record and ensure that they are in a valid format.
      * @param metadataMap containing values given to the transformer creating the view.
      * @param recordValues containing values that have been extracted from the metadata record.
      */
     private static void extractStartAndEndDatesToMetadataMap(Map<String, String> metadataMap, RecordValues recordValues) {
-        metadataMap.put("startDate", DataCleanup.getCleanZonedDateTimeFromString(recordValues.getStartTime()).format(DateTimeFormatter.ISO_INSTANT));
-        metadataMap.put("endDate", DataCleanup.getCleanZonedDateTimeFromString(recordValues.getEndTime()).format(DateTimeFormatter.ISO_INSTANT));
+        metadataMap.put("startDate", recordValues.getStartTime());
+        metadataMap.put("endDate", recordValues.getEndTime());
     }
 
     /**
@@ -266,9 +238,9 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
      * @param metadata map, which holds values that are to be used in the XSLT transformation later on.
      *                 Holdback values are added to this map.
      */
-    private void updateMetadataMapWithHoldback(DsRecordDto record, Map<String, String> metadata) {
+    private void updateMetadataMapWithHoldback(DsRecordDto record, Map<String, String> metadata, RecordValues extractedValues) {
         try {
-            HoldbackObject holdbackObject = HoldbackDatePicker.getInstance().getHoldbackDateForRecord(record, metadata.get("startDate"));
+            HoldbackObject holdbackObject = HoldbackDatePicker.getInstance().getHoldbackDateForRecord(extractedValues, record.getOrigin());
 
             metadata.put("holdbackDate", holdbackObject.getHoldbackDate());
             metadata.put("holdbackPurposeName", holdbackObject.getHoldbackPurposeName());

--- a/src/main/java/dk/kb/present/View.java
+++ b/src/main/java/dk/kb/present/View.java
@@ -144,7 +144,8 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
         switch (strategy) {
             case DR:
                 updateMetadataMapWithHoldback(record, metadata, extractedValues);
-                // IMPORTANT: No break here as MANIFESTATION strategy should also be applied.
+                updateMetadataMapWithPreservicaManifestation(record, metadata);
+                break;
             case MANIFESTATION:
                 updateMetadataMapWithPreservicaManifestation(record, metadata);
                 break;

--- a/src/main/java/dk/kb/present/holdback/HoldbackDatePicker.java
+++ b/src/main/java/dk/kb/present/holdback/HoldbackDatePicker.java
@@ -115,7 +115,7 @@ public class HoldbackDatePicker {
      *
      * @return the updated HoldbackObject.
      */
-    private HoldbackObject getHoldbackForRadioRecord(HoldbackObject result) throws IOException {
+    private HoldbackObject getHoldbackForRadioRecord(HoldbackObject result) {
         // Radio should be held back by three years by DR request.
         result.setHoldbackDate(calculateHoldbackDate(ZonedDateTime.parse(startDate), 1096));
         result.setHoldbackPurposeName("");
@@ -128,7 +128,7 @@ public class HoldbackDatePicker {
      * @param result holdbackDTO containing the purposeName and the holdbackDate for a record.
      * @return the result object with updated values.
      */
-    private static HoldbackObject getHoldbackForTvRecord(RecordValues extractedValues, HoldbackObject result) throws IOException {
+    private static HoldbackObject getHoldbackForTvRecord(RecordValues extractedValues, HoldbackObject result) {
         try {
             result.setHoldbackPurposeName(getPurposeName(extractedValues));
 
@@ -181,7 +181,7 @@ public class HoldbackDatePicker {
 
         // Slå Indhold op i IndholdFra-IndholdTil i matrice i FormNr kolonne.
         String purposeNumber = purposeMatrixSheet.getPurposeIdFromContentAndForm(contentsItem, formString);
-        purposeNumber = validatePurpose(purposeNumber, extractedValues.getProductionCountry());
+        purposeNumber = validatePurpose(purposeNumber, extractedValues.getOrigin());
 
         // Brug den fundne værdi i formåls arket til at finde formålNavn
         return purposeSheet.getPurposeNameFromNumber(purposeNumber);
@@ -190,10 +190,11 @@ public class HoldbackDatePicker {
     /**
      * Validate and handle special cases of IDs constructed by {@link PurposeMatrixSheet#getPurposeIdFromContentAndForm(String, String)}.
      * @param purposeId which is to be validated.
-     * @param productionCountry string containing the productionCountry value from a preservica record.
+     * @param productionCountry string containing the productionCountry value from a preservica record. This should not be extracted from the fields named productionCountry or
+     *                          countryOfOrigin, but rather from the field origin.
      * @return an updated PurposeID
      */
-    private static String validatePurpose(String purposeId, String productionCountry) throws ParserConfigurationException, IOException, SAXException {
+    private static String validatePurpose(String purposeId, String productionCountry) {
         // Handling of special case for purposeID 2.05, where country of production is needed to create the correct value.
         if (purposeId.equals("2.05")) {
             if (productionCountry.equals("1000")) {

--- a/src/main/java/dk/kb/present/holdback/HoldbackDatePicker.java
+++ b/src/main/java/dk/kb/present/holdback/HoldbackDatePicker.java
@@ -2,25 +2,19 @@ package dk.kb.present.holdback;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
-import dk.kb.present.RecordValues;
+import dk.kb.present.util.ExtractedPreservicaValues;
 import dk.kb.present.config.ServiceConfig;
-import dk.kb.present.util.saxhandlers.ElementExtractionHandler;
-import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.util.Resolver;
 import dk.kb.util.webservice.exception.InternalServiceException;
-import org.apache.commons.io.IOUtils;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 /**
@@ -85,7 +79,7 @@ public class HoldbackDatePicker {
         return datePicker;
     }
 
-    public HoldbackObject getHoldbackDateForRecord(RecordValues extractedValues, String origin) throws IOException {
+    public HoldbackObject getHoldbackDateForRecord(ExtractedPreservicaValues extractedValues, String origin) throws IOException {
         HoldbackDatePicker.startDate = extractedValues.getStartTime();
         HoldbackObject result = new HoldbackObject();
         if (origin == null){
@@ -128,7 +122,7 @@ public class HoldbackDatePicker {
      * @param result holdbackDTO containing the purposeName and the holdbackDate for a record.
      * @return the result object with updated values.
      */
-    private static HoldbackObject getHoldbackForTvRecord(RecordValues extractedValues, HoldbackObject result) {
+    private static HoldbackObject getHoldbackForTvRecord(ExtractedPreservicaValues extractedValues, HoldbackObject result) {
         try {
             result.setHoldbackPurposeName(getPurposeName(extractedValues));
 
@@ -165,10 +159,10 @@ public class HoldbackDatePicker {
 
     /**
      * Get purposeName for a preservica record containing metadata about a DR program.
-     * @param extractedValues {@link RecordValues} containing data from a preservica record for analysis.
+     * @param extractedValues {@link ExtractedPreservicaValues} containing data from a preservica record for analysis.
      * @return the purposeName for a given program.
      */
-    private static String getPurposeName(RecordValues extractedValues) throws IOException, ParserConfigurationException, SAXException {
+    private static String getPurposeName(ExtractedPreservicaValues extractedValues) throws IOException, ParserConfigurationException, SAXException {
         // Get form value
         String form = extractedValues.getFormValue();
 

--- a/src/main/java/dk/kb/present/holdback/HoldbackSheet.java
+++ b/src/main/java/dk/kb/present/holdback/HoldbackSheet.java
@@ -62,11 +62,18 @@ public class HoldbackSheet {
      * @return amount of holdback days.
      */
     public int getHoldbackDaysForPurpose(String purpose) {
+        // If the purpose gets calculated to 'Udenlandsk Dramatik & Fiktion' the record will be filtered away by the own-prodution filter and therefore a "random" high value is
+        // set here.
+        if (purpose.equals("Udenlandsk Dramatik & Fiktion")){
+            return 999999;
+        }
+
         for (Map.Entry<String, Integer> entry : holdbackDaysForPurpose.entrySet()) {
             if (purpose.equals(entry.getKey())){
                 return entry.getValue();
             }
         }
+
 
         log.error("No holdback has been defined for purpose: '{}'.", purpose);
         throw new NotFoundServiceException("No holdback value cold be found for purpose: '" + purpose + "' in holdbackSheet.");

--- a/src/main/java/dk/kb/present/util/DataCleanup.java
+++ b/src/main/java/dk/kb/present/util/DataCleanup.java
@@ -14,8 +14,6 @@
  */
 package dk.kb.present.util;
 
-import dk.kb.present.RecordValues;
-import dk.kb.present.util.saxhandlers.ElementExtractionHandler;
 import dk.kb.present.util.saxhandlers.ElementsExtractionHandler;
 import dk.kb.util.DatetimeParser;
 import dk.kb.util.MalformedIOException;
@@ -76,9 +74,9 @@ public class DataCleanup {
      * Extract all needed values from a preservica record. These values are either tricky values such as dates, where we know that extra parsing is needed or values that are
      * used in multiple parts of the processing of the record.
      * @param content of the record. i.e. the XML data.
-     * @return a {@link RecordValues}-object containing the extracted values.
+     * @return a {@link ExtractedPreservicaValues}-object containing the extracted values.
      */
-    public static RecordValues extractValuesFromPreservicaContent(String content) throws ParserConfigurationException, SAXException {
+    public static ExtractedPreservicaValues extractValuesFromPreservicaContent(String content) throws ParserConfigurationException, SAXException {
         try (InputStream xml = IOUtils.toInputStream(content, StandardCharsets.UTF_8)) {
             SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setNamespaceAware(false);

--- a/src/main/java/dk/kb/present/util/DataCleanup.java
+++ b/src/main/java/dk/kb/present/util/DataCleanup.java
@@ -59,42 +59,10 @@ public class DataCleanup {
     }
     private static final Pattern XML_DECLARATION = Pattern.compile("[\n ]*<[?]xml [^?]*[?]>\n?", Pattern.DOTALL);
 
-
-    /**
-     * Extract startDate for a Preservica record. Extracts the value present at {@code PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreDateAvailable/dateAvailableStart} and
-     * parses it as a well formatted ZonedDateTime. Resets the stream after use.
-     * @param xml stream representing a preservica record, with the field {@code PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreDateAvailable/dateAvailableStart} present.
-     * @return a well formatted ZonedDateTime with the value.
-     */
-    public static ZonedDateTime getStartDate(InputStream xml) throws ParserConfigurationException, SAXException, IOException {
-        factory.setNamespaceAware(false);
-        SAXParser saxParser = factory.newSAXParser();
-
-        ElementExtractionHandler handler = new ElementExtractionHandler("/XIP/Metadata/Content/PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreDateAvailable/dateAvailableStart");
-        return getCleanZonedDateTime(xml, saxParser, handler);
-    }
-
-    /**
-     * Extract startDate for a Preservica record. Extracts the value present at {@code PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreDateAvailable/dateAvailableEnd} and
-     * parses it as a well formatted ZonedDateTime. Resets the stream after use.
-     * @param xml stream representing a preservica record, with the field {@code PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreDateAvailable/dateAvailableEnd} present.
-     * @return a well formatted ZonedDateTime with the value.
-     */
-    public static ZonedDateTime getEndDate(InputStream xml) throws ParserConfigurationException, SAXException, IOException {
-        factory.setNamespaceAware(false);
-        SAXParser saxParser = factory.newSAXParser();
-        ElementExtractionHandler handler = new ElementExtractionHandler("/XIP/Metadata/Content/PBCoreDescriptionDocument/pbcoreInstantiation/pbcoreDateAvailable/dateAvailableEnd");
-        return getCleanZonedDateTime(xml, saxParser, handler);
-    }
-
-    private static ZonedDateTime getCleanZonedDateTime(InputStream xml, SAXParser saxParser, ElementExtractionHandler handler) throws SAXException, IOException {
-        saxParser.parse(xml, handler);
-        xml.reset();
-        String datetimeString =  handler.getCurrentValue();
-
+    public static ZonedDateTime getCleanZonedDateTimeFromString(String datetime){
         String dateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss[XX][XXX]";
         try {
-            return DatetimeParser.parseStringToZonedDateTime(datetimeString, dateTimeFormat);
+            return DatetimeParser.parseStringToZonedDateTime(datetime, dateTimeFormat);
         } catch (MalformedIOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/dk/kb/present/util/ExtractedPreservicaValues.java
+++ b/src/main/java/dk/kb/present/util/ExtractedPreservicaValues.java
@@ -1,7 +1,4 @@
-package dk.kb.present;
-
-import dk.kb.present.util.DataCleanup;
-import dk.kb.present.util.PathPair;
+package dk.kb.present.util;
 
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -12,15 +9,15 @@ import java.util.Map;
 /**
  * An object containing all values from a single Preservica record, that are to be handled in either a special context or in multiple contexts. The main component of this object is
  * the {@link #values}-map. This map contains keys, representing the name of each entry, and values of type {@link PathPair}, containing the path to the extracted value as
- * {@link PathPair#path} and the value extracted from the specified path at {@link PathPair#value}. This value can then be retrieved by getters in {@link RecordValues}.
+ * {@link PathPair#path} and the value extracted from the specified path at {@link PathPair#value}. This value can then be retrieved by getters in {@link ExtractedPreservicaValues}.
  * <br/>
  * Can be used in conjunction with {@link dk.kb.present.util.saxhandlers.ElementsExtractionHandler} to parse an XML stream for multiple values.
  */
-public class RecordValues {
+public class ExtractedPreservicaValues {
 
     public Map<String, PathPair<String,String>> values = new HashMap<>();
 
-    public RecordValues(){
+    public ExtractedPreservicaValues(){
         values.put("startTime", new PathPair<>(startTimePath, ""));
         values.put("endTime", new PathPair<>(endTimePath, ""));
         values.put("form", new PathPair<>(formPath, ""));
@@ -87,7 +84,7 @@ public class RecordValues {
 
     @Override
     public String toString() {
-        return "RecordValues{" +
+        return "ExtractedPreservicaValues{" +
                 "values=" + values +
                 '}';
     }

--- a/src/main/java/dk/kb/present/util/PathPair.java
+++ b/src/main/java/dk/kb/present/util/PathPair.java
@@ -1,0 +1,77 @@
+package dk.kb.present.util;
+
+import java.util.List;
+
+/**
+ * Pair object for storing a pair of path and value.
+ * Almost identical with the {@link dk.kb.util.Pair}-class. The only difference is that Path and Value can be set through a setter in PathPair.
+ *
+ * @param <Path>  representing a path.
+ * @param <Value> represents the value present at given path.
+ */
+public class PathPair<Path, Value> {
+
+    private Path path;
+    private Value value;
+
+    public PathPair(Path path, Value value) {
+        this.path = path;
+        this.value = value;
+    }
+
+    public Path getPath() {
+        return path;
+    }
+
+    public Path getKey() {
+        return path;
+    }
+
+    public Value getValue() {
+        return value;
+    }
+
+    public void setPath(Path path) {
+        this.path = path;
+    }
+
+    public void setValue(Value value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PathPair)) {
+            return false;
+        }
+
+        PathPair<?, ?> pair = (PathPair<?, ?>) o;
+
+        if (path != null ? !path.equals(pair.getPath()) : pair.getPath() != null) {
+            return false;
+        }
+        if (value != null ? !value.equals(pair.getValue()) : pair.getValue() != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = path != null ? path.hashCode() : 0;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "PathPair{" +
+                "path=" + path +
+                ", value=" + value +
+                '}';
+    }
+}

--- a/src/main/java/dk/kb/present/util/saxhandlers/ElementsExtractionHandler.java
+++ b/src/main/java/dk/kb/present/util/saxhandlers/ElementsExtractionHandler.java
@@ -1,6 +1,6 @@
 package dk.kb.present.util.saxhandlers;
 
-import dk.kb.present.RecordValues;
+import dk.kb.present.util.ExtractedPreservicaValues;
 import dk.kb.present.util.DataCleanup;
 import dk.kb.present.util.PathPair;
 import org.xml.sax.Attributes;
@@ -8,15 +8,14 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.Map;
 
 /**
- * Extract multiple values from an XML stream to a {@link RecordValues}-object.
+ * Extract multiple values from an XML stream to a {@link ExtractedPreservicaValues}-object.
  */
 public class ElementsExtractionHandler extends DefaultHandler {
 
-    private final RecordValues recordValues = new RecordValues();
+    private final ExtractedPreservicaValues extractedPreservicaValues = new ExtractedPreservicaValues();
     private String currentPath = "";
     private boolean captureValue = false;
     private String captureValueKey = "";
@@ -28,7 +27,7 @@ public class ElementsExtractionHandler extends DefaultHandler {
         currentPath += "/" + elementName;
 
         // Check if the current path matches any target path
-        for (Map.Entry<String, PathPair<String, String>> entry : recordValues.values.entrySet()) {
+        for (Map.Entry<String, PathPair<String, String>> entry : extractedPreservicaValues.values.entrySet()) {
             if (currentPath.equals(entry.getValue().getPath())){
                 captureValue = true;
                 captureValueKey = entry.getKey();
@@ -39,7 +38,7 @@ public class ElementsExtractionHandler extends DefaultHandler {
     @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
         // Check if we are at the end of the target element
-        for (Map.Entry<String, PathPair<String, String>> entry : recordValues.values.entrySet()) {
+        for (Map.Entry<String, PathPair<String, String>> entry : extractedPreservicaValues.values.entrySet()) {
             if (currentPath.equals(entry.getValue().getPath())){
                 captureValue = false;
                 break;
@@ -59,15 +58,15 @@ public class ElementsExtractionHandler extends DefaultHandler {
 
             if (captureValueKey.equals("startTime") || captureValueKey.equals("endTime")){
                 String cleanedTime = DataCleanup.getCleanZonedDateTimeFromString(currentValue.toString()).format(DateTimeFormatter.ISO_INSTANT);
-                recordValues.values.get(captureValueKey).setValue(cleanedTime);
+                extractedPreservicaValues.values.get(captureValueKey).setValue(cleanedTime);
             } else {
-                recordValues.values.get(captureValueKey).setValue(currentValue.toString());
+                extractedPreservicaValues.values.get(captureValueKey).setValue(currentValue.toString());
             }
         }
     }
 
-    public RecordValues getDataValues() {
-        return recordValues;
+    public ExtractedPreservicaValues getDataValues() {
+        return extractedPreservicaValues;
     }
 
     /**

--- a/src/main/java/dk/kb/present/util/saxhandlers/ElementsExtractionHandler.java
+++ b/src/main/java/dk/kb/present/util/saxhandlers/ElementsExtractionHandler.java
@@ -1,0 +1,75 @@
+package dk.kb.present.util.saxhandlers;
+
+import dk.kb.present.RecordValues;
+import dk.kb.present.util.PathPair;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Extract multiple values from an XML stream to a {@link RecordValues}-object.
+ */
+public class ElementsExtractionHandler extends DefaultHandler {
+
+    private final RecordValues recordValues = new RecordValues();
+    private String currentPath = "";
+    private boolean captureValue = false;
+    private String captureValueKey = "";
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        String elementName = stripPrefix(qName);
+        // Update the current path
+        currentPath += "/" + elementName;
+
+        // Check if the current path matches any target path
+        for (Map.Entry<String, PathPair<String, String>> entry : recordValues.values.entrySet()) {
+            if (currentPath.equals(entry.getValue().getPath())){
+                captureValue = true;
+                captureValueKey = entry.getKey();
+            }
+        }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        // Check if we are at the end of the target element
+        for (Map.Entry<String, PathPair<String, String>> entry : recordValues.values.entrySet()) {
+            if (currentPath.equals(entry.getValue().getPath())){
+                captureValue = false;
+                break;
+            }
+        }
+
+        // Update the current path
+        currentPath = currentPath.substring(0, currentPath.lastIndexOf('/'));
+    }
+
+    @Override
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        StringBuilder currentValue = new StringBuilder();
+        // Capture characters if we are within the target element
+        if (captureValue) {
+            currentValue.append(new String(ch, start, length));
+            recordValues.values.get(captureValueKey).setValue(currentValue.toString());
+        }
+    }
+
+    public RecordValues getDataValues() {
+        return recordValues;
+    }
+
+    /**
+     * Ignore namespace prefixes while traversing.
+     */
+    private String stripPrefix(String qName) {
+        int colonIndex = qName.indexOf(':');
+        if (colonIndex != -1) {
+            return qName.substring(colonIndex + 1);
+        }
+        return qName;
+    }
+}

--- a/src/main/java/dk/kb/present/util/saxhandlers/ElementsExtractionHandler.java
+++ b/src/main/java/dk/kb/present/util/saxhandlers/ElementsExtractionHandler.java
@@ -1,11 +1,13 @@
 package dk.kb.present.util.saxhandlers;
 
 import dk.kb.present.RecordValues;
+import dk.kb.present.util.DataCleanup;
 import dk.kb.present.util.PathPair;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +56,13 @@ public class ElementsExtractionHandler extends DefaultHandler {
         // Capture characters if we are within the target element
         if (captureValue) {
             currentValue.append(new String(ch, start, length));
-            recordValues.values.get(captureValueKey).setValue(currentValue.toString());
+
+            if (captureValueKey.equals("startTime") || captureValueKey.equals("endTime")){
+                String cleanedTime = DataCleanup.getCleanZonedDateTimeFromString(currentValue.toString()).format(DateTimeFormatter.ISO_INSTANT);
+                recordValues.values.get(captureValueKey).setValue(cleanedTime);
+            } else {
+                recordValues.values.get(captureValueKey).setValue(currentValue.toString());
+            }
         }
     }
 

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -37,6 +37,7 @@
   <xsl:param name="conditionsOfAccess"/>
   <xsl:param name="holdbackDate"/>
   <xsl:param name="holdbackPurposeName"/>
+  <xsl:param name="ownProductionCode"/>
   <xsl:include href="xslt/utils.xsl"/>
 
   <xsl:variable name="InternalAccessionRef">

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -35,8 +35,10 @@
   <xsl:param name="mTime"/>
   <!-- Access condition for DR material. Currently, this param contains a placeholder. -->
   <xsl:param name="conditionsOfAccess"/>
+  <!-- Holdback and Own Production params are values needed for DR material. They are used in the transformations to determine if users are allowed to access the material. -->
   <xsl:param name="holdbackDate"/>
   <xsl:param name="holdbackPurposeName"/>
+  <xsl:param name="ownProductionBool"/>
   <xsl:param name="ownProductionCode"/>
   <xsl:include href="xslt/utils.xsl"/>
 
@@ -891,6 +893,18 @@
     <xsl:for-each select="/XIP/Metadata/Content/program_structure:program_structure">
       <xsl:call-template name="program-structure"/>
     </xsl:for-each>
+
+
+    <xsl:if test="$ownProductionBool != ''">
+      <f:boolean key="kb:own_production">
+        <xsl:value-of select="$ownProductionBool"/>
+      </f:boolean>
+    </xsl:if>
+    <xsl:if test="$ownProductionCode != ''">
+      <f:number key="kb:own_production_code">
+        <xsl:value-of select="$ownProductionCode"/>
+      </f:number>
+    </xsl:if>
 
     <!-- Holdback date included here. Holdback purpose is only included for video objects, therefor it is done in the
           internal-video-fields template. -->

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -900,7 +900,7 @@
         <xsl:value-of select="$ownProductionBool"/>
       </f:boolean>
     </xsl:if>
-    <xsl:if test="$ownProductionCode != ''">
+    <xsl:if test="$ownProductionCode != '' and not(f:empty($ownProductionCode))">
       <f:number key="kb:own_production_code">
         <xsl:value-of select="$ownProductionCode"/>
       </f:number>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -280,6 +280,18 @@
         </xsl:if>
       </xsl:if>
 
+      <!-- Extraction of ownprocution related fields. -->
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:own_production') != ''">
+        <f:string key="own_production">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:own_production')"/>
+        </f:string>
+      </xsl:if>
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:own_production_code') != ''">
+        <f:string key="own_production_code">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:own_production_code')"/>
+        </f:string>
+      </xsl:if>
+
       <!-- Extraction of holdback related fields. -->
       <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:holdback_name') != ''">
         <f:string key="holdback_name">

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -46,7 +46,7 @@
       <xsl:when test="f:empty($object)"><xsl:value-of select="''"/></xsl:when>
       <xsl:when test="f:empty(map:get($object, $map1))"><xsl:value-of select="''"/></xsl:when>
       <xsl:when test="f:empty(map:get(map:get($object, $map1), $map2))"><xsl:value-of select="''"/></xsl:when>
-      <xsl:otherwise> <xsl:value-of select="map:get(map:get($object, $map1),$map2)"/></xsl:otherwise>
+      <xsl:otherwise><xsl:value-of select="map:get(map:get($object, $map1),$map2)"/></xsl:otherwise>
     </xsl:choose>
   </xsl:function>
 

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -517,6 +517,17 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     78e74634-bec1-4cea-a984-20192c97b743?>
   </field>
 
+  <field name="own_production" type="boolean">
+    <?desciption A boolean representing if the record has been produced by DR?>
+    <?example true?>
+  </field>
+
+  <field name="own_production_code" type="pint">
+    <?desciption A four digit code containing information about wether the record has been produces by DR. numbers below 2000 are considered own production, which would also be
+            reflected in the boolean 'own_production?>
+    <?example 1100?>
+  </field>
+
   <field name="holdback_expired_date" type="pdate">
     <?description The point in time where the given record is outside of holdback and can be shown/used in the archive
                   in UTC time.?>

--- a/src/main/webapp/mappings_radiotv.html
+++ b/src/main/webapp/mappings_radiotv.html
@@ -439,6 +439,18 @@ metadata are connected in the following way:
         <td>kb:program_structure_overlap/file2UUID</td>
         <td></td>
     </tr>
+    <tr>
+        <td>/XIP/Metadata/Content/record/source/tvmeter/origin</td>
+        <td>own_production_code</td>
+        <td>kb:internal/kb:own_production_code</td>
+        <td>The TV-Meter origin is extracted as own_production_code as it is used in relation to calculation of own production here.</td>
+    </tr>
+    <tr>
+        <td>/XIP/Metadata/Content/record/source/tvmeter/origin</td>
+        <td>own_production</td>
+        <td>kb:internal/kb:own_production</td>
+        <td>These schema.org and solr values are booleans. Calculated by comparing origin to 2000. origin < 2000 = true.</td>
+    </tr>
     <tbody>
 </table>
 

--- a/src/test/java/dk/kb/present/HoldbackTest.java
+++ b/src/test/java/dk/kb/present/HoldbackTest.java
@@ -32,7 +32,7 @@ public class HoldbackTest {
 
         tvValues1.setFormValue("4411");
         tvValues1.setContentsItem("3190");
-        tvValues1.setProductionCountry("1000");
+        tvValues1.setOrigin("1000");
         tvValues1.setStartTime("2016-01-20T10:34:42+0100");
 
         tvValues2.setStartTime("2022-02-28T17:29:55Z");
@@ -41,7 +41,7 @@ public class HoldbackTest {
 
         badValues.setFormValue("1800");
         badValues.setContentsItem("3100");
-        badValues.setProductionCountry("2211");
+        badValues.setOrigin("2211");
         badValues.setStartTime("2016-01-06T18:08:17+0100");
     }
 

--- a/src/test/java/dk/kb/present/HoldbackTest.java
+++ b/src/test/java/dk/kb/present/HoldbackTest.java
@@ -6,9 +6,6 @@ import dk.kb.present.holdback.HoldbackDatePicker;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.util.Resolver;
 import dk.kb.util.webservice.exception.InternalServiceException;
-import org.apache.poi.xssf.usermodel.XSSFCell;
-import org.apache.poi.xssf.usermodel.XSSFRow;
-import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -22,76 +19,76 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag("integration")
 public class HoldbackTest {
 
-    private static DsRecordDto tvRecord1 = new DsRecordDto();
-    private static DsRecordDto tvRecord2 = new DsRecordDto();
-    private static DsRecordDto radioRecord1 = new DsRecordDto();
-    private static DsRecordDto badRecord = new DsRecordDto();
-    private static DsRecordDto noOriginRecord = new DsRecordDto();
-    private static DsRecordDto badOriginRecord = new DsRecordDto();
+    private static RecordValues tvValues1 = new RecordValues();
+    private static RecordValues tvValues2 = new RecordValues();
+    private static RecordValues radioValues = new RecordValues();
+    private static RecordValues badValues = new RecordValues();
 
     @BeforeAll
     static void setup() throws IOException {
         ServiceConfig.initialize("conf/ds-present-behaviour.yaml");
         HoldbackDatePicker.init();
 
-        tvRecord1.setOrigin("ds.tv");
-        tvRecord1.setData(Resolver.resolveUTF8String(TestFiles.PVICA_DOMS_MIG_9ed10d66));
 
-        tvRecord2.setOrigin("ds.tv");
-        tvRecord2.setData(Resolver.resolveUTF8String(TestFiles.PVICA_RECORD_3006e2f8));
+        tvValues1.setFormValue("4411");
+        tvValues1.setContentsItem("3190");
+        tvValues1.setProductionCountry("1000");
+        tvValues1.setStartTime("2016-01-20T10:34:42+0100");
 
-        radioRecord1.setOrigin("ds.radio");
-        radioRecord1.setData(Resolver.resolveUTF8String(TestFiles.PVICA_RECORD_2b462c63));
+        tvValues2.setStartTime("2022-02-28T17:29:55Z");
 
-        badRecord.setOrigin("ds.tv");
-        badRecord.setData(Resolver.resolveUTF8String(TestFiles.PVICA_HOMEMADE_HOLDBACK_TEST_RECORD));
+        radioValues.setStartTime("2018-04-03T08:03:00Z");
 
-        noOriginRecord.setOrigin(null);
-        badOriginRecord.setOrigin("this.is.not.an.origin");
+        badValues.setFormValue("1800");
+        badValues.setContentsItem("3100");
+        badValues.setProductionCountry("2211");
+        badValues.setStartTime("2016-01-06T18:08:17+0100");
     }
 
     @Test
     public void badOriginsTest() throws IOException {
-        assertEquals("", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(noOriginRecord, "").getHoldbackDate());
-        assertEquals("", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(noOriginRecord, "").getHoldbackPurposeName());
+        RecordValues values = new RecordValues();
+        assertEquals("", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(values, null).getHoldbackDate());
+        assertEquals("", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(values, null).getHoldbackPurposeName());
 
-        Exception exception = assertThrowsExactly(InternalServiceException.class, () -> HoldbackDatePicker.getInstance().getHoldbackDateForRecord(badOriginRecord, ""));
+        Exception exception = assertThrowsExactly(InternalServiceException.class, () -> HoldbackDatePicker.getInstance().getHoldbackDateForRecord(values, ""));
         assertEquals("Holdback cannot be calculated for records that are not from origins 'ds.radio' or 'ds.tv'. Returning a result object without values.", exception.getMessage());
     }
 
     @Test
     public void badRecordTest() throws IOException {
-        assertEquals("9999-01-01T00:00:00Z", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(badRecord, "").getHoldbackDate());
+        assertEquals("9999-01-01T00:00:00Z", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(badValues, "ds.tv").getHoldbackDate());
     }
 
     @Test
     public void getHoldbackDateFromXmlTest() throws IOException {
-        assertEquals("2026-01-17T09:34:42Z", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(tvRecord1, "2016-01-20T09:34:42Z").getHoldbackDate());
+        assertEquals("2026-01-17T09:34:42Z", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(tvValues1, "ds.tv").getHoldbackDate());
     }
+
 
     @Test
     public void holdbackNoValueTest() throws IOException {
-        assertEquals("9999-01-01T00:00:00Z", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(tvRecord2, "2022-02-28T17:29:55Z").getHoldbackDate());
+        assertEquals("9999-01-01T00:00:00Z", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(tvValues2, "ds.tv").getHoldbackDate());
     }
 
     @Test
     public void holdbackNameNoValueTest() throws IOException {
-        assertTrue(HoldbackDatePicker.getInstance().getHoldbackDateForRecord(tvRecord2, "2022-02-28T17:29:55Z").getHoldbackPurposeName().isEmpty());
+        assertTrue(HoldbackDatePicker.getInstance().getHoldbackDateForRecord(tvValues2, "ds.tv").getHoldbackPurposeName().isEmpty());
     }
 
     @Test
     public void getHoldbackPurposeFromXmlTest() throws IOException {
-        assertEquals("Dansk Dramatik & Fiktion", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(tvRecord1, "2016-01-20T09:34:42Z").getHoldbackPurposeName());
+        assertEquals("Dansk Dramatik & Fiktion", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(tvValues1, "ds.tv").getHoldbackPurposeName());
     }
 
     @Test
     public void getNoHoldbackDateFromXmlTest() throws IOException {
-        assertEquals("9999-01-01T00:00:00Z", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(tvRecord2, "2022-02-28T17:29:55Z").getHoldbackDate());
+        assertEquals("9999-01-01T00:00:00Z", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(tvValues2, "ds.tv").getHoldbackDate());
     }
 
     @Test
     public void radioHoldbackTest() throws IOException {
-        HoldbackObject holdbackObject =  HoldbackDatePicker.getInstance().getHoldbackDateForRecord(radioRecord1, "2018-04-03T08:03:00Z");
+        HoldbackObject holdbackObject =  HoldbackDatePicker.getInstance().getHoldbackDateForRecord(radioValues, "ds.radio");
 
         assertEquals("2021-04-03T08:03:00Z", holdbackObject.getHoldbackDate());
         assertEquals("", holdbackObject.getHoldbackPurposeName());

--- a/src/test/java/dk/kb/present/HoldbackTest.java
+++ b/src/test/java/dk/kb/present/HoldbackTest.java
@@ -3,8 +3,7 @@ package dk.kb.present;
 import dk.kb.present.config.ServiceConfig;
 import dk.kb.present.holdback.HoldbackObject;
 import dk.kb.present.holdback.HoldbackDatePicker;
-import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.util.Resolver;
+import dk.kb.present.util.ExtractedPreservicaValues;
 import dk.kb.util.webservice.exception.InternalServiceException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -19,10 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag("integration")
 public class HoldbackTest {
 
-    private static RecordValues tvValues1 = new RecordValues();
-    private static RecordValues tvValues2 = new RecordValues();
-    private static RecordValues radioValues = new RecordValues();
-    private static RecordValues badValues = new RecordValues();
+    private static ExtractedPreservicaValues tvValues1 = new ExtractedPreservicaValues();
+    private static ExtractedPreservicaValues tvValues2 = new ExtractedPreservicaValues();
+    private static ExtractedPreservicaValues radioValues = new ExtractedPreservicaValues();
+    private static ExtractedPreservicaValues badValues = new ExtractedPreservicaValues();
 
     @BeforeAll
     static void setup() throws IOException {
@@ -47,7 +46,7 @@ public class HoldbackTest {
 
     @Test
     public void badOriginsTest() throws IOException {
-        RecordValues values = new RecordValues();
+        ExtractedPreservicaValues values = new ExtractedPreservicaValues();
         assertEquals("", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(values, null).getHoldbackDate());
         assertEquals("", HoldbackDatePicker.getInstance().getHoldbackDateForRecord(values, null).getHoldbackPurposeName());
 

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -51,6 +51,7 @@ public class TestFiles {
     public static final String PVICA_DOMS_MIG_e2dfb840 = "internal_test_files/domsMigrated/e2dfb840-68a5-45f6-b9b6-232de1af597e.xml";
     public static final String PVICA_DOMS_MIG_73aad1c3 = "internal_test_files/domsMigrated/73aad1c3-5af0-4720-a569-98441edbd245.xml";
     public static final String PVICA_HOMEMADE_HOLDBACK_TEST_RECORD = "internal_test_files/homemade/badHoldbackFieldContents.xml";
+    public static final String PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED = "internal_test_files/homemade/correctDomsMigWithTVMeterEnrichment.xml";
 
     // From preservica 6, not in preservica 7 stage
     public static final String PVICA6_RECORD_00a9e71c = "internal_test_files/preservica6/00a9e71c-1264-4e57-9238-b38ec5672fb2.xml";

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -52,6 +52,7 @@ public class TestFiles {
     public static final String PVICA_DOMS_MIG_73aad1c3 = "internal_test_files/domsMigrated/73aad1c3-5af0-4720-a569-98441edbd245.xml";
     public static final String PVICA_HOMEMADE_HOLDBACK_TEST_RECORD = "internal_test_files/homemade/badHoldbackFieldContents.xml";
     public static final String PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED = "internal_test_files/homemade/correctDomsMigWithTVMeterEnrichment.xml";
+    public static final String PVICA_HOMEMADE_NOT_OWNPROD = "internal_test_files/homemade/badOwnProduction.xml";
 
     // From preservica 6, not in preservica 7 stage
     public static final String PVICA6_RECORD_00a9e71c = "internal_test_files/preservica6/00a9e71c-1264-4e57-9238-b38ec5672fb2.xml";

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -120,7 +120,9 @@ public class TestUtil {
 				"holdbackPurposeName","Aktualitet og debat",
 				"kalturaID", "aVeryTrueKalturaID",
 				"startTime", "1987-05-04T14:45:00Z",
-				"endTime", "1987-05-04T16:45:00Z");
+				"endTime", "1987-05-04T16:45:00Z",
+				"ownProductionBool", "true",
+				"ownProductionCode","1000");
 		String schemaOrgJson = TestUtil.getTransformedWithAccessFieldsAdded(schemaOrgTransformer, record, injections);
 		//prettyPrintJson(schemaOrgJson);
 

--- a/src/test/java/dk/kb/present/ViewTest.java
+++ b/src/test/java/dk/kb/present/ViewTest.java
@@ -226,6 +226,20 @@ class ViewTest {
         executorService.shutdown();
     }
 
+    @Test
+    @Tag("integration")
+    void dataExtractionTest() throws Exception {
+        HoldbackDatePicker.init();
+        View jsonldView = getPreservicaJsonView();
+        String pvica = Resolver.resolveUTF8String(TestFiles.PVICA_DOMS_MIG_9ed10d66);
+        DsRecordDto recordDto = new DsRecordDto().data(pvica).id("test.id").mTimeHuman("2023-11-29 13:45:49+0100").mTime(1701261949625000L)
+                .origin("ds.tv").kalturaId("randomKalturaId");
+
+
+        String jsonld = jsonldView.apply(recordDto);
+        prettyPrintJson(jsonld);
+    }
+
 
     /**
      * Create test view for Preservica Schema.org transformation

--- a/src/test/java/dk/kb/present/ViewTest.java
+++ b/src/test/java/dk/kb/present/ViewTest.java
@@ -226,7 +226,7 @@ class ViewTest {
 
     @Test
     @Tag("integration")
-    void ownProductionTest() throws Exception {
+    void ownProductionTrueTest() throws Exception {
         HoldbackDatePicker.init();
         View jsonldView = getPreservicaTvJsonView();
         String pvica = Resolver.resolveUTF8String(TestFiles.PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED);
@@ -237,7 +237,24 @@ class ViewTest {
         String jsonld = jsonldView.apply(recordDto);
 
         assertTrue(jsonld.contains("\"kb:own_production\":true," +
-                                    "\"kb:own_production_code\":1000,"));
+                                    "\"kb:own_production_code\":1000"));
+    }
+
+    @Test
+    @Tag("integration")
+    void ownProductionFalseTest() throws Exception {
+        HoldbackDatePicker.init();
+        View jsonldView = getPreservicaTvJsonView();
+        String pvica = Resolver.resolveUTF8String(TestFiles.PVICA_HOMEMADE_NOT_OWNPROD);
+        DsRecordDto recordDto = new DsRecordDto().data(pvica).id("test.id").mTimeHuman("2023-11-29 13:45:49+0100").mTime(1701261949625000L)
+                .origin("ds.tv").kalturaId("randomKalturaId");
+
+
+        String jsonld = jsonldView.apply(recordDto);
+        prettyPrintJson(jsonld);
+
+        assertTrue(jsonld.contains("\"kb:own_production\":false," +
+                                    "\"kb:own_production_code\":2300"));
     }
 
 

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -49,9 +49,9 @@ import static dk.kb.present.TestFiles.CUMULUS_RECORD_ANSK;
 import static dk.kb.present.TestFiles.CUMULUS_RECORD_FM;
 import static dk.kb.present.TestFiles.CUMULUS_RECORD_aaf3b130;
 import static dk.kb.present.TestFiles.CUMULUS_RECORD_e2519ce0;
-import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_9779a1b2;
 import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_e2dfb840;
 import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_eaea0362;
+import static dk.kb.present.TestFiles.PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED;
 import static dk.kb.present.TestFiles.PVICA_RECORD_0b3f6a54;
 import static dk.kb.present.TestFiles.PVICA_RECORD_2b462c63;
 import static dk.kb.present.TestFiles.PVICA_RECORD_3006e2f8;
@@ -695,6 +695,14 @@ public class EmbeddedSolrTest {
     @Tag("integration")
     void testMigratedFrom() throws Exception {
         testStringValuePreservicaField(PVICA_DOMS_MIG_e2dfb840, "migrated_from", "DOMS");
+    }
+
+    @Test
+    @Tag("integration")
+    void testOwnProductionFields() throws Exception {
+        testBooleanValuePreservicaField(PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED, "own_production", true);
+        testIntValuePreservicaField(PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED, "own_production_code", 1000);
+
     }
 
     /*


### PR DESCRIPTION
### Prepare for own production filtering. 
This PR refactors how values that are used before the XSLT transformations are extracted from Preservica records. Before each value was extracted from an XML stream whenever they were needed. Now all values are extracted to a common POJO and then accessed from there. This makes the reading of the XML happen once instead of 3-5 times. **This is the cause for so many changed files**.

Besides this, the PR introduces fields for own_production in the trasnformations and in the solr schema. **NB: These are quite hard to test as we don't have the data present in the preservica stage environment yet. I've tried creating a couple of test records by hand.**

Ps. Remeber to pull newest test files from aegis. 