### PR TITLE
Update ProductionIdLookup class to handle text and number formatted fields

### DIFF
--- a/conf/ds-present-behaviour.yaml
+++ b/conf/ds-present-behaviour.yaml
@@ -128,7 +128,7 @@ dr:
   holdback:
     purposeSheet: 'internal_test_files/dr_formaalstabeller_20240704.xlsx'
     holdbackSheet: 'internal_test_files/dr_holdbacktabel_20240902.xlsx'
-  restrictionSheet: 'internal_test_files/dr_klausuleringsliste_20241105.xlsx'
+  restrictionSheet: 'internal_test_files/dr_klausuleringsliste_20250304.xlsx'
   # This number specifies which material gets indexed as own production and therefore gets viewable in the system.
   # value < 2000 = truly own production
   # value < 3000 = co production

--- a/src/main/java/dk/kb/present/dr/restrictions/ProductionIdLookup.java
+++ b/src/main/java/dk/kb/present/dr/restrictions/ProductionIdLookup.java
@@ -54,6 +54,10 @@ public class ProductionIdLookup {
         return restrictedProductionIds.contains(id);
     }
 
+    public long getAmountOfRestrictedIds() {
+        return restrictedProductionIds.size();
+    }
+
 
     /**
      * Load restricted production IDs from an Excel sheet defined in the configuration for ds-present.
@@ -74,6 +78,10 @@ public class ProductionIdLookup {
                 if (cell != null) {
                     if (Objects.requireNonNull(cell.getCellType()) == CellType.STRING) {
                         restrictedProductionIds.add(reformatProductionId(cell.getStringCellValue()));
+                    } else if (cell.getCellType() == CellType.NUMERIC) {
+                        // The new entries in the document are formatted differently than the old ones
+                        String formattedId = reformatProductionId(Integer.toString((int) cell.getNumericCellValue()));
+                        restrictedProductionIds.add(formattedId);
                     }
                 }
             }

--- a/src/test/java/dk/kb/present/ViewTest.java
+++ b/src/test/java/dk/kb/present/ViewTest.java
@@ -421,6 +421,22 @@ class ViewTest {
         } );
     }
 
+    @Test
+    @Tag("integration")
+    void testRestrictionOfProductionIds() {
+        HoldbackDatePicker.init();
+        ProductionIdLookup.init();
+
+        // Should be more than 2500 after latest update to the list
+        assertTrue(ProductionIdLookup.getInstance().getAmountOfRestrictedIds() > 2500L);
+
+        // List should contain a sample of the older ids
+        assertTrue(ProductionIdLookup.getInstance().doLookup("2912081400"));
+
+        // List should contain a sample from the newer ids
+        assertTrue(ProductionIdLookup.getInstance().doLookup("8007034000"));
+    }
+
     //********************************************** PRIVATE HELPER METHODS BELOW ***************************************************************
 
     /**


### PR DESCRIPTION
Also update the file used for productionIdLookup in aegis. File has been copied to both skygge and devel setups, but the configuration has currently only been deployed on skygge env. 

No re indexing has been done on devel yet as I would like to implement the ds id restrictions before starting the indexing