### PR TITLE
Dra 1428 last genre cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed:
 - Changed configuration naming for YAML key `holdback.dr` to `dr.holdback` in preparation for addition of `dr.restrictions`.
+- Moved unresolved genres to the genre `Rodekassen`.
 
 ## [2.1.6](https://github.com/kb-dk/ds-present/releases/tag/ds-present-2.1.6) 2024-11-05
 ### Added

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -846,7 +846,7 @@
                 <xsl:value-of select="'Rodekassen'"/>
               </xsl:when>
               <xsl:otherwise>
-                <xsl:value-of select="'Unresolved'"/>
+                <xsl:value-of select="'Rodekassen'"/>
               </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -805,12 +805,12 @@
         <xsl:value-of select="normalize-space(f:string-join($keywordsSequence, ', '))"/>
       </xsl:variable>
 
-      <xsl:if test="$keywordsString != ''">
-        <f:string key="keywords">
-          <xsl:value-of select="$keywordsString"/>
-        </f:string>
-
-        <xsl:variable name="genreValue">
+      <xsl:choose>
+        <xsl:when test="$keywordsString != ''">
+          <f:string key="keywords">
+            <xsl:value-of select="$keywordsString"/>
+          </f:string>
+          <xsl:variable name="genreValue">
             <xsl:choose>
               <xsl:when test="my:sequenceAContainsValueFromSequenceB($keywordsSequence, $NewsPoliticsSociety)">
                 <xsl:value-of select="'Nyheder, politik og samfund'"/>
@@ -828,7 +828,7 @@
                 <xsl:value-of select="'Humor, quiz og underholdning'"/>
               </xsl:when>
               <xsl:when test="my:sequenceAContainsValueFromSequenceB($keywordsSequence, $ChildrenYouth)">
-                <xsl:value-of select="'Børn og Unge'"/>
+                <xsl:value-of select="'Børn og unge'"/>
               </xsl:when>
               <xsl:when test="my:sequenceAContainsValueFromSequenceB($keywordsSequence, $Documentary)">
                 <xsl:value-of select="'Dokumentar'"/>
@@ -840,7 +840,7 @@
                 <xsl:value-of select="'Livsstil'"/>
               </xsl:when>
               <xsl:when test="my:sequenceAContainsValueFromSequenceB($keywordsSequence, $ScienceNature)">
-                <xsl:value-of select="'Videnskab og natur'"/>
+                <xsl:value-of select="'Natur og videnskab'"/>
               </xsl:when>
               <xsl:when test="my:sequenceAContainsValueFromSequenceB($keywordsSequence, $Misc)">
                 <xsl:value-of select="'Rodekassen'"/>
@@ -849,12 +849,18 @@
                 <xsl:value-of select="'Rodekassen'"/>
               </xsl:otherwise>
             </xsl:choose>
-        </xsl:variable>
-
-        <f:string key="genre">
-          <xsl:value-of select="$genreValue"/>
-        </f:string>
-      </xsl:if>
+          </xsl:variable>
+          <f:string key="genre">
+            <xsl:value-of select="$genreValue"/>
+          </f:string>
+        </xsl:when>
+        <!-- Adding a fallback to 'Rodekassen' as we have 160K records without genre at all. -->
+        <xsl:otherwise>
+          <f:string key="genre">
+            <xsl:value-of select="'Rodekassen'"/>
+          </f:string>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:if>
 
     <!-- Extract directors if any present in metadata. see https://schema.org/director -->

--- a/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
+++ b/src/test/java/dk/kb/present/transform/XSLTPreservicaSchemaOrgTransformerTest.java
@@ -222,10 +222,10 @@ public class XSLTPreservicaSchemaOrgTransformerTest extends XSLTTransformerTestB
         Assertions.assertTrue(hasGenre.contains("\"genre\":\"Humor, quiz og underholdning\""));
 
         String noGenre = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_4f706cda);
-        Assertions.assertFalse(noGenre.contains("\"genre\":"));
+        Assertions.assertTrue(noGenre.contains("\"genre\":\"Rodekassen\""));
 
         String emptyGenre = TestUtil.getTransformedWithAccessFieldsAdded(PRESERVICA2SCHEMAORG, TestFiles.PVICA_RECORD_4f706cda);
-        Assertions.assertFalse(emptyGenre.contains("\"genre\":"));
+        Assertions.assertTrue(emptyGenre.contains("\"genre\":\"Rodekassen\""));
     }
 
     @Test


### PR DESCRIPTION
This PR does the following: 
* Rename genres as specified by UX Team.
* Remove genre `Unresolved` and move these values to `Rodekassen`. (1000 viewable records will be affected.)
* Add default genre `Rodekassen` for records that have no genre what so ever.

To remove the category `Sport` a ds-license restriction has to be updated. Here is the updated restriction on devel. I've added `genre:"Sport"`: 
![image](https://github.com/user-attachments/assets/31cf6fb9-15d4-4f4d-8c6d-497cce179b4e)
