### PR TITLE
Dra 1321 update solr download script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed 
 - Fixed mime-type for JSON responses to `/records`-endpoint.
+- Fixed download of solr in solr setup scripts.
 
 ## [2.1.3](https://github.com/kb-dk/ds-present/releases/tag/ds-present-2.1.3) 2024-09-30
 ### Added 

--- a/bin/cloud.conf
+++ b/bin/cloud.conf
@@ -13,10 +13,12 @@
 # Digitale Samlinger Solr config
 : ${CONFIG_FOLDER:="$(pwd)/../src/main/solr/dssolr/conf/"}
 
-# Normally SOLR_BASE_URL would have the form
-# "https://archive.apache.org/dist/lucene/solr/${S}/solr-${S}.tgz"
-# but Solr 9 is not yet available in the archives
-: ${SOLR_BASE_URL:="https://dlcdn.apache.org/solr/solr"}
+# Normally SOLR_BASE_URL would have the form, however some newer versions might not be available here sometimes.
+# When that is the case they might be found here: https://dlcdn.apache.org/solr/solr
+
+# For solr 9 and above the archive URL is: "https://archive.apache.org/dist/solr/solr/${S}/solr-${S}.tgz"
+# For solr 8 and below the archive URL is: "https://archive.apache.org/dist/lucene/solr/${S}/solr-${S}.tgz"
+: ${SOLR_BASE_URL:="https://archive.apache.org/dist/solr/solr"}
 
 #https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
 : ${ZOO_URL:="https://dlcdn.apache.org/zookeeper/zookeeper-${ZOO_VERSION}/apache-zookeeper-${ZOO_VERSION_TAR}.tar.gz"}

--- a/bin/get_solr.sh
+++ b/bin/get_solr.sh
@@ -8,8 +8,6 @@ pushd ${BASH_SOURCE%/*} > /dev/null
 source general.conf
 # Optionally only download a specific Solr
 : ${SPECIFIC_SOLR:="$1"}
-# "https://archive.apache.org/dist/lucene/solr/${S}/solr-${S}.tgz"
-: ${SOLR_BASE_URL:="https://archive.apache.org/dist/lucene/solr"}
 
 mkdir -p cache
 pushd cache > /dev/null
@@ -111,6 +109,21 @@ resolve_multi() {
             download "http://archive.apache.org/dist/lucene/solr/4.10.4/solr-4.10.4.tgz" solr-4.10.4.tgz
         elif [[ "trunk" == "$S" ]]; then
             compile_trunk
+        elif [ -n "$SPECIFIC_SOLR" ]; then
+              # Determine if we are working with solr 9 or older versions.
+              MAJOR_VERSION="${SPECIFIC_SOLR:0:1}"
+              MAJOR_VERSION_INT=$((MAJOR_VERSION))
+
+              # Specify where to fetch solr from.
+              if [ $MAJOR_VERSION_INT -le 8 ]; then
+                  # "https://archive.apache.org/dist/lucene/solr/${S}/solr-${S}.tgz"
+                SOLR_BASE_URL="https://archive.apache.org/dist/lucene/solr"
+                download "$SOLR_BASE_URL/${S}/solr-${S}.tgz" solr-${S}.tgz
+              else
+                # "https://archive.apache.org/dist/solr/solr/${S}/solr-${S}.tgz"
+                SOLR_BASE_URL="https://archive.apache.org/dist/solr/solr"
+                download "$SOLR_BASE_URL/${S}/solr-${S}.tgz" solr-${S}.tgz
+              fi
         else
             download "${SOLR_BASE_URL}/${S}/solr-${S}.tgz" solr-${S}.tgz
         fi


### PR DESCRIPTION
A simpler version was used to make devel work again. This version has been tested locally it downloads versions before and after 9 as expected.