### PR TITLE
Dra 1095 add missing fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <license.name>Apache License, Version 2.0</license.name>
         <license.url>https://www.apache.org/licenses/LICENSE-2.0.txt</license.url>
         <timestamp>${maven.build.timestamp}</timestamp>
-        <solr.config.version>1.6.12</solr.config.version> <!-- Semantic versioning of solr config and schema -->
+        <solr.config.version>1.6.13</solr.config.version> <!-- Semantic versioning of solr config and schema -->
 
         <project.package>dk.kb.present</project.package>
     </properties>

--- a/src/main/resources/xslt/mods2solr.xsl
+++ b/src/main/resources/xslt/mods2solr.xsl
@@ -358,7 +358,7 @@
               </xsl:for-each>
             </f:array>
             <!-- Extracts family and given name and combines into a full name-->
-            <f:array key="creator_full_name">
+            <f:array key="creator">
               <xsl:for-each select="m:name">
                 <xsl:if test="./m:namePart[@type='family'] or ./m:namePart[@type='given']">
                   <f:string>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -682,7 +682,6 @@
     <!-- Extract actors if any present in metadata. see https://schema.org/actor and the JSON.LD example -->
     <xsl:if test="./pbcoreContributor/contributorRole = 'medvirkende' and ./pbcoreContributor/contributor != ''">
       <f:array key="actor">
-
         <xsl:for-each select="./pbcoreContributor">
           <xsl:if test="./contributorRole = 'medvirkende' and ./contributor != ''">
             <f:map>
@@ -715,9 +714,21 @@
             </f:map>
           </xsl:if>
         </xsl:for-each>
-
       </f:array>
     </xsl:if>
+
+    <!-- Extract directors if any present in metadata. see https://schema.org/director -->
+    <!-- In our devel system we dont have any records where there are more than one contributer with the role 'instruktion' therefore this is not implemented as an array. -->
+    <xsl:for-each select="./pbcoreContributor">
+      <xsl:if test="./contributorRole = 'instruktion' and ./contributor != ''">
+        <f:map key="director">
+          <f:string key="@type">Person</f:string>
+          <f:string key="name">
+            <xsl:value-of select="normalize-space(./contributor)"/>
+          </f:string>
+        </f:map>
+      </xsl:if>
+    </xsl:for-each>
 
     <!-- Construct identifiers for accession_number, ritzau_id and tvmeter_id -->
     <f:array key="identifier">

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -730,6 +730,22 @@
       </xsl:if>
     </xsl:for-each>
 
+    <!-- Extract authors/creators here we are using creators as these two can be used for the same content and we are using creator for images as well. -->
+    <xsl:if test="./pbcoreCreator/creatorRole = 'forfatter' and ./pbcoreCreator/creator != ''">
+      <f:array key="creator">
+        <xsl:for-each select="./pbcoreCreator">
+          <xsl:if test="./creatorRole = 'forfatter' and ./creator != ''">
+            <f:map>
+              <f:string key="@type">Person</f:string>
+              <f:string key="name">
+                <xsl:value-of select="normalize-space(./creator)"/>
+              </f:string>
+            </f:map>
+          </xsl:if>
+        </xsl:for-each>
+      </f:array>
+    </xsl:if>
+
     <!-- Construct identifiers for accession_number, ritzau_id and tvmeter_id -->
     <f:array key="identifier">
       <f:map>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -142,9 +142,43 @@
             <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
           </xsl:call-template>
 
-          <!-- This is the only field directly present in pbc:PBCoreDescriptionDocument, which is only used for video
-               objects. Therefore, it is extracted here. If more fields from this part of the metadata were only
-               relevant for video objects, then a new template would be introduced. -->
+          <!-- Extract actors if any present in metadata. see https://schema.org/actor and the JSON.LD example -->
+          <xsl:if test="$pbCore/pbcoreContributor/contributorRole = 'medvirkende' and ./pbcoreContributor/contributor != ''">
+            <f:array key="actor">
+              <xsl:for-each select="./pbcoreContributor">
+                <xsl:if test="./contributorRole = 'medvirkende' and ./contributor != ''">
+                  <f:map>
+                    <f:string key="@type">PerformanceRole</f:string>
+                    <xsl:choose>
+                      <!-- When contributor contains a ':' it means that the character on the left is played by the actor on the right of the ':'. In this case we are creating
+                            a Person object and a characterName string. -->
+                      <xsl:when test="contains(./contributor, ':')">
+                        <f:map key="actor">
+                          <f:string key="@type">Person</f:string>
+                          <f:string key="name">
+                            <xsl:value-of select="normalize-space(substring-after(./contributor, ':'))"/>
+                          </f:string>
+                        </f:map>
+                        <f:string key="characterName">
+                          <xsl:value-of select="normalize-space(substring-before(./contributor, ':'))"/>
+                        </f:string>
+                      </xsl:when>
+                      <!-- When contributor doesn't contain a ':' we dont know anything about the character and therefore we aren't creating a characterName string but using the full
+                      content as name for the Person. -->
+                      <xsl:when test="not(contains(./contributor, ':') and ./contributor != '')">
+                        <f:map key="actor">
+                          <f:string key="@type">Person</f:string>
+                          <f:string key="name">
+                            <xsl:value-of select="normalize-space(./contributor)"/>
+                          </f:string>
+                        </f:map>
+                      </xsl:when>
+                    </xsl:choose>
+                  </f:map>
+                </xsl:if>
+              </xsl:for-each>
+            </f:array>
+          </xsl:if>
           <!-- Is the resource hd? or do we know anything about the video quality=? -->
           <xsl:if test="//pbcoreInstantiation/formatStandard != ''">
             <f:string key="videoQuality"><xsl:value-of select="//pbcoreInstantiation/formatStandard"/></f:string>
@@ -258,6 +292,23 @@
                 <xsl:with-param name="type" select="$type"/>
                 <xsl:with-param name="pbcExtensions" select="$pbcExtensions"/>
               </xsl:call-template>
+
+
+              <!-- Extract contributor if any present in metadata. see https://schema.org/contributor and the JSON.LD example -->
+              <xsl:if test="$pbCore/pbcoreContributor/contributorRole = 'medvirkende' and ./pbcoreContributor/contributor != ''">
+                <f:array key="contributor">
+                  <xsl:for-each select="./pbcoreContributor">
+                    <xsl:if test="./contributorRole = 'medvirkende' and ./contributor != ''">
+                      <f:map>
+                        <f:string key="@type">Person</f:string>
+                        <f:string key="name">
+                          <xsl:value-of select="normalize-space(./contributor)"/>
+                        </f:string>
+                      </f:map>
+                    </xsl:if>
+                  </xsl:for-each>
+                </f:array>
+              </xsl:if>
             </xsl:for-each>
           </xsl:when>
           <xsl:otherwise>
@@ -680,44 +731,6 @@
         <!-- If no genre is present, the field should not be created.-->
         <xsl:otherwise></xsl:otherwise>
       </xsl:choose>
-    </xsl:if>
-
-    <!-- Extract actors if any present in metadata. see https://schema.org/actor and the JSON.LD example -->
-    <xsl:if test="./pbcoreContributor/contributorRole = 'medvirkende' and ./pbcoreContributor/contributor != ''">
-      <f:array key="actor">
-        <xsl:for-each select="./pbcoreContributor">
-          <xsl:if test="./contributorRole = 'medvirkende' and ./contributor != ''">
-            <f:map>
-              <f:string key="@type">PerformanceRole</f:string>
-              <xsl:choose>
-                <!-- When contributor contains a ':' it means that the character on the left is played by the actor on the right of the ':'. In this case we are creating
-                      a Person object and a characterName string. -->
-                <xsl:when test="contains(./contributor, ':')">
-                  <f:map key="actor">
-                    <f:string key="@type">Person</f:string>
-                    <f:string key="name">
-                      <xsl:value-of select="normalize-space(substring-after(./contributor, ':'))"/>
-                    </f:string>
-                  </f:map>
-                  <f:string key="characterName">
-                    <xsl:value-of select="normalize-space(substring-before(./contributor, ':'))"/>
-                  </f:string>
-                </xsl:when>
-                <!-- When contributor doesn't contain a ':' we dont know anything about the character and therefore we aren't creating a characterName string but using the full
-                content as name for the Person. -->
-                <xsl:when test="not(contains(./contributor, ':') and ./contributor != '')">
-                  <f:map key="actor">
-                    <f:string key="@type">Person</f:string>
-                    <f:string key="name">
-                      <xsl:value-of select="normalize-space(./contributor)"/>
-                    </f:string>
-                  </f:map>
-                </xsl:when>
-              </xsl:choose>
-            </f:map>
-          </xsl:if>
-        </xsl:for-each>
-      </f:array>
     </xsl:if>
 
     <!-- Extract directors if any present in metadata. see https://schema.org/director -->

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -679,6 +679,46 @@
       </xsl:choose>
     </xsl:if>
 
+    <!-- Extract actors if any present in metadata. see https://schema.org/actor and the JSON.LD example -->
+    <xsl:if test="./pbcoreContributor/contributorRole = 'medvirkende' and ./pbcoreContributor/contributor != ''">
+      <f:array key="actor">
+
+        <xsl:for-each select="./pbcoreContributor">
+          <xsl:if test="./contributorRole = 'medvirkende' and ./contributor != ''">
+            <f:map>
+              <f:string key="@type">PerformanceRole</f:string>
+              <xsl:choose>
+                <!-- When contributor contains a ':' it means that the character on the left is played by the actor on the right of the ':'. In this case we are creating
+                      a Person object and a characterName string. -->
+                <xsl:when test="contains(./contributor, ':')">
+                  <f:map key="actor">
+                    <f:string key="@type">Person</f:string>
+                    <f:string key="name">
+                      <xsl:value-of select="normalize-space(substring-after(./contributor, ':'))"/>
+                    </f:string>
+                  </f:map>
+                  <f:string key="characterName">
+                    <xsl:value-of select="normalize-space(substring-before(./contributor, ':'))"/>
+                  </f:string>
+                </xsl:when>
+                <!-- When contributor doesn't contain a ':' we dont know anything about the character and therefore we aren't creating a characterName string but using the full
+                content as name for the Person. -->
+                <xsl:when test="not(contains(./contributor, ':') and ./contributor != '')">
+                  <f:map key="actor">
+                    <f:string key="@type">Person</f:string>
+                    <f:string key="name">
+                      <xsl:value-of select="normalize-space(./contributor)"/>
+                    </f:string>
+                  </f:map>
+                </xsl:when>
+              </xsl:choose>
+            </f:map>
+          </xsl:if>
+        </xsl:for-each>
+
+      </f:array>
+    </xsl:if>
+
     <!-- Construct identifiers for accession_number, ritzau_id and tvmeter_id -->
     <f:array key="identifier">
       <f:map>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -198,6 +198,21 @@
         </xsl:if>
       </xsl:if>
 
+      <!-- Extract contributors from schema.org json -->
+      <xsl:if test="f:exists($schemaorg-xml('contributor'))">
+        <xsl:variable name="contributors" as="item()*">
+          <xsl:copy-of select="array:flatten($schemaorg-xml('contributor'))"/>
+        </xsl:variable>
+
+        <f:array key="contributor">
+          <xsl:for-each select="$contributors">
+            <f:string>
+              <xsl:value-of select="map:get(., 'name')"/>
+            </f:string>
+          </xsl:for-each>
+        </f:array>
+      </xsl:if>
+
       <!-- Extract director from schema.org json -->
       <xsl:if test="f:exists($schemaorg-xml('director'))">
         <f:string key="director">

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -199,11 +199,27 @@
       </xsl:if>
 
       <!-- Extract director from schema.org json -->
-    <xsl:if test="f:exists($schemaorg-xml('director'))">
-      <f:string key="director">
-        <xsl:value-of select="map:get($schemaorg-xml('director'), 'name')"/>
-      </f:string>
-    </xsl:if>
+      <xsl:if test="f:exists($schemaorg-xml('director'))">
+        <f:string key="director">
+          <xsl:value-of select="map:get($schemaorg-xml('director'), 'name')"/>
+        </f:string>
+      </xsl:if>
+
+     <!-- Extracts creators from the array of creators present in the creator value from schema.org-->
+      <xsl:if test="f:exists($schemaorg-xml('creator'))">
+        <xsl:variable name="creators" as="item()*">
+          <xsl:copy-of select="array:flatten($schemaorg-xml('creator'))"/>
+        </xsl:variable>
+
+        <!-- Reusing the field 'creator_full_name' here as us used for images as well. -->
+        <f:array key="creator_full_name">
+          <xsl:for-each select="$creators">
+            <f:string>
+              <xsl:value-of select="map:get(., 'name')"/>
+            </f:string>
+          </xsl:for-each>
+        </f:array>
+      </xsl:if>
 
       <!-- Extract the creater affiliation. Two fields are required here as creator_affiliation can change over time.
            Therefore, we are also extracting the creator_affiliation_generic which contains the same value for e.g.

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -163,6 +163,41 @@
         </f:string>
       </xsl:if>
 
+      <!-- Extract actors and characters is present.-->
+      <xsl:if test="f:exists($schemaorg-xml('actor'))">
+        <xsl:variable name="actors" as="item()*">
+          <xsl:copy-of select="array:flatten($schemaorg-xml('actor'))"/>
+        </xsl:variable>
+
+        <!-- Extract actor names from nested map-->
+        <f:array key="actors">
+          <xsl:for-each select="$actors">
+            <f:string><xsl:value-of select="my:getNestedMapValue2Levels(., 'actor', 'name')"/></f:string>
+          </xsl:for-each>
+        </f:array>
+
+        <!-- Here we need to know if the value 'characterName' is present somewhere in the nested map. I dont know of anyway else of checking this than through a variable
+        getting populated true strings that we then can do an if-lookup on. -->
+        <xsl:variable name="charactersBool">
+          <xsl:for-each select="$actors">
+            <xsl:if test="map:get(., 'characterName')"><xsl:value-of select="f:true()"/></xsl:if>
+          </xsl:for-each>
+        </xsl:variable>
+
+        <!-- Get character names from map if they are present.-->
+        <xsl:if test="contains($charactersBool, 'true')">
+          <f:array key="characters">
+            <xsl:for-each select="$actors">
+              <xsl:if test="f:exists(map:get(., 'characterName'))">
+                <f:string>
+                  <xsl:value-of select="map:get(., 'characterName')"/>
+                </f:string>
+              </xsl:if>
+            </xsl:for-each>
+          </f:array>
+        </xsl:if>
+      </xsl:if>
+
       <!-- Extract the creater affiliation. Two fields are required here as creator_affiliation can change over time.
            Therefore, we are also extracting the creator_affiliation_generic which contains the same value for e.g.
            DR P1 from 1960 'program 1' and 2000's 'P1'. Here the value would be drp1. -->

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -198,6 +198,13 @@
         </xsl:if>
       </xsl:if>
 
+      <!-- Extract director from schema.org json -->
+    <xsl:if test="f:exists($schemaorg-xml('director'))">
+      <f:string key="director">
+        <xsl:value-of select="map:get($schemaorg-xml('director'), 'name')"/>
+      </f:string>
+    </xsl:if>
+
       <!-- Extract the creater affiliation. Two fields are required here as creator_affiliation can change over time.
            Therefore, we are also extracting the creator_affiliation_generic which contains the same value for e.g.
            DR P1 from 1960 'program 1' and 2000's 'P1'. Here the value would be drp1. -->

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -170,7 +170,7 @@
         </xsl:variable>
 
         <!-- Extract actor names from nested map-->
-        <f:array key="actors">
+        <f:array key="actor">
           <xsl:for-each select="$actors">
             <f:string><xsl:value-of select="my:getNestedMapValue2Levels(., 'actor', 'name')"/></f:string>
           </xsl:for-each>
@@ -186,7 +186,7 @@
 
         <!-- Get character names from map if they are present.-->
         <xsl:if test="contains($charactersBool, 'true')">
-          <f:array key="characters">
+          <f:array key="character">
             <xsl:for-each select="$actors">
               <xsl:if test="f:exists(map:get(., 'characterName'))">
                 <f:string>
@@ -211,8 +211,8 @@
           <xsl:copy-of select="array:flatten($schemaorg-xml('creator'))"/>
         </xsl:variable>
 
-        <!-- Reusing the field 'creator_full_name' here as us used for images as well. -->
-        <f:array key="creator_full_name">
+        <!-- Reusing the field 'creator' here as us used for images as well. -->
+        <f:array key="creator">
           <xsl:for-each select="$creators">
             <f:string>
               <xsl:value-of select="map:get(., 'name')"/>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -506,6 +506,11 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     Hans Christian Varnæs?>
   </field>
 
+  <field name="director" type="string"  docValues="true">
+    <?description The name of the director of the recording.?>
+    <?example     Thomas Vinterberg?>
+  </field>
+
   <field name="creator_affiliation_generic" type="text_general" multiValued="true">
     <?description The name of an organization, institution, etc. with which
                   the entity was associated at the time that the resource was created.

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -119,6 +119,11 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     12?>
   </field>
 
+  <field name="creator_full_name" type="string" multiValued="true"  docValues="true">
+    <?description The name of the creator written as given name family name.?>
+    <?example     John R. Johnsen?>
+  </field>
+
   <field name="creator_affiliation" type="text_general">
     <?description The name of an organization, institution, etc. with which
             the entity was associated at the time that the resource was created.?>
@@ -228,11 +233,6 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <field name="creator_name" type="text_strict" multiValued="true">
     <?description The name of the creator written as family name, given name.?>
     <?example     Johnsen, John R.?>
-  </field>
-
-  <field name="creator_full_name" type="string" multiValued="true"  docValues="true">
-    <?description The name of the creator written as given name family name.?>
-    <?example     John R. Johnsen?>
   </field>
 
   <field name="creator_full_name_strict" type="text_strict" multiValued="true">

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -119,7 +119,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     12?>
   </field>
 
-  <field name="creator_full_name" type="string" multiValued="true"  docValues="true">
+  <field name="creator" type="string" multiValued="true"  docValues="true">
     <?description The name of the creator written as given name family name.?>
     <?example     John R. Johnsen?>
   </field>
@@ -235,7 +235,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     Johnsen, John R.?>
   </field>
 
-  <field name="creator_full_name_strict" type="text_strict" multiValued="true">
+  <field name="creator_strict" type="text_strict" multiValued="true">
     <?description The name of the creator written as givenName familyName.
                   This is a strict field, which produces a better ranking when querying.?>
     <?example     John R. Johnsen?>
@@ -496,12 +496,12 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     DR?>
   </field>
 
-  <field name="actors" type="string" multiValued="true"  docValues="true">
+  <field name="actor" type="string" multiValued="true"  docValues="true">
     <?description The name of the actors present in the recording.?>
     <?example     John R. Johnsen?>
   </field>
 
-  <field name="characters" type="string" multiValued="true"  docValues="true">
+  <field name="character" type="string" multiValued="true"  docValues="true">
     <?description The name of the characters played by the actors in the recording.?>
     <?example     Hans Christian Varnæs?>
   </field>
@@ -1133,7 +1133,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <!-- END FIELDTYPE DEFINITIONS-->
 
   <!-- START COPYFIELDS  -->
-  <copyField source="creator_full_name" dest="creator_full_name_strict">
+  <copyField source="creator" dest="creator_strict">
     <?description Copies the full name of the creator to a strict field, which produces a higher ranking when queried.?>
     <?example     A query for Hans Christian Andersen would produce a higher ranking than H.C Andersen.?>
   </copyField>
@@ -1150,7 +1150,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   </copyField>
 
   <copyField source="creator_name" dest="freetext"/>
-  <copyField source="creator_full_name" dest="freetext"/>
+  <copyField source="creator" dest="freetext"/>
   <copyField source="creator_given_name" dest="freetext"/>
   <copyField source="creator_terms_of_address" dest="freetext"/>
   <copyField source="area" dest="freetext"/>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -39,7 +39,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 1.6.10: Add fields for holdback management
 1.6.11: Rename schema fields following feedback from metadata review.
 1.6.12: Add kaltura_id to schema and remove old wowza streaming url.
-1.6.13: Add fields actor, director, character and creator and their respective _strict fields.
+1.6.13: Add fields actor, director, character, contributor and creator and their respective _strict fields.
   -->
   <field name="_ds_1.6.13_" type="string" indexed="false" stored="false"/>
   <uniqueKey>id</uniqueKey>
@@ -497,12 +497,22 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   </field>
 
   <field name="actor" type="string" multiValued="true"  docValues="true">
-    <?description The name of the actors present in the recording.?>
+    <?description The name of the actors present in the recording. Applies to records from origin ds.tv?>
     <?example     John R. Johnsen?>
   </field>
 
   <field name="actor_strict" type="text_strict" multiValued="true"  >
-    <?description The name of the actors present in the recording.?>
+    <?description The name of the actors present in the recording. Applies to records from origin ds.tv?>
+    <?example     John R. Johnsen?>
+  </field>
+
+  <field name="contributor" type="string" multiValued="true"  docValues="true">
+    <?description The name of contributors present in the recording. Applies to records from origin ds.radio?>
+    <?example     John R. Johnsen?>
+  </field>
+
+  <field name="contributor_strict" type="text_strict" multiValued="true"  >
+    <?description The name of contributors present in the recording. Applies to records from origin ds.radio?>
     <?example     John R. Johnsen?>
   </field>
 
@@ -1180,6 +1190,8 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
   <copyField source="creator" dest="freetext"/>
   <copyField source="actor" dest="freetext"/>
   <copyField source="actor" dest="actor_strict"/>
+  <copyField source="contributor" dest="freetext"/>
+  <copyField source="contributor" dest="contributor_strict"/>
   <copyField source="character" dest="freetext"/>
   <copyField source="character" dest="character_strict"/>
   <copyField source="director" dest="freetext"/>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -496,6 +496,16 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     DR?>
   </field>
 
+  <field name="actors" type="string" multiValued="true"  docValues="true">
+    <?description The name of the actors present in the recording.?>
+    <?example     John R. Johnsen?>
+  </field>
+
+  <field name="characters" type="string" multiValued="true"  docValues="true">
+    <?description The name of the characters played by the actors in the recording.?>
+    <?example     Hans Christian Varnæs?>
+  </field>
+
   <field name="creator_affiliation_generic" type="text_general" multiValued="true">
     <?description The name of an organization, institution, etc. with which
                   the entity was associated at the time that the resource was created.

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -39,7 +39,7 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 1.6.10: Add fields for holdback management
 1.6.11: Rename schema fields following feedback from metadata review.
 1.6.12: Add kaltura_id to schema and remove old wowza streaming url.
-1.6.13
+1.6.13: Add fields actor, director, character and creator and their respective _strict fields.
   -->
   <field name="_ds_1.6.13_" type="string" indexed="false" stored="false"/>
   <uniqueKey>id</uniqueKey>
@@ -501,7 +501,17 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?example     John R. Johnsen?>
   </field>
 
+  <field name="actor_strict" type="text_strict" multiValued="true"  >
+    <?description The name of the actors present in the recording.?>
+    <?example     John R. Johnsen?>
+  </field>
+
   <field name="character" type="string" multiValued="true"  docValues="true">
+    <?description The name of the characters played by the actors in the recording.?>
+    <?example     Hans Christian Varnæs?>
+  </field>
+
+<field name="character_strict" type="text_strict" multiValued="true">
     <?description The name of the characters played by the actors in the recording.?>
     <?example     Hans Christian Varnæs?>
   </field>
@@ -510,6 +520,12 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
     <?description The name of the director of the recording.?>
     <?example     Thomas Vinterberg?>
   </field>
+
+  <field name="director_strict" type="text_strict">
+    <?description The name of the director of the recording.?>
+    <?example     Thomas Vinterberg?>
+  </field>
+
 
   <field name="creator_affiliation_generic" type="text_general" multiValued="true">
     <?description The name of an organization, institution, etc. with which
@@ -1151,6 +1167,12 @@ In solrconfig.xml the classic schema is defined with this:  <schemaFactory class
 
   <copyField source="creator_name" dest="freetext"/>
   <copyField source="creator" dest="freetext"/>
+  <copyField source="actor" dest="freetext"/>
+  <copyField source="actor" dest="actor_strict"/>
+  <copyField source="character" dest="freetext"/>
+  <copyField source="character" dest="character_strict"/>
+  <copyField source="director" dest="freetext"/>
+  <copyField source="director" dest="director_strict"/>
   <copyField source="creator_given_name" dest="freetext"/>
   <copyField source="creator_terms_of_address" dest="freetext"/>
   <copyField source="area" dest="freetext"/>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -763,10 +763,16 @@
         actor_strict^5.0
         character_strict^5.0
         director_strict^5.0
+        contributor_strict^5.0
         pid^5.0
         episode_title^4.0
         topic^2.0
         location
+        creator
+        actor
+        character
+        director
+        contributor
         notes
         collection
         categories
@@ -973,7 +979,8 @@
   <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
     <!-- mlt-parameteres probably needs to be tweaked. This is just a semi-loose first attempt -->
     <lst name="defaults">
-      <str name="mlt.fl">abstract,description,genre_sub,title,subtitle,alternative_title,creator,area,topic,notes,catalog,production_place,subject_full_name,audience,text</str>
+      <str name="mlt.fl">abstract,description,genre_sub,title,subtitle,alternative_title,creator,actor,character,director,contributor,area,topic,notes,catalog,production_place,
+        subject_full_name,audience,text</str>
       <str name="mlt.mintf">2</str>
       <str name="mlt.mindf">2</str>
       <str name="mlt.boost">true</str>
@@ -987,10 +994,16 @@
         actor_strict^5.0
         character_strict^5.0
         director_strict^5.0
+        contributor_strict^5.0
         pid^5.0
         episode_title^4.0
         topic^2.0
         location
+        creator
+        actor
+        character
+        director
+        contributor
         notes
         collection
         categories
@@ -1019,8 +1032,14 @@
           actor_strict^5.0
           character_strict^5.0
           director_strict^5.0
+          contributor_strict^5.0
           topic^2.0
           location
+          creator
+          actor
+          character
+          director
+          contributor
           notes
           collection
           catalog

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -760,6 +760,9 @@
         title_strict^5.0
         title
         creator_strict^5.0
+        actor_strict^5.0
+        character_strict^5.0
+        director_strict^5.0
         pid^5.0
         episode_title^4.0
         topic^2.0
@@ -981,6 +984,9 @@
         title
         title_strict^5.0
         creator_strict^5.0
+        actor_strict^5.0
+        character_strict^5.0
+        director_strict^5.0
         pid^5.0
         episode_title^4.0
         topic^2.0
@@ -1010,6 +1016,9 @@
           title
           title_strict^5.0
           creator_strict^5.0
+          actor_strict^5.0
+          character_strict^5.0
+          director_strict^5.0
           topic^2.0
           location
           notes

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -759,7 +759,7 @@
         filename_local^5.0
         title_strict^5.0
         title
-        creator_full_name_strict^5.0
+        creator_strict^5.0
         pid^5.0
         episode_title^4.0
         topic^2.0
@@ -795,7 +795,7 @@
        <!-- Describes the type of material. Should be available across collections. -->
        <str name="facet.field">resource_description</str>
        <str name="facet.field">resource_description_general</str>
-       <str name="facet.field">creator_full_name</str>
+       <str name="facet.field">creator</str>
        <str name="facet.field">subject_full_name</str>
 
        <str name="facet.field">temporal_start_month</str>
@@ -970,7 +970,7 @@
   <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
     <!-- mlt-parameteres probably needs to be tweaked. This is just a semi-loose first attempt -->
     <lst name="defaults">
-      <str name="mlt.fl">abstract,description,genre_sub,title,subtitle,alternative_title,creator_full_name,area,topic,notes,catalog,production_place,subject_full_name,audience,text</str>
+      <str name="mlt.fl">abstract,description,genre_sub,title,subtitle,alternative_title,creator,area,topic,notes,catalog,production_place,subject_full_name,audience,text</str>
       <str name="mlt.mintf">2</str>
       <str name="mlt.mindf">2</str>
       <str name="mlt.boost">true</str>
@@ -980,7 +980,7 @@
         filename_local^5.0
         title
         title_strict^5.0
-        creator_full_name_strict^5.0
+        creator_strict^5.0
         pid^5.0
         episode_title^4.0
         topic^2.0
@@ -1009,7 +1009,7 @@
           filename_local^5.0
           title
           title_strict^5.0
-          creator_full_name_strict^5.0
+          creator_strict^5.0
           topic^2.0
           location
           notes

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -54,6 +54,7 @@ public class TestFiles {
     public static final String PVICA_HOMEMADE_HOLDBACK_TEST_RECORD = "internal_test_files/homemade/badHoldbackFieldContents.xml";
     public static final String PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED = "internal_test_files/homemade/correctDomsMigWithTVMeterEnrichment.xml";
     public static final String PVICA_HOMEMADE_NOT_OWNPROD = "internal_test_files/homemade/badOwnProduction.xml";
+    public static final String PVICA_HOMEMADE_RADIO_WITH_CONTRIBUTORS = "internal_test_files/homemade/radioWithContributors.xml";
 
     // From preservica 6, not in preservica 7 stage
     public static final String PVICA6_RECORD_00a9e71c = "internal_test_files/preservica6/00a9e71c-1264-4e57-9238-b38ec5672fb2.xml";

--- a/src/test/java/dk/kb/present/TestFiles.java
+++ b/src/test/java/dk/kb/present/TestFiles.java
@@ -50,6 +50,7 @@ public class TestFiles {
     public static final String PVICA_DOMS_MIG_cb4bb835 = "internal_test_files/domsMigrated/cb4bb835-8949-4841-b4ad-fe09b4e62790.xml";
     public static final String PVICA_DOMS_MIG_e2dfb840 = "internal_test_files/domsMigrated/e2dfb840-68a5-45f6-b9b6-232de1af597e.xml";
     public static final String PVICA_DOMS_MIG_73aad1c3 = "internal_test_files/domsMigrated/73aad1c3-5af0-4720-a569-98441edbd245.xml";
+    public static final String PVICA_DOMS_MIG_054c55b3 = "internal_test_files/domsMigrated/054c55b3-ed3a-442c-99dd-1b80c0218114.xml";
     public static final String PVICA_HOMEMADE_HOLDBACK_TEST_RECORD = "internal_test_files/homemade/badHoldbackFieldContents.xml";
 
     // From preservica 6, not in preservica 7 stage

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
@@ -204,7 +204,7 @@ public class EmbeddedSolrFieldAnalyseTest {
     
     private long getCreatorNameStrictResultsForQuery(String query) throws Exception {
         SolrQuery solrQuery = new SolrQuery();
-        solrQuery.setQuery("creator_full_name_strict:(" + query + ")");
+        solrQuery.setQuery("creator_strict:(" + query + ")");
         solrQuery.setRows(10);
         QueryResponse rsp = embeddedServer.query(solrQuery, METHOD.POST);
         return rsp.getResults().getNumFound();
@@ -262,14 +262,14 @@ public class EmbeddedSolrFieldAnalyseTest {
             SolrInputDocument document = new SolrInputDocument();
             document.addField("id", 1);
             document.addField("origin", "ds.test");
-            document.addField("creator_full_name", "Thomas Egense");
-            document.addField("creator_full_name", "Antoine de Saint-Exupéry");
-            document.addField("creator_full_name", "Honoré de Balzac");
-            document.addField("creator_full_name", "Søren Kierkegaard");
-            document.addField("creator_full_name", "Juliusz Słowacki");
-            document.addField("creator_full_name", "Maria Dąbrowska");
-            document.addField("creator_full_name", "Gabriel García Márquez");
-            document.addField("creator_full_name", "Günter Grass");
+            document.addField("creator", "Thomas Egense");
+            document.addField("creator", "Antoine de Saint-Exupéry");
+            document.addField("creator", "Honoré de Balzac");
+            document.addField("creator", "Søren Kierkegaard");
+            document.addField("creator", "Juliusz Słowacki");
+            document.addField("creator", "Maria Dąbrowska");
+            document.addField("creator", "Gabriel García Márquez");
+            document.addField("creator", "Günter Grass");
             document.addField("access_billede_aftale", false); // required field
             document.addField("access_foto_aftale", false);// required field
             document.addField("title", "Romeo og Julie");

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -49,6 +49,8 @@ import static dk.kb.present.TestFiles.CUMULUS_RECORD_ANSK;
 import static dk.kb.present.TestFiles.CUMULUS_RECORD_FM;
 import static dk.kb.present.TestFiles.CUMULUS_RECORD_aaf3b130;
 import static dk.kb.present.TestFiles.CUMULUS_RECORD_e2519ce0;
+import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_054c55b3;
+import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_597e79f7;
 import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_9779a1b2;
 import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_e2dfb840;
 import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_eaea0362;
@@ -695,6 +697,17 @@ public class EmbeddedSolrTest {
     @Tag("integration")
     void testMigratedFrom() throws Exception {
         testStringValuePreservicaField(PVICA_DOMS_MIG_e2dfb840, "migrated_from", "DOMS");
+    }
+
+    @Test
+    @Tag("integration")
+    void testActorsPreservica() throws Exception{
+        testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "actors", "Elizabeth McGovern", "James Woods", "Robert De Niro");
+    }
+    @Test
+    @Tag("integration")
+    void testCharactersPreservica() throws Exception{
+        testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "characters", "Max", "Noodles", "Deborah");
     }
 
     /*

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -53,6 +53,7 @@ import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_054c55b3;
 import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_e2dfb840;
 import static dk.kb.present.TestFiles.PVICA_DOMS_MIG_eaea0362;
 import static dk.kb.present.TestFiles.PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED;
+import static dk.kb.present.TestFiles.PVICA_HOMEMADE_RADIO_WITH_CONTRIBUTORS;
 import static dk.kb.present.TestFiles.PVICA_RECORD_0b3f6a54;
 import static dk.kb.present.TestFiles.PVICA_RECORD_2b462c63;
 import static dk.kb.present.TestFiles.PVICA_RECORD_3006e2f8;
@@ -726,6 +727,12 @@ public class EmbeddedSolrTest {
     @Tag("integration")
     void testCreatorPreservica() throws Exception{
         testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "creator", "Franco Arcalli", "Piero De Bernardi", "Franco Ferrini og Sergio Leon");
+    }
+
+    @Test
+    @Tag("integration")
+    void testContributorPreservicaRadio() throws Exception{
+        testStringPresentInPreservicaMultiField(PVICA_HOMEMADE_RADIO_WITH_CONTRIBUTORS, "contributor", "Max: James Woods");
     }
     /*
      * ------- Private helper methods below --------------

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -171,8 +171,8 @@ public class EmbeddedSolrTest {
         // creator_name
         assertMultivalueField(record,"creator_name", "Clemens, Johann Friderich");
 
-        // creator_full_name
-        assertMultivalueField(record,"creator_full_name", "Johann Friderich Clemens");
+        // creator
+        assertMultivalueField(record,"creator", "Johann Friderich Clemens");
 
         // creator_family_name
         assertMultivalueField(record,"creator_family_name", "Clemens");
@@ -702,12 +702,12 @@ public class EmbeddedSolrTest {
     @Test
     @Tag("integration")
     void testActorsPreservica() throws Exception{
-        testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "actors", "Elizabeth McGovern", "James Woods", "Robert De Niro");
+        testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "actor", "Elizabeth McGovern", "James Woods", "Robert De Niro");
     }
     @Test
     @Tag("integration")
     void testCharactersPreservica() throws Exception{
-        testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "characters", "Max", "Noodles", "Deborah");
+        testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "character", "Max", "Noodles", "Deborah");
     }
 
     @Test
@@ -718,7 +718,7 @@ public class EmbeddedSolrTest {
     @Test
     @Tag("integration")
     void testCreatorPreservica() throws Exception{
-        testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "creator_full_name", "Franco Arcalli", "Piero De Bernardi", "Franco Ferrini og Sergio Leon");
+        testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "creator", "Franco Arcalli", "Piero De Bernardi", "Franco Ferrini og Sergio Leon");
     }
     /*
      * ------- Private helper methods below --------------

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -715,7 +715,11 @@ public class EmbeddedSolrTest {
     void testDirectorPreservica() throws Exception{
         testStringValuePreservicaField(PVICA_DOMS_MIG_054c55b3, "director", "Sergio Leone");
     }
-
+    @Test
+    @Tag("integration")
+    void testCreatorPreservica() throws Exception{
+        testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "creator_full_name", "Franco Arcalli", "Piero De Bernardi", "Franco Ferrini og Sergio Leon");
+    }
     /*
      * ------- Private helper methods below --------------
      */

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -710,6 +710,12 @@ public class EmbeddedSolrTest {
         testStringPresentInPreservicaMultiField(PVICA_DOMS_MIG_054c55b3, "characters", "Max", "Noodles", "Deborah");
     }
 
+    @Test
+    @Tag("integration")
+    void testDirectorPreservica() throws Exception{
+        testStringValuePreservicaField(PVICA_DOMS_MIG_054c55b3, "director", "Sergio Leone");
+    }
+
     /*
      * ------- Private helper methods below --------------
      */

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -461,6 +461,12 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
         assertTrue(transformedJSON.contains("\"name\":\"Temalørdag: Pavarotti\","));
     }
 
+    @Test
+    public void testActors() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
+        prettyPrintJson(transformedJSON);
+    }
+
     private static void printSchemaOrgJson(String xml) throws IOException {
         Map<String, String> injections = Map.of("imageserver", "https://example.com/imageserver/",
                                                 "conditionsOfAccess", "placeholderCondition");

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -464,11 +464,17 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     public void testActors() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
-        prettyPrintJson(transformedJSON);
         assertTrue(transformedJSON.contains("\"actor\":" +
                                             "[{\"@type\":\"PerformanceRole\",\"actor\":{\"@type\":\"Person\",\"name\":\"Elizabeth McGovern\"},\"characterName\":\"Deborah\"}," +
                                             "{\"@type\":\"PerformanceRole\",\"actor\":{\"@type\":\"Person\",\"name\":\"James Woods\"},\"characterName\":\"Max\"}," +
                                             "{\"@type\":\"PerformanceRole\",\"actor\":{\"@type\":\"Person\",\"name\":\"Robert De Niro\"},\"characterName\":\"Noodles\"}]"));
+    }
+
+    @Test
+    public void testDirectors() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
+        prettyPrintJson(transformedJSON);
+        assertTrue(transformedJSON.contains("\"director\":{\"@type\":\"Person\",\"name\":\"Sergio Leone\"}"));
     }
 
     private static void printSchemaOrgJson(String xml) throws IOException {

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -464,6 +464,7 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     public void testActors() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
+        prettyPrintJson(transformedJSON);
         assertTrue(transformedJSON.contains("\"actor\":" +
                                             "[{\"@type\":\"PerformanceRole\",\"actor\":{\"@type\":\"Person\",\"name\":\"Elizabeth McGovern\"},\"characterName\":\"Deborah\"}," +
                                             "{\"@type\":\"PerformanceRole\",\"actor\":{\"@type\":\"Person\",\"name\":\"James Woods\"},\"characterName\":\"Max\"}," +
@@ -492,6 +493,7 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     public void testCreators() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
+        prettyPrintJson(transformedJSON);
         assertTrue(transformedJSON.contains("\"creator\":[{\"@type\":\"Person\",\"name\":\"Franco Ferrini og Sergio Leon\"},{\"@type\":\"Person\",\"name\":\"Franco Arcalli\"}," +
                                             "{\"@type\":\"Person\",\"name\":\"Enrico Medioli\"},{\"@type\":\"Person\",\"name\":\"Piero De Bernardi\"}," +
                                             "{\"@type\":\"Person\",\"name\":\"Leonardo Benvenuti\"}]"));
@@ -502,6 +504,13 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
         assertFalse(transformedJSON.contains("\"creator\""));
 
+    }
+
+    @Test
+    public void voidContributorsTest() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_HOMEMADE_RADIO_WITH_CONTRIBUTORS);
+        prettyPrintJson(transformedJSON);
+        assertTrue(transformedJSON.contains("\"contributor\""));
     }
 
     private static void printSchemaOrgJson(String xml) throws IOException {

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -465,6 +465,10 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     public void testActors() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
         prettyPrintJson(transformedJSON);
+        assertTrue(transformedJSON.contains("\"actor\":" +
+                                            "[{\"@type\":\"PerformanceRole\",\"actor\":{\"@type\":\"Person\",\"name\":\"Elizabeth McGovern\"},\"characterName\":\"Deborah\"}," +
+                                            "{\"@type\":\"PerformanceRole\",\"actor\":{\"@type\":\"Person\",\"name\":\"James Woods\"},\"characterName\":\"Max\"}," +
+                                            "{\"@type\":\"PerformanceRole\",\"actor\":{\"@type\":\"Person\",\"name\":\"Robert De Niro\"},\"characterName\":\"Noodles\"}]"));
     }
 
     private static void printSchemaOrgJson(String xml) throws IOException {

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -464,7 +464,6 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     public void testActors() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
-        prettyPrintJson(transformedJSON);
         assertTrue(transformedJSON.contains("\"actor\":" +
                                             "[{\"@type\":\"PerformanceRole\",\"actor\":{\"@type\":\"Person\",\"name\":\"Elizabeth McGovern\"},\"characterName\":\"Deborah\"}," +
                                             "{\"@type\":\"PerformanceRole\",\"actor\":{\"@type\":\"Person\",\"name\":\"James Woods\"},\"characterName\":\"Max\"}," +
@@ -509,7 +508,6 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     @Test
     public void voidContributorsTest() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_HOMEMADE_RADIO_WITH_CONTRIBUTORS);
-        prettyPrintJson(transformedJSON);
         assertTrue(transformedJSON.contains("\"contributor\""));
     }
 

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -471,10 +471,37 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
     }
 
     @Test
+    public void testNoActors() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
+        assertFalse(transformedJSON.contains("\"actor\""));
+    }
+
+    @Test
     public void testDirectors() throws IOException {
         String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
-        prettyPrintJson(transformedJSON);
         assertTrue(transformedJSON.contains("\"director\":{\"@type\":\"Person\",\"name\":\"Sergio Leone\"}"));
+    }
+
+    @Test
+    public void testNoDirectors() throws IOException{
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
+        assertFalse(transformedJSON.contains("\"director\""));
+
+    }
+
+    @Test
+    public void testCreators() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
+        assertTrue(transformedJSON.contains("\"creator\":[{\"@type\":\"Person\",\"name\":\"Franco Ferrini og Sergio Leon\"},{\"@type\":\"Person\",\"name\":\"Franco Arcalli\"}," +
+                                            "{\"@type\":\"Person\",\"name\":\"Enrico Medioli\"},{\"@type\":\"Person\",\"name\":\"Piero De Bernardi\"}," +
+                                            "{\"@type\":\"Person\",\"name\":\"Leonardo Benvenuti\"}]"));
+    }
+
+    @Test
+    public void testNoCreators() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
+        assertFalse(transformedJSON.contains("\"creator\""));
+
     }
 
     private static void printSchemaOrgJson(String xml) throws IOException {

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -434,7 +434,30 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
     @Test
     void testEmptyFields() throws IOException {
         String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_3b0c391f);
-        prettyPrintJson(solrString);
+    }
+
+    @Test
+    void testActors() throws IOException {
+        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
+        assertTrue(solrString.contains("\"actors\":[" +
+                "\"Elizabeth McGovern\",\"James Woods\",\"Robert De Niro\"],"));
+    }
+    @Test
+    void testCharacters() throws IOException {
+        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
+        assertTrue(solrString.contains("\"characters\":[" +
+                "\"Deborah\",\"Max\",\"Noodles\"],"));
+    }
+
+    @Test
+    void testNoActors() throws IOException {
+        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
+        assertFalse(solrString.contains("\"actors\":["));
+    }
+    @Test
+    void testNoCharacters() throws IOException {
+        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
+        assertFalse(solrString.contains("\"characters\":["));
     }
 
     /**

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -460,6 +460,18 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
         assertFalse(solrString.contains("\"characters\":["));
     }
 
+    @Test
+    void testDirector() throws IOException {
+        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
+        assertTrue(solrString.contains("\"director\":\"Sergio Leone\","));
+    }
+
+    @Test
+    void testNoDirector() throws IOException {
+        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
+        assertFalse(solrString.contains("\"director\":"));
+    }
+
     /**
      * Wrapper for {@link #assertMultiTestsThroughSchemaTransformation(String, Consumer[])} which verifies that the
      * transformed record contains the given {@code substring}.

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -439,25 +439,25 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
     @Test
     void testActors() throws IOException {
         String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
-        assertTrue(solrString.contains("\"actors\":[" +
+        assertTrue(solrString.contains("\"actor\":[" +
                 "\"Elizabeth McGovern\",\"James Woods\",\"Robert De Niro\"],"));
     }
     @Test
     void testCharacters() throws IOException {
         String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
-        assertTrue(solrString.contains("\"characters\":[" +
+        assertTrue(solrString.contains("\"character\":[" +
                 "\"Deborah\",\"Max\",\"Noodles\"],"));
     }
 
     @Test
     void testNoActors() throws IOException {
         String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
-        assertFalse(solrString.contains("\"actors\":["));
+        assertFalse(solrString.contains("\"actor\":["));
     }
     @Test
     void testNoCharacters() throws IOException {
         String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
-        assertFalse(solrString.contains("\"characters\":["));
+        assertFalse(solrString.contains("\"character\":["));
     }
 
     @Test
@@ -475,13 +475,13 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
     @Test
     void testCreators() throws IOException {
         String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
-        assertTrue(solrString.contains("\"creator_full_name\":[\"Franco Ferrini og Sergio Leon\","));
+        assertTrue(solrString.contains("\"creator\":[\"Franco Ferrini og Sergio Leon\","));
     }
 
     @Test
     void testNoCreators() throws IOException {
         String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
-        assertFalse(solrString.contains("\"creator_full_name\":"));
+        assertFalse(solrString.contains("\"creator\":"));
     }
 
     /**

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -472,6 +472,18 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
         assertFalse(solrString.contains("\"director\":"));
     }
 
+    @Test
+    void testCreators() throws IOException {
+        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_054c55b3);
+        assertTrue(solrString.contains("\"creator_full_name\":[\"Franco Ferrini og Sergio Leon\","));
+    }
+
+    @Test
+    void testNoCreators() throws IOException {
+        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
+        assertFalse(solrString.contains("\"creator_full_name\":"));
+    }
+
     /**
      * Wrapper for {@link #assertMultiTestsThroughSchemaTransformation(String, Consumer[])} which verifies that the
      * transformed record contains the given {@code substring}.

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaToSolrTransformerTest.java
@@ -450,6 +450,12 @@ public class XSLTPreservicaToSolrTransformerTest extends XSLTTransformerTestBase
     }
 
     @Test
+    void testContributor() throws IOException {
+        String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_HOMEMADE_RADIO_WITH_CONTRIBUTORS);
+        assertTrue(solrString.contains("\"contributor\":["));
+    }
+
+    @Test
     void testNoActors() throws IOException {
         String solrString = TestUtil.getTransformedToSolrJsonThroughSchemaJsonWithPreservica7File(PRESERVICA2SCHEMAORG, TestFiles.PVICA_DOMS_MIG_597e79f7);
         assertFalse(solrString.contains("\"actor\":["));


### PR DESCRIPTION
Adds the Preservica fields 'forfatter', 'medvirkende' and 'instruktion' to transformations and renames the image field creator_full_name to creator for better usage across collections. 

As I am drafting this text it occurs to me that 'medvirkende' in a radio show doesnt translate well to actor. contributor might be a better name in the schema.org. Would we then want to rename the solr fields for both origins? We might need to discuss this face to face.