### PR TITLE
Service2service OAuth2 enabling on DsPresentClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Bumped kb-util to v1.6.7 for service2service oauth support.
+- Added injection of Oauth token on all service methods when using DsPresentClient
+- IIIF metods not supported by service2service Oauth since no java client is generated for these methods. Also not intended to be called by other modules.
 
 ### Fixed
 - Fixed inclusion of the same dependencies from multiple sources.

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.6.2</version>
+            <version>1.6.7</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->
@@ -80,7 +80,7 @@
         <dependency>
           <groupId>dk.kb.storage</groupId>
           <artifactId>ds-storage</artifactId>
-            <version>2.2.0</version>
+            <version>2.3.3-SNAPSHOT</version>
             <type>jar</type>
             <classifier>classes</classifier>
             <exclusions>
@@ -309,7 +309,6 @@
            <groupId>com.google.code.gson</groupId>
            <artifactId>gson</artifactId>
            <version>2.10.1</version>
-           <scope>test</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.mock-server/mockserver-junit-jupiter -->

--- a/src/main/java/dk/kb/present/util/DsPresentClient.java
+++ b/src/main/java/dk/kb/present/util/DsPresentClient.java
@@ -19,9 +19,12 @@ import dk.kb.present.client.v1.DsPresentApi;
 import dk.kb.present.client.v1.IiifPresentationApi;
 import dk.kb.present.client.v1.ServiceApi;
 import dk.kb.present.invoker.v1.ApiClient;
+import dk.kb.present.invoker.v1.ApiException;
 import dk.kb.present.invoker.v1.Configuration;
 import dk.kb.present.model.v1.FormatDto;
+import dk.kb.present.model.v1.OriginDto;
 import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.util.webservice.Service2ServiceRequest;
 import dk.kb.util.webservice.exception.InternalServiceException;
 import dk.kb.util.webservice.stream.ContinuationInputStream;
 import dk.kb.util.webservice.stream.ContinuationStream;
@@ -103,6 +106,7 @@ public class DsPresentClient extends DsPresentApi {
         this(serviceURI, (Map<String, String>) null);
     }
 
+    
     /**
      * Create a client for the remote ds-present service.
      * <p>
@@ -133,6 +137,67 @@ public class DsPresentClient extends DsPresentApi {
         service = new ServiceApi(apiClient);
         log.info("Created OpenAPI client for '{}' with headers {}", serviceURI, headers);
     }
+    
+    /**
+     * Retrieve a formal description of a single origin.
+     * 
+     * @param id The ID of the origin (required)
+     * @return OriginDto
+     * @throws ApiException if fails to make API call
+     */
+    @Override
+    public OriginDto getOrigin(String id) throws ApiException {        
+        try {
+            URI uri = new URIBuilder(serviceURI + "origin/"+id) // Id is part of path                                                                                   
+                    .build();            
+            return Service2ServiceRequest.httpCallWithOAuthToken(uri,"GET", new OriginDto(),null);              
+        }
+        catch(Exception e) {
+            throw new ApiException(e);
+        }                      
+    }
+    
+    /**
+    * Retrieve a formal description of all available origins.
+    * 
+    * @return List&lt;OriginDto&gt;
+    * @throws ApiException if fails to make API call
+    */
+    @Override
+    public List<OriginDto> getOrigins() throws ApiException {
+        try {
+            URI uri = new URIBuilder(serviceURI + "origins/") // Id is part of path                                                                                   
+                    .build();            
+            return Service2ServiceRequest.httpCallWithOAuthToken(uri,"GET", new ArrayList<OriginDto>(),null);              
+        }
+        catch(Exception e) {
+            throw new ApiException(e);
+        }
+        
+    }
+    
+    /**
+     * Retrieve metadata for the record with the given ID and in the given format.
+     * 
+     * @param id The ID of the record (required)
+     * @param format The delivery format for the record: * JSON-LD: [Linked Data in JSON](https://json-ld.org/) (default) * MODS: [Metadata Object Description Schema](http://www.loc.gov/standards/mods/) * SolrJSON: [Solr JSON Formatted Index Updates](https://solr.apache.org/guide/8_8/uploading-data-with-index-handlers.html#json-formatted-index-updates) * raw: Metadata unchanged from the source.  (optional, default to JSON-LD)
+     * @return String
+     * @throws ApiException if fails to make API call
+     */
+    @Override
+    public String getRecord(String id, FormatDto format) throws ApiException {
+        try {
+        URI uri = new URIBuilder(serviceURI + "record/"+id) // Id is part of path                                                                                   
+                .addParameter("format",""+format.toString())
+                .build();           
+        return Service2ServiceRequest.httpCallWithOAuthToken(uri,"GET", new String(),null);       
+        }
+        catch(Exception e) {
+            throw new ApiException(e);
+        }
+    }
+    
+   
 
     /**
      * Call the remote ds-present {@link #getRecords} and return the response unchanged as a wrapped

--- a/src/main/java/dk/kb/present/webservice/KBOAuth2Handler.java
+++ b/src/main/java/dk/kb/present/webservice/KBOAuth2Handler.java
@@ -186,34 +186,37 @@ public class KBOAuth2Handler {
             case ENABLED:
                 if (endpointRoles.contains(KBAuthorization.PUBLIC)) {
                     if (invalidToken) {
-                        log.debug("Failed verification of provided access token (reason={}) but access to " +
+                        log.info("Failed verification of provided access token (reason={}) but access to " +
                                   "endpoint '{}' granted as roles included '{}'",
                                   failedReason, endpoint, KBAuthorization.PUBLIC);
                     } else {
-                        log.debug("No Authorization defined in request but access to endpoint '{}' granted as roles " +
+                        log.info("No Authorization defined in request but access to endpoint '{}' granted as roles " +
                                   "included '{}'", endpoint, KBAuthorization.PUBLIC);
                     }
                     break;
                 }
                 if (endpointRoles.contains(KBAuthorization.ANY)) {
                     if (invalidToken) {
-                        throw new Fault(new ValidationException(
-                                "Failed verification of provided access token (reason=" + failedReason +
-                                ") and endpoint " + endpoint + " requires a valid access token to be present"));
+                        String message= "Failed verification of provided access token (reason=" + failedReason +
+                                ") and endpoint " + endpoint + " requires a valid access token to be present";
+                        log.warn(message);
+                        throw new Fault(new ValidationException(message));
                     }
                     throw new Fault(new ValidationException(
                             "Authorization failed as there were no Authorization defined in request and " +
                             "endpoint " + endpoint + " requires it to be present"));
                 }
                 if (invalidToken) {
-                    throw new Fault(new ValidationException(
-                            "Failed verification of provided access token (reason=" + failedReason +
-                            ") and endpoint " + endpoint + " requires a valid access token to be present with " +
-                            "one of the roles " + endpointRoles));
+                    String message="Failed verification of provided access token (reason=+" + failedReason+ ") and endpoint " + endpoint + "" +
+                            " requires a valid access token to be present with " +
+                            " one of the roles " + endpointRoles;
+               log.warn(message);
+               throw new Fault(new ValidationException(message));
                 }
-                throw new Fault(new ValidationException(
-                        "Authorization failed as there were no Authorization defined in request and " +
-                        "endpoint " + endpoint + " requires it to be present with one of the roles " + endpointRoles));
+                String message="Authorization failed as there were no Authorization defined in request and " +
+                        "endpoint " + endpoint + " requires it to be present with one of the roles " + endpointRoles;
+                log.warn(message);
+                throw new Fault(new ValidationException(message));
             default: {
                 log.error("Unknown authorization mode: " + mode);
                 throw new Fault(new InternalServiceException("Unknown authorization mode" + mode));

--- a/src/main/openapi/ds-present-openapi_v1.yaml
+++ b/src/main/openapi/ds-present-openapi_v1.yaml
@@ -96,6 +96,9 @@ paths:
       tags:
         - '${project.name}'
       summary: 'Extract records from an origin after a given mTime.'
+      security: 
+        - KBOAuth:
+          - any      
       description: |
         The extracted records are returned in sorted order by mTime increasing. By changing the parameter `maxRecords`, 
         the size of the result can be defined. Records marked with a delete flag will also be returned.
@@ -1155,7 +1158,7 @@ components:
         implicit:   # <---- OAuth flow(authorizationCode, implicit, password or clientCredentials)
           #authorizationUrl is not used. Instead it uses keycloak url from yaml property file aegis-devel.
           #If we figure out what this is supposed to be used for, inject the value from yaml file  ${config.yaml.path}           
-          authorizationUrl: https://api.example.com/oauth2/authorize 
+          authorizationUrl: 'https://keycloak-devel-01.kb.dk/realms/ds-poc/protocol/openid-connect/auth' 
           scopes:
             generic_ds: 'Scope used for all Digitale Samlinger services'
             # Project specific roles

--- a/src/test/java/dk/kb/present/util/DsPresentClientTest.java
+++ b/src/test/java/dk/kb/present/util/DsPresentClientTest.java
@@ -16,7 +16,9 @@ package dk.kb.present.util;
 
 import dk.kb.present.webservice.AccessUtil;
 import dk.kb.present.config.ServiceConfig;
+import dk.kb.present.invoker.v1.ApiException;
 import dk.kb.present.model.v1.FormatDto;
+import dk.kb.present.model.v1.OriginDto;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.util.Resolver;
 import dk.kb.util.webservice.stream.ContinuationInputStream;
@@ -125,4 +127,27 @@ public class DsPresentClientTest {
         assertEquals("anonymous", headers.get(AccessUtil.HEADER_SIMULATED_GROUP),
                 "The group header should be correct");
     }
+    
+    @Test
+    public void testGetOrigin() throws ApiException {
+          OriginDto origin = remote.getOrigin("ds.radio"); //this should always exist 
+          assertNotNull(origin);          
+    }
+    
+    @Test
+    public void testGetOrigins() throws ApiException {
+        List<OriginDto> origins=remote.getOrigins(); // there will always be some        
+        assertTrue(origins.size() >0);
+          
+    }
+    
+    @Test
+    public void testGetRecord() throws ApiException {
+     String id="ds.tv:oai:io:d0df0579-4886-41d3-9177-a2f71f62de19"; //tv-avisen
+        String record = remote.getRecord(id, FormatDto.JSON_LD);        
+        assertNotNull(record); 
+          
+    }
+    
+    
 }


### PR DESCRIPTION
See full description here for DsStorage: 
https://github.com/kb-dk/ds-storage/pull/65

The two IIIF service methods has no java client class generation, and probably also should not have one.

