### PR TITLE
Dra 1282 cache startup query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added field `dr_production_id` to transformations and solr schema.
+- Added the query used to build frontpage of the webapp to warmup of solr searchers. Lowering Qtime from approx 300 ms to 50 ms on a local setup.
 
 ## [2.1.1](https://github.com/kb-dk/ds-present/releases/tag/ds-present-2.1.1) 2024-09-10
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <license.name>Apache License, Version 2.0</license.name>
         <license.url>https://www.apache.org/licenses/LICENSE-2.0.txt</license.url>
         <timestamp>${maven.build.timestamp}</timestamp>
-        <solr.config.version>1.6.16</solr.config.version> <!-- Semantic versioning of solr config and schema -->
+        <solr.config.version>1.7.0</solr.config.version> <!-- Semantic versioning of solr config and schema -->
 
         <project.package>dk.kb.present</project.package>
     </properties>

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -47,8 +47,9 @@ When adding fields to this schema please have the following guidelines in mind:
 1.6.14: Add _count and _length fields for all multiValued and text fields respectively.
 1.6.15: Add form and content value fields for holdback calculation
 1.6.16: Add dr_production_id
+1.7.0: Add warming of start-up query.
   -->
-  <field name="_ds_1.6.16_" type="string" indexed="false" stored="false"/>
+  <field name="_ds_1.7.0_" type="string" indexed="false" stored="false"/>
   <uniqueKey>id</uniqueKey>
 
    <!-- START FIELDS  -->

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -565,12 +565,26 @@
            <lst><str name="q">solr</str><str name="sort">price asc</str></lst>
            <lst><str name="q">rocks</str><str name="sort">weight asc</str></lst>
           -->
+
+        <!-- Query fired everytime a user visits the frontpage of the webapp: ?q=*&facet=true&facet.limit=-1 -->
+        <lst>
+          <str name="q">*:*</str>
+          <str name="rows">0</str>
+          <str name="facet">true</str>
+          <str name="facet.limit">-1</str>
+        </lst>
       </arr>
     </listener>
     <listener event="firstSearcher" class="solr.QuerySenderListener">
       <arr name="queries">
+        <!--<lst><str name="q">static firstSearcher warming in solrconfig.xml</str></lst>-->
+
+        <!-- Query fired everytime a user visits the frontpage of the webapp: ?q=*&facet=true&facet.limit=-1 -->
         <lst>
-          <str name="q">static firstSearcher warming in solrconfig.xml</str>
+          <str name="q">*:*</str>
+          <str name="rows">0</str>
+          <str name="facet">true</str>
+          <str name="facet.limit">-1</str>
         </lst>
       </arr>
     </listener>

--- a/src/main/solr/dssolr/conf/solrconfig.xml
+++ b/src/main/solr/dssolr/conf/solrconfig.xml
@@ -568,7 +568,7 @@
 
         <!-- Query fired everytime a user visits the frontpage of the webapp: ?q=*&facet=true&facet.limit=-1 -->
         <lst>
-          <str name="q">*:*</str>
+          <str name="q">*</str>
           <str name="rows">0</str>
           <str name="facet">true</str>
           <str name="facet.limit">-1</str>
@@ -581,7 +581,7 @@
 
         <!-- Query fired everytime a user visits the frontpage of the webapp: ?q=*&facet=true&facet.limit=-1 -->
         <lst>
-          <str name="q">*:*</str>
+          <str name="q">*</str>
           <str name="rows">0</str>
           <str name="facet">true</str>
           <str name="facet.limit">-1</str>


### PR DESCRIPTION
The frontend application sends the following query: `?q=*&facet=true&facet.limit=-1` everytime the frontpage is loaded. I've added the query to the warming of searchers. On my local index of devel, the query time went from 300millis to 50 millis by pre-warming the query.

This query is used to build the time searching component on the frontpage of the application.