### PR TITLE
Dra 1480 change own production value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added: 
 - Added functionality to change own production threshold in configuration files, with a default value which includes own-, co- and enterprise-production for DR records.
 
+### Changed
+- Renamed solr fields `own_production` and `own_production_code` to `production_code_allowed` and `production_code_value`. 
+
 ## [2.2.0](https://github.com/kb-dk/ds-present/releases/tag/ds-present-2.2.0) 2024-11-12
 ### Added:
 - Functionality to look up if a record has been restricted by DR by production ID.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added: 
+- Added functionality to change own production threshold in configuration files, with a default value which includes own-, co- and enterprise-production for DR records.
+
 ## [2.2.0](https://github.com/kb-dk/ds-present/releases/tag/ds-present-2.2.0) 2024-11-12
 ### Added:
 - Functionality to look up if a record has been restricted by DR by production ID.  

--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -119,15 +119,23 @@ origin:
     pattern: '[a-z0-9.]+'
 
 
-# Absolute paths to Excel sheets containing various information used to calculate all kinds of restrictions from DR.
-# This value needs to be changed to the correct placement of the files. The placeholder value is resolved from classpath
-# when the files have been injected from aegis. However, full paths can be specified as well.
+# Configuration specific for DR rights calculation
 dr:
+  # Absolute paths to Excel sheets containing various information used to calculate all kinds of restrictions from DR.
+  # This value needs to be changed to the correct placement of the files. The placeholder value is resolved from classpath
+  # when the files have been injected from aegis. However, full paths can be specified as well.
   # Absolute paths to Excel sheets containing information used to calculate holdback periods from DR.
   holdback:
     purposeSheet: 'internal_test_files/dr_formaalstabeller_20240704.xlsx'
     holdbackSheet: 'internal_test_files/dr_holdbacktabel_20240902.xlsx'
   restrictionSheet: 'internal_test_files/dr_klausuleringsliste_20241105.xlsx'
+  # This number specifies which material gets indexed as own production and therefore gets viewable in the system.
+  # value < 2000 = truly own production
+  # value < 3000 = co production
+  # value <= 3400 = some kind of enterprise production
+  # values > 3400 = probably not DR productions
+  ownProduction:
+    maxAllowedProductionCode: 3400
 
 
 

--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -134,8 +134,7 @@ dr:
   # value < 3000 = co production
   # value <= 3400 = some kind of enterprise production
   # values > 3400 = probably not DR productions
-  ownProduction:
-    maxAllowedProductionCode: 3400
+  maxAllowedProductionCode: 3400
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <license.name>Apache License, Version 2.0</license.name>
         <license.url>https://www.apache.org/licenses/LICENSE-2.0.txt</license.url>
         <timestamp>${maven.build.timestamp}</timestamp>
-        <solr.config.version>1.7.7</solr.config.version> <!-- Semantic versioning of solr config and schema -->
+        <solr.config.version>1.7.8</solr.config.version> <!-- Semantic versioning of solr config and schema -->
 
         <project.package>dk.kb.present</project.package>
     </properties>

--- a/src/main/java/dk/kb/present/View.java
+++ b/src/main/java/dk/kb/present/View.java
@@ -14,6 +14,7 @@
  */
 package dk.kb.present;
 
+import dk.kb.present.config.ServiceConfig;
 import dk.kb.present.dr.holdback.HoldbackObject;
 import dk.kb.present.dr.holdback.HoldbackDatePicker;
 import dk.kb.present.dr.restrictions.ProductionIdLookup;
@@ -237,7 +238,7 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
 
         if (!ownProduction.isEmpty()) {
             // Values below 2000 are considered own production. It can in fact be co-production, but these should all be covered by the rights-agreement made.
-            boolean isOwnProduction = Integer.parseInt(ownProduction) < 2000;
+            boolean isOwnProduction = Integer.parseInt(ownProduction) <= ServiceConfig.getOwnProductionCode();
             metadataMap.put("ownProductionBool", Boolean.toString(isOwnProduction));
             metadataMap.put("ownProductionCode", ownProduction);
         } else if (origin.equals("ds.radio")){

--- a/src/main/java/dk/kb/present/View.java
+++ b/src/main/java/dk/kb/present/View.java
@@ -185,7 +185,7 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
         extractStartAndEndDatesToMetadataMap(metadata, extractedValues);
         // The following three methods are all related to holdback and ownproduction calculations.
         updateMetadataMapWithFormAndContent(metadata, extractedValues);
-        updateMetadataMapWithOwnProduction(metadata, extractedValues);
+        updateMetadataMapWithProductionCode(metadata, extractedValues);
         updateMetadataMapWithHoldback(record, metadata, extractedValues);
         updateMetadataMapWithPreservicaManifestation(record, metadata);
 
@@ -220,30 +220,30 @@ public class View extends ArrayList<DSTransformer> implements Function<DsRecordD
     }
 
     /**
-     * Create values related to own production from a {@link ExtractedPreservicaValues}-object and ad them to the metadata map.
+     * Create values related to production codes from a {@link ExtractedPreservicaValues}-object and ad them to the metadata map.
      * @param metadataMap which the values should be added to.
-     * @param extractedValues to extract Nielsen/Gallup origin from used to determine own production.
+     * @param extractedValues to extract Nielsen/Gallup origin from used to determine availability based on production code.
      */
-    private void updateMetadataMapWithOwnProduction(Map<String, String> metadataMap, ExtractedPreservicaValues extractedValues) {
+    private void updateMetadataMapWithProductionCode(Map<String, String> metadataMap, ExtractedPreservicaValues extractedValues) {
         // If origin is below 2000 the record is produced by DR themselves. See internal notes on subpages to this site for explanations:
         // https://kb-dk.atlassian.net/wiki/spaces/DRAR/pages/40632339/Metadata
-        String ownProduction = extractedValues.getOrigin();
-        if (ownProduction.isEmpty()) {
+        String productionCode = extractedValues.getOrigin();
+        if (productionCode.isEmpty()) {
             log.debug("Nielsen/Gallup origin was empty. Own production can not be calculated.");
             // TODO: When we at some point have extra DR metadata, origin should be available there for records before 1993
             //throw new InternalServiceException("The Nielsen/Gallup origin was empty. Own production cannot be defined.");
-        } else if (ownProduction.length() != 4){
-            log.debug("Nielsen/Gallup origin did not have length 4. Own production will not be calculated correctly. Origin is: '{}'", ownProduction);
+        } else if (productionCode.length() != 4){
+            log.debug("Nielsen/Gallup origin did not have length 4. Production code allowance will not be calculated correctly. Origin is: '{}'", productionCode);
         }
 
-        if (!ownProduction.isEmpty()) {
+        if (!productionCode.isEmpty()) {
             // Values below 2000 are considered own production. It can in fact be co-production, but these should all be covered by the rights-agreement made.
-            boolean isOwnProduction = Integer.parseInt(ownProduction) <= ServiceConfig.getOwnProductionCode();
-            metadataMap.put("ownProductionBool", Boolean.toString(isOwnProduction));
-            metadataMap.put("ownProductionCode", ownProduction);
+            boolean allowedProductionCode = Integer.parseInt(productionCode) <= ServiceConfig.getMaxAllowedProductionCode();
+            metadataMap.put("productionCodeAllowed", Boolean.toString(allowedProductionCode));
+            metadataMap.put("productionCodeValue", productionCode);
         } else if (origin.equals("ds.radio")){
             log.debug("Record is a radio record, therefor we see it as own production no matter what.");
-            metadataMap.put("ownProductionBool", "true");
+            metadataMap.put("productionCodeAllowed", "true");
         }
     }
 

--- a/src/main/java/dk/kb/present/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/present/config/ServiceConfig.java
@@ -21,6 +21,10 @@ public class ServiceConfig {
      */
     private static YAML serviceConfig;
 
+    /**
+     * To calculate which records that are allowed to be shown in the publicly available DR Archive platform, we use this value to check records against. Records with tvmeter
+     * origin less than this value are considered ownProduction and can be shown in the DR Archive.
+     */
     private static int ownProductionCode;
 
     /**

--- a/src/main/java/dk/kb/present/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/present/config/ServiceConfig.java
@@ -3,7 +3,6 @@ package dk.kb.present.config;
 import java.io.IOException;
 import java.util.List;
 
-import dk.kb.present.View;
 import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +24,7 @@ public class ServiceConfig {
      * To calculate which records that are allowed to be shown in the publicly available DR Archive platform, we use this value to check records against. Records with tvmeter
      * origin less than this value are considered ownProduction and can be shown in the DR Archive.
      */
-    private static int ownProductionCode;
+    private static int maxAllowedProductionCode;
 
     /**
      * Initialized the configuration from the provided configFiles.
@@ -38,7 +37,7 @@ public class ServiceConfig {
         serviceConfig = YAML.resolveLayeredConfigs(configFiles);
         serviceConfig.setExtrapolate(true);
 
-        ownProductionCode = setValidOwnProductionCode();
+        maxAllowedProductionCode = setValidProductionCode();
     }
 
     /**
@@ -46,9 +45,9 @@ public class ServiceConfig {
      * Logs a warning if the values is above 3400, which defines the upper limit for DR produced material.
      * @return the maxAllowedProductionCode from the backing YAML configuration file.
      */
-    private static int setValidOwnProductionCode() {
+    private static int setValidProductionCode() {
         // Setting default value to include own, co- and enterprise production
-        int valueFromConf = serviceConfig.getInteger("dr.ownProduction.maxAllowedProductionCode", 3400);
+        int valueFromConf = serviceConfig.getInteger("dr.maxAllowedProductionCode", 3400);
         if (valueFromConf > 3400){
             log.warn("The specified maxAllowedProductionCode is '{}' which is greater than 3400. This means that records produced by other broadcasters than DR can be marked as " +
                     "own production", valueFromConf);
@@ -85,7 +84,7 @@ public class ServiceConfig {
         return serviceConfig;
     }
 
-    public static int getOwnProductionCode() {
-        return ownProductionCode;
+    public static int getMaxAllowedProductionCode() {
+        return maxAllowedProductionCode;
     }
 }

--- a/src/main/java/dk/kb/present/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/present/config/ServiceConfig.java
@@ -3,19 +3,25 @@ package dk.kb.present.config;
 import java.io.IOException;
 import java.util.List;
 
+import dk.kb.present.View;
 import dk.kb.util.yaml.YAML;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Sample configuration class using the Singleton pattern.
  * This should work well for most projects with non-dynamic properties.
  */
 public class ServiceConfig {
+    private static final Logger log = LoggerFactory.getLogger(ServiceConfig.class);
 
     /**
      * Besides parsing of YAML files using SnakeYAML, the YAML helper class provides convenience
      * methods like {@code getInteger("someKey", defaultValue)} and {@code getSubMap("config.sub1.sub2")}.
      */
     private static YAML serviceConfig;
+
+    private static int ownProductionCode;
 
     /**
      * Initialized the configuration from the provided configFiles.
@@ -27,6 +33,29 @@ public class ServiceConfig {
     public static synchronized void initialize(String... configFiles) throws IOException {
         serviceConfig = YAML.resolveLayeredConfigs(configFiles);
         serviceConfig.setExtrapolate(true);
+
+        ownProductionCode = setValidOwnProductionCode();
+    }
+
+    /**
+     * Method to securely load own production code from config. Performs validation on the record being exactly four digits.
+     * Logs a warning if the values is above 3400, which defines the upper limit for DR produced material.
+     * @return the maxAllowedProductionCode from the backing YAML configuration file.
+     */
+    private static int setValidOwnProductionCode() {
+        // Setting default value to include own, co- and enterprise production
+        int valueFromConf = serviceConfig.getInteger("dr.ownProduction.maxAllowedProductionCode", 3400);
+        if (valueFromConf > 3400){
+            log.warn("The specified maxAllowedProductionCode is '{}' which is greater than 3400. This means that records produced by other broadcasters than DR can be marked as " +
+                    "own production", valueFromConf);
+        }
+
+        if (valueFromConf >= 1000 && valueFromConf <= 9999) {
+            return valueFromConf;
+        } else {
+            throw new IllegalArgumentException("Invalid own production code: '" + valueFromConf + "'. The own production code must be a four digit number.");
+        }
+
     }
 
     /**
@@ -51,5 +80,8 @@ public class ServiceConfig {
         }
         return serviceConfig;
     }
-  
+
+    public static int getOwnProductionCode() {
+        return ownProductionCode;
+    }
 }

--- a/src/main/resources/xslt/preservica2schemaorg.xsl
+++ b/src/main/resources/xslt/preservica2schemaorg.xsl
@@ -38,8 +38,8 @@
   <xsl:param name="holdbackPurposeName"/>
   <xsl:param name="holdbackFormValue"/>
   <xsl:param name="holdbackContentValue"/>
-  <xsl:param name="ownProductionBool"/>
-  <xsl:param name="ownProductionCode"/>
+  <xsl:param name="productionCodeAllowed"/>
+  <xsl:param name="productionCodeValue"/>
   <!-- ProductionId has been extracted from either tvmeter or nielsen metadata, and is then injected as a single value. -->
   <xsl:param name="productionId"/>
   <xsl:param name="productionIdRestrictedDr"/>
@@ -1181,15 +1181,15 @@
     </xsl:for-each>
 
 
-    <xsl:if test="$ownProductionBool != ''">
-      <f:boolean key="kb:own_production">
-        <xsl:value-of select="$ownProductionBool"/>
+    <xsl:if test="$productionCodeAllowed != ''">
+      <f:boolean key="kb:production_code_allowed">
+        <xsl:value-of select="$productionCodeAllowed"/>
       </f:boolean>
     </xsl:if>
-    <xsl:if test="$ownProductionCode != '' and not(f:empty($ownProductionCode))">
-      <xsl:if test="string(number(normalize-space($ownProductionCode))) != 'NaN'">
-        <f:number key="kb:own_production_code">
-          <xsl:value-of select="number(normalize-space($ownProductionCode))"/>
+    <xsl:if test="$productionCodeValue != '' and not(f:empty($productionCodeValue))">
+      <xsl:if test="string(number(normalize-space($productionCodeValue))) != 'NaN'">
+        <f:number key="kb:production_code_value">
+          <xsl:value-of select="number(normalize-space($productionCodeValue))"/>
         </f:number>
       </xsl:if>
     </xsl:if>

--- a/src/main/resources/xslt/schemaorg2solr.xsl
+++ b/src/main/resources/xslt/schemaorg2solr.xsl
@@ -346,14 +346,14 @@
       </xsl:if>
 
       <!-- Extraction of ownprocution related fields. -->
-      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:own_production') != ''">
-        <f:string key="own_production">
-          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:own_production')"/>
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:production_code_allowed') != ''">
+        <f:string key="production_code_allowed">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:production_code_allowed')"/>
         </f:string>
       </xsl:if>
-      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:own_production_code') != ''">
-        <f:string key="own_production_code">
-          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:own_production_code')"/>
+      <xsl:if test="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:production_code_value') != ''">
+        <f:string key="production_code_value">
+          <xsl:value-of select="my:getNestedMapValue2Levels($schemaorg-xml, 'kb:internal', 'kb:production_code_value')"/>
         </f:string>
       </xsl:if>
 

--- a/src/main/solr/dssolr/conf/schema.xml
+++ b/src/main/solr/dssolr/conf/schema.xml
@@ -60,8 +60,10 @@ When adding fields to this schema please have the following guidelines in mind:
        Add fields contains_tvmeter, contains_nielsen & contains_ritzau for better debugging of metadata fragments
        Add copyField which copies description to freetext.
        Add field has_kaltura_id which should be used for filtering records.
+1.7.8  Rename own_production to production_code_allowed
+       Rename own_production_code to production_code_value
   -->
-  <field name="_ds_1.7.7_" type="string" indexed="false" stored="false"/>
+  <field name="_ds_1.7.8_" type="string" indexed="false" stored="false"/>
   <uniqueKey>id</uniqueKey>
 
    <!-- START FIELDS  -->
@@ -615,14 +617,14 @@ When adding fields to this schema please have the following guidelines in mind:
     <?example     78e74634-bec1-4cea-a984-20192c97b743?>
   </field>
 
-  <field name="own_production" type="boolean">
-    <?desciption A boolean representing if the record has been produced by DR?>
+  <field name="production_code_allowed" type="boolean">
+    <?desciption A boolean representing if the record has been produced by DR and is allowed to be shown in the archive based on this information?>
     <?example true?>
   </field>
 
-  <field name="own_production_code" type="pint">
-    <?desciption A four digit code containing information about wether the record has been produces by DR. numbers below 2000 are considered own production, which would also be
-            reflected in the boolean 'own_production?>
+  <field name="production_code_value" type="pint">
+    <?desciption A four digit code containing information about wether the record has been produces by DR, by others or in cooperation between DR and others. Numbers below 2000
+            are considered own production, which would also be reflected in the boolean 'production_code_value'?>
     <?example 1100?>
   </field>
 
@@ -1348,7 +1350,7 @@ When adding fields to this schema please have the following guidelines in mind:
   <copyField source="title" dest="spellcheck"/> <!--Important field. Will give high ranking(accuracy) when for spellcheck searches -->    
   <copyField source="description" dest="spellcheck"/> <!--This is a large field to copy just for spellcheck  -->
   <copyField source="description" dest="freetext"/>
-  <copyField source="own_production" dest="suggest_context"/>
+  <copyField source="production_code_allowed" dest="suggest_context"/>
   <copyField source="text" dest="text_shingles">
     <?description Copies the content of the basic text field to the shingles enabled text field, for better phrase search ranking and keyword extraction.?>
   </copyField>

--- a/src/test/java/dk/kb/present/TestUtil.java
+++ b/src/test/java/dk/kb/present/TestUtil.java
@@ -119,8 +119,8 @@ public class TestUtil {
 				"kalturaID", "aVeryTrueKalturaID",
 				"startTime", "1987-05-04T14:45:00Z",
 				"endTime", "1987-05-04T16:45:00Z",
-				"ownProductionBool", "true",
-				"ownProductionCode","1000");
+				"productionCodeAllowed", "true",
+				"productionCodeValue","1000");
 		String schemaOrgJson = TestUtil.getTransformedWithAccessFieldsAdded(schemaOrgTransformer, record, injections);
 		//prettyPrintJson(schemaOrgJson);
 

--- a/src/test/java/dk/kb/present/ViewTest.java
+++ b/src/test/java/dk/kb/present/ViewTest.java
@@ -280,7 +280,7 @@ class ViewTest {
 
         String jsonld = jsonldView.apply(recordDto);
         assertTrue(jsonld.contains("\"kb:own_production\":false," +
-                                    "\"kb:own_production_code\":2300"));
+                                    "\"kb:own_production_code\":3600"));
     }
 
 

--- a/src/test/java/dk/kb/present/ViewTest.java
+++ b/src/test/java/dk/kb/present/ViewTest.java
@@ -237,8 +237,8 @@ class ViewTest {
 
         String jsonld = jsonldView.apply(recordDto);
 
-        assertTrue(jsonld.contains("\"kb:own_production\":true," +
-                                    "\"kb:own_production_code\":1000"));
+        assertTrue(jsonld.contains("\"kb:production_code_allowed\":true," +
+                                    "\"kb:production_code_value\":1000"));
     }
 
     @Test
@@ -250,7 +250,8 @@ class ViewTest {
                 .mTime(1701261949625000L).origin("ds.radio").kalturaId("randomKalturaId");
 
         String solrDoc = solrView.apply(recordDto);
-        assertTrue(solrDoc.contains("\"own_production\":\"true\""));
+        prettyPrintJson(solrDoc);
+        assertTrue(solrDoc.contains("\"production_code_allowed\":\"true\""));
     }
 
     @Test
@@ -279,8 +280,8 @@ class ViewTest {
 
 
         String jsonld = jsonldView.apply(recordDto);
-        assertTrue(jsonld.contains("\"kb:own_production\":false," +
-                                    "\"kb:own_production_code\":3600"));
+        assertTrue(jsonld.contains("\"kb:production_code_allowed\":false," +
+                                    "\"kb:production_code_value\":3600"));
     }
 
 
@@ -350,7 +351,7 @@ class ViewTest {
                 .origin("ds.tv").kalturaId("randomKalturaId");
 
         String solrdoc = jsonldView.apply(recordDto);
-        assertTrue(solrdoc.contains("\"own_production_code\":\"4400\""));
+        assertTrue(solrdoc.contains("\"production_code_value\":\"4400\""));
 
     }
 

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrFieldAnalyseTest.java
@@ -325,7 +325,7 @@ public class EmbeddedSolrFieldAnalyseTest {
             document.addField("origin", "ds.test");
             document.addField("title", "Velkommen til TVavisen"); // Synonym file: tv-avisen, tvavis, tvavisen, tv-avis
             document.addField("broadcaster", "DR");
-            document.addField("own_production", "true");
+            document.addField("production_code_allowed", "true");
             // => tv avisen
 
             embeddedServer.add(document);
@@ -430,7 +430,7 @@ public class EmbeddedSolrFieldAnalyseTest {
             document.addField("origin", "ds.test");
             document.addField("title", "Velkommen til tvavisen hos TV2");
             document.addField("broadcaster", "TV2");
-            document.addField("own_production", "false");
+            document.addField("production_code_allowed", "false");
 
             embeddedServer.add(document);
             embeddedServer.commit();

--- a/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/present/solr/EmbeddedSolrTest.java
@@ -695,8 +695,8 @@ public class EmbeddedSolrTest {
     @Test
     @Tag("integration")
     void testOwnProductionFields() throws Exception {
-        testBooleanValuePreservicaField(PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED, "own_production", true);
-        testIntValuePreservicaField(PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED, "own_production_code", 1000);
+        testBooleanValuePreservicaField(PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED, "production_code_allowed", true);
+        testIntValuePreservicaField(PVICA_HOMEMADE_DOMS_MIG_WITH_TVMETER_ADDED, "production_code_value", 1000);
 
     }
 


### PR DESCRIPTION
Currently we create the fields with the following names: 

- `own_production`
- `own_production_code`

Do you think that these should be renamed to `production_code_allowed` and `production_code_value` as including co-production and enterprise-production in a field names `own_production` could potentially be misleading? 

This would require a change in the license filter to look at `production_code_allowed` instead of `own_production`. 

What are your thoughts on this?

I've created this as a draft PR until I get your comments on the above 