### PR TITLE
DRA-2708-minimum-client-jar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Marked unittest with @Tag("integration") so it can build without aegis. 
 - Bumb solr schema version to 1.8.9
+- Create minimum client jar. Cross module dependencies uses this new jar instead of the full classes jar.
 
 ## [4.0.2](https://github.com/kb-dk/ds-present/releases/tag/ds-present-4.0.2) 2026-04-07
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -52,35 +52,37 @@
         </dependency>
 
 
-        <!-- Client for ds-storage This will also require the org.openapitools dependency-->
-        <dependency>
-          <groupId>dk.kb.storage</groupId>
-          <artifactId>ds-storage</artifactId>
+        <!-- Client for ds-license -->       
+       <dependency>
+            <groupId>dk.kb.license</groupId>
+            <artifactId>ds-license</artifactId>
             <version>100.0.0-SNAPSHOT</version>
             <type>jar</type>
-            <classifier>classes</classifier>
+            <classifier>api</classifier>
             <exclusions>
-              <exclusion>
-                <groupId>*</groupId>
-                <artifactId>*</artifactId>
-              </exclusion>
-          </exclusions>
-          </dependency>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-        <!-- Client for ds-license. This will also require the org.openapitools dependency-->
-      <dependency>
-        <groupId>dk.kb.license</groupId>
-        <artifactId>ds-license</artifactId>
-          <version>100.0.0-SNAPSHOT</version>
-          <type>jar</type>
-          <classifier>classes</classifier>
-          <exclusions>
-            <exclusion>
-              <groupId>*</groupId>
-              <artifactId>*</artifactId>
-            </exclusion>
-        </exclusions>
-      </dependency>
+            <!-- Client for ds-license -->       
+       <dependency>
+            <groupId>dk.kb.storage</groupId>
+            <artifactId>ds-storage</artifactId>
+            <version>100.0.0-SNAPSHOT</version>
+            <type>jar</type>
+            <classifier>api</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+    
       <!-- Remember to include caffeine when using ds license client-->
       <!-- https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine -->
       <!-- Used for DsLicenseClient -->

--- a/pom.xml
+++ b/pom.xml
@@ -604,8 +604,8 @@
                         </manifest>
                     </archive>
 
-                    <!-- Generate a JAR with client classes and openapi-YAML for easy use by other services -->
-                    <attachClasses>true</attachClasses>
+                    <!-- Generation of API jar is done seperate plugin and only contains DTOs and client class -->
+                    <!--<attachClasses>true</attachClasses> -->
 
                     <!--Enable maven filtering for the web.xml-->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
@@ -630,6 +630,26 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-jar-plugin</artifactId>            
+               <executions>
+                   <execution>
+                   <id>build-specific-jar</id>
+                   <phase>package</phase>
+                   <goals>
+                       <goal>jar</goal>
+                   </goals>
+                  <configuration>                
+                      <classifier>api</classifier>
+                      <includes>                
+                          <include>dk/kb/present/model/**</include>
+                          <include>dk/kb/present/util/DsPresentClient*</include>                                            
+                      </includes>
+                 </configuration>
+                 </execution>
+              </executions>
+            </plugin>
 
             <!-- Used only for mvn jetty:run jetty:run-war -->
             <plugin>


### PR DESCRIPTION
Build new minimum client-jar with DTO's and client class only. Use maven jar plugin. New classifier is 'api'.
Remove building old jar for all classes. Cross module dependencies use the new minimum api jar.