### PR TITLE
Dra 1289 channel facet missing values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed field used for ownproduction calculation from country_of_origin to origin as specified by DR metadata specialists.
 
+### Fixed
+- Some documents did not get the channel facet correctly created. A check for these DR1 and DR2 records have been added in the preservica2schemaorg XSLT.
+
 ## [2.1.2](https://github.com/kb-dk/ds-present/releases/tag/ds-present-2.1.2) 2024-09-17
 ### Added
 - Added field `dr_production_id` to transformations and solr schema.

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -481,6 +481,8 @@
                 <xsl:when test="f:starts-with($publisherGeneral, 'dr')">
                   <xsl:value-of select="my:cleanDrChannel($publisherGeneral)"/>
                 </xsl:when>
+                <!-- In some cases records from DR1 and DR2 doesn't contain a value in the field $publisherGeneral, when this happens and the value in $publisherSpecific is
+                either DR1 or DR2, then these values should be used for generation of alternateName. -->
                 <xsl:when test="$publisherSpecific = 'DR1' or $publisherSpecific = 'DR2'">
                   <xsl:value-of select="my:cleanDrChannel($publisherSpecific)"/>
                 </xsl:when>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -473,12 +473,16 @@
                 </xsl:otherwise>
               </xsl:choose>
             </f:string>
-            <xsl:if test="f:exists($publisherGeneral) and not(f:empty($publisherGeneral)) and $publisherGeneral != ''">
+            <xsl:if test="(f:exists($publisherGeneral) and not(f:empty($publisherGeneral)) and $publisherGeneral != '') or
+                          ($publisherSpecific = 'DR1' or $publisherSpecific = 'DR2')">
             <f:string key="alternateName">
               <xsl:choose>
                 <!-- Do clean up of DR channel names -->
                 <xsl:when test="f:starts-with($publisherGeneral, 'dr')">
                   <xsl:value-of select="my:cleanDrChannel($publisherGeneral)"/>
+                </xsl:when>
+                <xsl:when test="$publisherSpecific = 'DR1' or $publisherSpecific = 'DR2'">
+                  <xsl:value-of select="my:cleanDrChannel($publisherSpecific)"/>
                 </xsl:when>
                 <!-- Plain usage of alterneName which isn't going to be used before other collections than DR are in the system -->
                 <xsl:otherwise>

--- a/src/main/resources/xslt/utils.xsl
+++ b/src/main/resources/xslt/utils.xsl
@@ -138,10 +138,10 @@
     <xsl:param name="channelCode"/>
     <xsl:choose>
       <!-- TV channels start here -->
-      <xsl:when test="$channelCode = 'dr1' or $channelCode = 'dr'">
+      <xsl:when test="lower-case($channelCode) = 'dr1' or $channelCode = 'dr'">
         <xsl:value-of select="'DR 1'"/>
       </xsl:when>
-      <xsl:when test="$channelCode = 'dr2'">
+      <xsl:when test="lower-case($channelCode) = 'dr2'">
         <xsl:value-of select="'DR 2'"/>
       </xsl:when>
       <xsl:when test="$channelCode = 'dr3'">

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -517,4 +517,12 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
         assertTrue(transformedJSON.contains("\"alternateName\":\"DR OLINE\""));
         assertTrue(transformedJSON.contains("\"broadcastDisplayName\":\"DR Oline\","));
     }
+
+    @Test
+    public void testAlternateNameForDR1AndDR2() throws IOException {
+        String transformedJSON = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, "internal_test_files/domsMigrated/172c987b-515d-4fbb-91d8-ebcc45b75095.xml");
+        prettyPrintJson(transformedJSON);
+        assertTrue(transformedJSON.contains("\"alternateName\":\"DR 1\""));
+    }
+
 }


### PR DESCRIPTION
Fixes channel facet bug found by test team. I've run the transformations locally and all documents getting transformed seem to transform correctly now. (The indexing ends with an error due to the TV2 record you are looking at.)

On devel the following solr query gives approx. 27K results: `http://develurl:10007/solr/ds-write/select?indent=true&q.op=OR&q=creator_affiliation%3A*%20AND%20NOT%20creator_affiliation_facet%3A*&useParams=`

In my local solr no results are found, which means that all records now gets a value for the channel facet field. However we cannot build a new index on devel, before the error that you are working on has been fixed (or we remove the ugly record again.)